### PR TITLE
GH action workflow to publish prereleases

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -38,12 +38,18 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
-      - run: npm publish
+      - if: ${{ !github.event.release.prerelease }}
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - if: ${{ github.event.release.prerelease }}
+        run: npm publish --tag next
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
   publish-assets:
     name: Publish to assets server
+    if: ${{ !github.event.release.prerelease }}
     needs: [build, publish-npm]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Done

Update release publish action to work with prereleases.
Makes sure prereleases are published to `next` tag on npm and are not uploaded to assets server.

## QA

- Review updated action file
- Check test run (prerelease): https://github.com/bartaz/vanilla-framework/actions/runs/1380028582
- Check test run (release): https://github.com/bartaz/vanilla-framework/actions/runs/1380046290

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

