### PR TITLE
Lock MarkupSafe at version 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+MarkupSafe==2.0.1 # workaround for breaking MakrupSafe 2.1.0 release https://github.com/pallets/jinja/issues/1587
 canonicalwebteam.flask-base==1.0.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.search==1.0.0


### PR DESCRIPTION
## Done

Fixes issues caused by breaking change in MarkupSafe affecting Jinja: https://github.com/pallets/jinja/issues/1587

## QA

- All CI checks should pass

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


