### PR TITLE
Fetch segmented control design guidelines

### DIFF
--- a/component_tabs.yaml
+++ b/component_tabs.yaml
@@ -4,14 +4,19 @@ patterns/accordion:
   accessibility: True
 patterns/badge:
   accessibility: True
+  design_guidelines: True
 patterns/breadcrumbs:
   accessibility: True
 patterns/buttons:
   accessibility: True
+  design_guidelines: True
 patterns/card:
   accessibility: True
+patterns/chip:
+  design_guidelines: True
 patterns/contextual-menu:
   accessibility: True
+  design_guidelines: True
 patterns/grid:
   accessibility: True
 patterns/heading-icon:
@@ -24,6 +29,8 @@ patterns/lists:
   accessibility: True
 patterns/logo-section:
   accessibility: True
+patterns/matrix:
+  design_guidelines: True
 patterns/modal:
   accessibility: True
 patterns/navigation:
@@ -38,12 +45,15 @@ patterns/search-box:
   accessibility: True
 patterns/segmented-control:
   design_guidelines: True
+patterns/slider:
+  design_guidelines: True
 patterns/status-labels:
   accessibility: True
 patterns/strip:
   accessibility: True
 patterns/switch:
   accessibility: True
+  design_guidelines: True
 patterns/tabs:
   accessibility: True
 patterns/tooltips:

--- a/component_tabs.yaml
+++ b/component_tabs.yaml
@@ -36,6 +36,8 @@ patterns/pull-quote:
   accessibility: True
 patterns/search-box:
   accessibility: True
+patterns/segmented-control:
+  design_guidelines: True
 patterns/status-labels:
   accessibility: True
 patterns/strip:

--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -87,7 +87,7 @@
     - title: Sections
       url: /docs/patterns/section
     - title: Segmented control
-      url: /docs/patterns/segmented-control
+      url: /design/patterns/segmented-control
     - title: Slider
       url: /docs/patterns/slider
     - title: Status labels

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -44,7 +44,7 @@
                           {% elif updatedFeatures[url]=="Deprecated" %}
                           <span class="p-status-label--negative">
                           {% elif updatedFeatures[url]=="In Progress" %}
-                          <span class="p-status-label--caution">    
+                          <span class="p-status-label--caution">
                           {% endif %}
                           {{ updatedFeatures[url] }}
                           </span>
@@ -52,7 +52,7 @@
                     </a>
                   </li>
               {%- endmacro %}
-              
+
               {% for item in sideNavigation %}
               <ul class="p-side-navigation__list">
                 <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">{{ item.heading | replace("{version}", version) }}</span></li>
@@ -66,7 +66,7 @@
           </div>
       </div>
     </aside>
-    
+
     <div class="p-strip is-shallow l-full-width">
       <div class="l-main">
         <div class="row">

--- a/templates/_layouts/docs_discourse.html
+++ b/templates/_layouts/docs_discourse.html
@@ -10,9 +10,16 @@
 
 {% include "_layouts/_component_tabs.html" %}
 
-{{ document.body_html | safe }}
+<div class="row">
+  <div class="col-8">
+    {{ document.body_html | safe }}
+  </div>
+</div>
+
 <hr />
+
 <p><em>Last updated {{ document.updated }}.</em></p>
+
 <div class="p-notification--information">
   <div class="p-notification__content">
     <p class="p-notification__message">

--- a/templates/docs/patterns/segmented-control.md
+++ b/templates/docs/patterns/segmented-control.md
@@ -4,10 +4,6 @@ context:
   title: Segmented control | Components
 ---
 
-# Segmented control
-
-<hr>
-
 Segmented control can be used in two ways:
 
 **Secondary tabs:** if the page already has a set of primary tabs used as navigation, this can be used as a sub-navigation of those primary tabs.


### PR DESCRIPTION
## Done

- Fetch segmented control guidelines from discourse and display in docs

Fixes [#1353](https://github.com/canonical-web-and-design/vanilla-squad/issues/1353)

## QA

- Open [demo](https://vanilla-framework-4445.demos.haus/docs/patterns/segmented-control)
- Check the design guidelines appear as expected

Segmented control: https://vanilla-framework-4445.demos.haus/design/patterns/segmented-control
Switch: https://vanilla-framework-4445.demos.haus/design/patterns/switch
Slider: https://vanilla-framework-4445.demos.haus/design/patterns/slider
Matrix: https://vanilla-framework-4445.demos.haus/design/patterns/matrix
Chips: https://vanilla-framework-4445.demos.haus/design/patterns/chip
Badge: https://vanilla-framework-4445.demos.haus/design/patterns/badge
Contextual menu: https://vanilla-framework-4445.demos.haus/design/patterns/contextual-menu
Button: https://vanilla-framework-4445.demos.haus/design/patterns/buttons


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
