### PR TITLE
Update 12 col breakpoint from medium to large

### DIFF
--- a/templates/docs/upgrade-guide-v3.md
+++ b/templates/docs/upgrade-guide-v3.md
@@ -70,7 +70,13 @@ Using `.u-hide` utility inside expanding table to hide table heading placeholder
 
 ## Grid
 
+### Column classes
+
 Use of `.col` classes outside of `.row` is deprecated. If you use `.col-X` class names outside of `.row` or your custom styling depends on specificity of `.col-X` class name you will need to review and update your styles accordingly.
+
+### Column layout change
+
+Previously, the grid layout would switch from 6 to 12 columns wide at the medium breakpoint. This has been changed so that the switch happens at the large breakpoint instead. We recommend visually checking your layouts at each breakpoint for any adverse effects this change may cause.
 
 ## Tables
 


### PR DESCRIPTION
## Done

- Updated the default breakpoint setting at which the layout switches to 12 columns
- Updated the breakpoint at which the side nav is displayed to match the above

Fixes #3209 

## QA

- Open [demo](https://vanilla-framework-4078.demos.haus/docs)
- Resize the browser, see that the layout doesn't break
- Compare to [live site](https://vanillaframework.io/docs), see that the demo layout changes to 12 column at a wider breakpoint

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/master/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
