### PR TITLE
remove IE fallback grid

### DIFF
--- a/scss/_base_grid-definitions.scss
+++ b/scss/_base_grid-definitions.scss
@@ -46,12 +46,6 @@
   %vf-row {
     @extend %fixed-width-container;
 
-    // default to flexbox for IE on large screens
-    // on small screens we let columns render one under another
-    @media (min-width: $threshold-6-12-col) {
-      display: flex;
-    }
-
     & & {
       @include vf-b-row-reset;
     }
@@ -108,20 +102,5 @@
       padding-left: map-get($grid-margin-widths, large);
       padding-right: map-get($grid-margin-widths, large);
     }
-  }
-}
-
-// flexbox approximation of grid column styles for IE
-// this needs to be a @mixin rather than %placeholder because it's used inside @media queries
-@mixin vf-grid-flex-column($size: 1) {
-  flex-basis: 0;
-  flex-grow: $size;
-  flex-shrink: 1;
-
-  // set static gutter width
-  margin-left: map-get($grid-gutter-widths, large);
-
-  &:first-child {
-    margin-left: 0;
   }
 }

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -5,10 +5,6 @@
   @supports (display: grid) {
     grid-column-end: span #{$col};
 
-    // reset flex box fallback styles
-    margin-left: 0;
-    width: auto;
-
     //nesting
     @if $col > 1 {
       & .row {
@@ -57,9 +53,7 @@
     @for $i from $grid-columns through 1 {
       // set col-* to span respective number of columns on desktop
       .#{$grid-large-col-prefix}#{$i} {
-        // on large screens provide flex box column implementation for IE
         // on smaller screens let them display full width one under another
-        @include vf-grid-flex-column($i);
         @include vf-grid-column($i);
       }
     }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -328,14 +328,6 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
 
     margin-left: auto;
 
-    // fallback for IE flex box grid implementation
-    @media (min-width: $threshold-6-12-col) {
-      .p-stepped-list__content,
-      .p-stepped-list__title {
-        @include vf-grid-flex-column;
-      }
-    }
-
     @supports (display: grid) {
       .p-stepped-list__content {
         @media (min-width: $threshold-6-12-col) {


### PR DESCRIPTION
## Done

Removed IE fallback grid
- The sequel to https://github.com/canonical-web-and-design/vanilla-framework/pull/4004

## QA
- See that Percy checks pass

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
