### PR TITLE
Update references to repo location in the new org

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,11 +17,11 @@ If this PR contains Vanilla SCSS code changes, it should contain the following c
 
 - [ ] PR should have one of the following labels to automatically categorise it in release notes:
   - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
-- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical-web-and-design/vanilla-framework/releases/latest), following semver convention:
+- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
   - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
   - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
-  - see the [wiki for more details](https://github.com/canonical-web-and-design/vanilla-framework/wiki/Release-process#pre-release-tasks)
-- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/templates/docs/whats-new.md).
+  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
+- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
 - [ ] Documentation side navigation should be updated with the relevant labels.
 
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Check inclusive naming
-        uses: canonical-web-and-design/inclusive-naming@main
+        uses: canonical/inclusive-naming@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,9 @@ As developers and maintainers of the Vanilla project, we follow a [Code of Condu
 
 ## Reporting bugs and issues
 
-We use the [GitHub issues](https://github.com/canonical-web-and-design/vanilla-framework/issues) to track all our bugs and feature requests.
+We use the [GitHub issues](https://github.com/canonical/vanilla-framework/issues) to track all our bugs and feature requests.
 
-When [submitting a new issue](https://github.com/canonical-web-and-design/vanilla-framework/issues/new), please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.
+When [submitting a new issue](https://github.com/canonical/vanilla-framework/issues/new), please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.
 
 Please provide as much information possible detailing what you're currently experiencing and what you'd expect to experience.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ![vanilla](https://assets.ubuntu.com/v1/70041419-vanilla-framework.png?w=35 'Vanilla') Vanilla Framework
 
-[![CircleCI build status](https://circleci.com/gh/canonical-web-and-design/vanilla-framework.svg?style=shield)](https://circleci.com/gh/canonical-web-and-design/vanilla-framework)
+[![CircleCI build status](https://circleci.com/gh/canonical/vanilla-framework.svg?style=shield)](https://circleci.com/gh/canonical/vanilla-framework)
 [![npm version](https://badge.fury.io/js/vanilla-framework.svg)](http://badge.fury.io/js/vanilla-framework)
 [![Downloads](http://img.shields.io/npm/dm/vanilla-framework.svg)](https://www.npmjs.com/package/vanilla-framework)
-[![devDependency Status](https://david-dm.org/canonical-web-and-design/vanilla-framework/dev-status.svg)](https://david-dm.org/canonical-web-and-design/vanilla-framework#info=devDependencies)
+[![devDependency Status](https://david-dm.org/canonical/vanilla-framework/dev-status.svg)](https://david-dm.org/canonical/vanilla-framework#info=devDependencies)
 [![Chat in #vanilla-framework on Freenode](https://img.shields.io/badge/chat-%23vanilla--framework-blue.svg)](http://webchat.freenode.net/?channels=vanilla-framework)
 [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io)
 
@@ -24,7 +24,7 @@ Vanilla Framework is an extensible CSS framework, built using [Sass](http://sass
 
 ### Hotlinking
 
-You can link to the latest build to add directly into your markup like so, by replacing the x values with the [version number you wish to link](https://github.com/canonical-web-and-design/vanilla-framework/releases).
+You can link to the latest build to add directly into your markup like so, by replacing the x values with the [version number you wish to link](https://github.com/canonical/vanilla-framework/releases).
 
 ```html
 <link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-x.x.x.min.css" />

--- a/guides/hacking.md
+++ b/guides/hacking.md
@@ -16,7 +16,7 @@
 
 ### Via dotrun
 
-The simplest way to run the Vanilla framework on Linux is with the [dotrun snap](https://github.com/canonical-web-and-design/dotrun/), and using the `dotrun` command to build the project:
+The simplest way to run the Vanilla framework on Linux is with the [dotrun snap](https://github.com/canonical/dotrun/), and using the `dotrun` command to build the project:
 
 ```bash
 # Build CSS into the ./build/ directory,

--- a/guides/pull-requests.md
+++ b/guides/pull-requests.md
@@ -23,13 +23,13 @@ If your work includes any of the following:
 
 your changes should be listed in [What's new](/templates/docs/whats-new) page. Within that document is a list of all prior changes, each associated with a particular version release.
 
-When updating the document, first note the [most recently released version of Vanilla](https://github.com/canonical-web-and-design/vanilla-framework/tags). If the changes listed in the "What's new in Vanilla" table match that version, those changes should be moved to the "Previously in Vanilla" table below.
+When updating the document, first note the [most recently released version of Vanilla](https://github.com/canonical/vanilla-framework/tags). If the changes listed in the "What's new in Vanilla" table match that version, those changes should be moved to the "Previously in Vanilla" table below.
 
 You can then detail your changes as a row in the "What's new" table.
 
 ### Updating the Vanilla version number
 
-We use [semver](https://semver.org/) conventions when deciding how to update the Vanilla version in [package.json](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/package.json):
+We use [semver](https://semver.org/) conventions when deciding how to update the Vanilla version in [package.json](https://github.com/canonical/vanilla-framework/blob/main/package.json):
 
 - <code>\_.\_.**X**</code>: use a patch release when the release is only bugfixes,
 - <code>\_.**X**.\_</code>: use minor release if there are any added features (new components or new variants/modifiers to existing components)

--- a/guides/release-process.md
+++ b/guides/release-process.md
@@ -14,7 +14,7 @@
 ## Pre release tasks
 
 - Merge all pull requests relating to the given release
-- On [GitHub releases page](https://github.com/canonical-web-and-design/vanilla-framework/releases) update latest draft automatically created by Release Drafter
+- On [GitHub releases page](https://github.com/canonical/vanilla-framework/releases) update latest draft automatically created by Release Drafter
   - make sure automatic version is correct
   - clean up the log from unnecessary lines, move changes to relevant section if it didn't happen automatically based on labels, reword the changes for better readability
 
@@ -28,12 +28,12 @@
 
 ### Releasing on GitHub
 
-- Publish the latest release on [Github](https://github.com/canonical-web-and-design/vanilla-framework/releases/) with the new version number and add the release notes you created earlier.
+- Publish the latest release on [Github](https://github.com/canonical/vanilla-framework/releases/) with the new version number and add the release notes you created earlier.
   - Make sure to mark the release as a pre-release if it's an Alpha or Beta
 
 ### Releasng to NPM
 
-This should happen automatically after publishing the release on GH (thanks to [GH actions workflow](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/.github/workflows/publish-on-release.yml)).
+This should happen automatically after publishing the release on GH (thanks to [GH actions workflow](https://github.com/canonical/vanilla-framework/blob/main/.github/workflows/publish-on-release.yml)).
 
 In case that fails, here are manual steps to release to NPM:
 
@@ -43,7 +43,7 @@ In case that fails, here are manual steps to release to NPM:
 
 ### Releasing to assets server
 
-This should happen automatically after publishing the release on GH (thanks to [GH actions workflow](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/.github/workflows/publish-on-release.yml)).
+This should happen automatically after publishing the release on GH (thanks to [GH actions workflow](https://github.com/canonical/vanilla-framework/blob/main/.github/workflows/publish-on-release.yml)).
 
 In case that fails, here are manual steps to release to assets server:
 
@@ -59,9 +59,9 @@ In case that fails, here are manual steps to release to assets server:
 
 ## Releasing React Components
 
-When the Vanilla npm package is published, [react-components](https://github.com/canonical-web-and-design/react-components/) project should be updated to latest version of Vanilla (renovate should prepare an update PR) and the updated `react-components` package should be published as well.
+When the Vanilla npm package is published, [react-components](https://github.com/canonical/react-components/) project should be updated to latest version of Vanilla (renovate should prepare an update PR) and the updated `react-components` package should be published as well.
 
-Please follow the [release process](https://github.com/canonical-web-and-design/react-components/blob/main/PUBLISH-NPM-PACKAGE.md) documented in the `react-components` repository.
+Please follow the [release process](https://github.com/canonical/react-components/blob/main/PUBLISH-NPM-PACKAGE.md) documented in the `react-components` repository.
 
 ## Promotion
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "bugs": {
     "email": "webteam@canonical.com",
-    "url": "http://github.com/canonical-web-and-design/vanilla-framework/issues"
+    "url": "http://github.com/canonical/vanilla-framework/issues"
   },
   "description": "A simple, extendable CSS framework.",
   "homepage": "https://vanillaframework.io/",
@@ -23,7 +23,7 @@
   "name": "vanilla-framework",
   "repository": {
     "type": "git",
-    "url": "https://github.com/canonical-web-and-design/vanilla-framework"
+    "url": "https://github.com/canonical/vanilla-framework"
   },
   "scripts": {
     "start": "yarn build && yarn serve",

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -89,7 +89,7 @@
     // In cases where contextual menu toggle is a button, we do not want it to
     // have a margin, but since it is never the last child in this pattern,
     // so we need to remove the margin.
-    // https://github.com/canonical-web-and-design/vanilla-framework/pull/3584
+    // https://github.com/canonical/vanilla-framework/pull/3584
     margin-right: 0;
 
     &[aria-expanded='true'] .p-contextual-menu__indicator {

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -16,7 +16,7 @@
 
 @mixin vf-p-grid {
   // FIXME: this should be removed from framework SCSS
-  // (see https://github.com/canonical-web-and-design/vanilla-framework/issues/3199)
+  // (see https://github.com/canonical/vanilla-framework/issues/3199)
   .grid-demo [class*='#{$grid-column-prefix}'] {
     background: transparentize($color-negative, 0.9);
     margin-bottom: $spv--small;

--- a/templates/404.html
+++ b/templates/404.html
@@ -12,7 +12,7 @@
 <div class="p-strip is-shallow">
   <div class="row">
     <div class="col 12">
-      <p>Sorry, we can't find the page you're looking for. If you think this is an error on our site, please <a href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new">file a bug on GitHub.</a></p>
+      <p>Sorry, we can't find the page you're looking for. If you think this is an error on our site, please <a href="https://github.com/canonical/vanilla-framework/issues/new">file a bug on GitHub.</a></p>
     </div>
   </div>
 </div>

--- a/templates/_layouts/_footer.html
+++ b/templates/_layouts/_footer.html
@@ -5,13 +5,13 @@
       <nav aria-label="Footer">
         <ul class="p-inline-list--middot u-no-margin--bottom">
           <li class="p-inline-list__item">
-            <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">Vanilla framework v{{ version }}</a>
+            <a href="https://github.com/canonical/vanilla-framework/releases/latest">Vanilla framework v{{ version }}</a>
           </li>
           <li class="p-inline-list__item">
             <a href="https://www.ubuntu.com/legal">Legal info</a>
           </li>
           <li class="p-inline-list__item">
-            <a href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new/choose">Report a bug</a>
+            <a href="https://github.com/canonical/vanilla-framework/issues/new/choose">Report a bug</a>
           </li>
           <li class="p-inline-list__item">
             <a href="#tracker-settings" class="js-revoke-cookie-manager">Manage your tracker settings</a>

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -146,7 +146,7 @@
             <ul class="p-side-navigation__list">
               <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Resources</span></li>
               {{ side_nav_item("/docs/examples", "Component examples") }}
-              {{ side_nav_item("https://github.com/canonical-web-and-design/vanilla-framework/releases/latest", "Release notes for " ~ version) }}
+              {{ side_nav_item("https://github.com/canonical/vanilla-framework/releases/latest", "Release notes for " ~ version) }}
               {{ side_nav_item("https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch", "Download Sketch UI Kit") }}
             </ul>
 

--- a/templates/accessibility.html
+++ b/templates/accessibility.html
@@ -125,7 +125,7 @@
 <div class="p-strip">
   <div class="u-fixed-width">
     <h2>Noticed an issue?</h2>
-    <p>If you spot an accessibility problem in Vanilla, let us know <br> by <a href="https://github.com/canonical-web-and-design/vanilla-framework/issues">filing&nbsp;an&nbsp;issue</a> on GitHub.</p>
+    <p>If you spot an accessibility problem in Vanilla, let us know <br> by <a href="https://github.com/canonical/vanilla-framework/issues">filing&nbsp;an&nbsp;issue</a> on GitHub.</p>
   </div>
 </div>
 {% endblock %}

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -77,7 +77,7 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <p>When <a href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new/choose">submitting a new issue</a>, please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.</p>
+      <p>When <a href="https://github.com/canonical/vanilla-framework/issues/new/choose">submitting a new issue</a>, please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.</p>
       <p>Please provide as much information possible detailing what you're currently experiencing and what you'd expect to experience.</p>
       <p>To work on an issue, please fork this repo and create a new branch on your local fork. When you're happy and would like to propose that changeset to be merged back upstream, open a pull request to merge from your local origin/master to upstream/master.</p>
       <p>When committing changes, make sure to group related changes so that the project is always in a working state. Use succinct yet descriptive commit messages to allow for easy reading of the commit log.</p>
@@ -96,7 +96,7 @@
       <div class="row">
         <div class="col-3 p-card">
           <h3>File a bug</h3>
-          <p>We use <a href="https://github.com/canonical-web-and-design/vanilla-framework/issues">GitHub issues</a> to track all our bugs and feature requests.</p>
+          <p>We use <a href="https://github.com/canonical/vanilla-framework/issues">GitHub issues</a> to track all our bugs and feature requests.</p>
         </div>
         <div class="col-3 p-card">
           <h3>Chat with us</h3>
@@ -124,7 +124,7 @@
         </div>
       </div>
       <p>The simplest way to run Vanilla framework is to first <a href="https://docs.docker.com/install/">install Docker</a>, and then use the <code>./run</code> script to <a
-          href="https://github.com/canonical-web-and-design/vanilla-framework#vanilla-local-development">build the site</a>. Before proposing a pull request, ensure that the tests pass on your local fork. To kick off the tests for your project, in the terminal <code>./run test</code>.</p>
+          href="https://github.com/canonical/vanilla-framework#vanilla-local-development">build the site</a>. Before proposing a pull request, ensure that the tests pass on your local fork. To kick off the tests for your project, in the terminal <code>./run test</code>.</p>
     </div>
     <div class="col-6">
       <div class="p-heading-icon">

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -120,4 +120,4 @@ View example of the code snippet with a border
 
 You can use code snippet in React by installing our react-component library and importing code snippet component.
 
-[See the documentation for our React `CodeSnippet` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/codesnippet--default-story#code-snippet)
+[See the documentation for our React `CodeSnippet` component](https://canonical.github.io/react-components/?path=/docs/codesnippet--default-story#code-snippet)

--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -246,6 +246,6 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use forms in React by installing our react-component library and importing `Form` and `Input` component.
 
-[See the documentation for our React `Form` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/form--default-story#form)
+[See the documentation for our React `Form` component](https://canonical.github.io/react-components/?path=/docs/form--default-story#form)
 
-[See the documentation for our React `Input` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/input--text-input#input)
+[See the documentation for our React `Input` component](https://canonical.github.io/react-components/?path=/docs/input--text-input#input)

--- a/templates/docs/base/tables.md
+++ b/templates/docs/base/tables.md
@@ -108,6 +108,6 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use tables in React by installing our react-component library and importing `MainTable` or `ModularTable` component.
 
-[See the documentation for our React `MainTable` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/maintable--default-story#maintable)
+[See the documentation for our React `MainTable` component](https://canonical.github.io/react-components/?path=/docs/maintable--default-story#maintable)
 
-[See the documentation for our React `ModularTable` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/modulartable--default-story)
+[See the documentation for our React `ModularTable` component](https://canonical.github.io/react-components/?path=/docs/modulartable--default-story)

--- a/templates/docs/base/typography.md
+++ b/templates/docs/base/typography.md
@@ -16,7 +16,7 @@ Vanilla's typographic scale has a base font-size of `1rem`.
 
 The pixel value of `1rem` depends on the browser (in most cases, `16px`) and the user's browser settings.
 
-In addition to that, Vanilla multiplies that value by <a href="https://github.com/canonical-web-and-design/vanilla-framework/blob/ea6f05b4a90169b36a5e9c5a86ceae40cbddd986/scss/_settings_font.scss#L9">`$font-size-ratio--largescreen`</a> on resolutions above a certain threshold (<a href="https://github.com/canonical-web-and-design/vanilla-framework/blob/ea6f05b4a90169b36a5e9c5a86ceae40cbddd986/scss/_settings_breakpoints.scss#L8">`$font-size-largescreen`</a>). This is done to account for the bigger distance at which larger screens are usually positioned from the viewer.
+In addition to that, Vanilla multiplies that value by <a href="https://github.com/canonical/vanilla-framework/blob/ea6f05b4a90169b36a5e9c5a86ceae40cbddd986/scss/_settings_font.scss#L9">`$font-size-ratio--largescreen`</a> on resolutions above a certain threshold (<a href="https://github.com/canonical/vanilla-framework/blob/ea6f05b4a90169b36a5e9c5a86ceae40cbddd986/scss/_settings_breakpoints.scss#L8">`$font-size-largescreen`</a>). This is done to account for the bigger distance at which larger screens are usually positioned from the viewer.
 
 To disable this behaviour, include the following after you import and include the framework in your `scss`:
 
@@ -231,7 +231,7 @@ The CSS [`font-display`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-
 $font-display-option: <auto | block | swap | fallback | optional>;
 ```
 
-The default value of the `font-display` property on [all fonts used by Vanilla](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/scss/_base_fontfaces.scss) is set to `fallback`.
+The default value of the `font-display` property on [all fonts used by Vanilla](https://github.com/canonical/vanilla-framework/blob/main/scss/_base_fontfaces.scss) is set to `fallback`.
 
 ## Import
 

--- a/templates/docs/building-vanilla.md
+++ b/templates/docs/building-vanilla.md
@@ -273,7 +273,7 @@ For more options on configuring `gulp-sass`, for example minification and autopr
 
 Creating a submodule in the git repo does not add all the code to the project but includes a reference and path to include the framework. You may find this method useful if you're planing to host on Github Pages.
 
-Run this command at the root of your project (replacing vX.X.X with the [release](https://github.com/canonical-web-and-design/vanilla-framework/releases) you wish to use)
+Run this command at the root of your project (replacing vX.X.X with the [release](https://github.com/canonical/vanilla-framework/releases) you wish to use)
 
 ```
 git submodule add -b vX.X.X -- git@github.com:vanilla-framework/vanilla-framework.git _sass/vanilla-framework

--- a/templates/docs/examples/patterns/icons/icons-links.html
+++ b/templates/docs/examples/patterns/icons/icons-links.html
@@ -4,6 +4,6 @@
 {% block standalone_css %}patterns_icons{% endblock %}
 
 {% block content %}
-<a class="p-icon--github" href="https://github.com/canonical-web-and-design/vanilla-framework/">GitHub</a>
+<a class="p-icon--github" href="https://github.com/canonical/vanilla-framework/">GitHub</a>
 <a class="p-icon--twitter" href="https://twitter.com/vanillaframewrk">Twitter</a>
 {% endblock %}

--- a/templates/docs/index.html
+++ b/templates/docs/index.html
@@ -32,15 +32,15 @@
 
 <h2>Download</h2>
 <p>Download the latest version of Vanilla from GitHub.</p>
-<p><a class="p-button--positive" href="https://github.com/canonical-web-and-design/vanilla-framework/archive/v{{ version }}.zip">Download v{{ version }}</a></p>
-<p>See the <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases">release notes</a> for details on the latest updates.</p>
+<p><a class="p-button--positive" href="https://github.com/canonical/vanilla-framework/archive/v{{ version }}.zip">Download v{{ version }}</a></p>
+<p>See the <a href="https://github.com/canonical/vanilla-framework/releases">release notes</a> for details on the latest updates.</p>
 
 <h2>Local development</h2>
-<p>To make improvements to Vanilla itself, please follow the instructions on the project’s <a href="https://github.com/canonical-web-and-design/vanilla-framework#vanilla-framework">README.md</a>.</p>
+<p>To make improvements to Vanilla itself, please follow the instructions on the project’s <a href="https://github.com/canonical/vanilla-framework#vanilla-framework">README.md</a>.</p>
 <ul class="p-inline-list">
   <li class="p-inline-list__item"><i class="p-list__icon--slack"></i><a href="https://vanillaframework.slack.com/">Join our channel</a></li>
   <li class="p-inline-list__item"><i class="p-list__icon--twitter"></i><a href="https://twitter.com/vanillaframewrk">Tweet us</a></li>
-  <li class="p-inline-list__item"><i class="p-list__icon--github"></i><a href="https://github.com/canonical-web-and-design/vanilla-framework/issues/new">Fork us on GitHub</a></li>
+  <li class="p-inline-list__item"><i class="p-list__icon--github"></i><a href="https://github.com/canonical/vanilla-framework/issues/new">Fork us on GitHub</a></li>
 </ul>
 
 {% endblock %}

--- a/templates/docs/patterns/accordion/index.md
+++ b/templates/docs/patterns/accordion/index.md
@@ -64,4 +64,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use accordion in React by installing our react-component library and importing `Accordion` component.
 
-[See the documentation for our React `Accordion` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/accordion--default-story#accordion)
+[See the documentation for our React `Accordion` component](https://canonical.github.io/react-components/?path=/docs/accordion--default-story#accordion)

--- a/templates/docs/patterns/buttons/index.md
+++ b/templates/docs/patterns/buttons/index.md
@@ -97,7 +97,7 @@ View example of the icon button pattern
 
 In cases where a button needs to indicate that an action is occurring (e.g. saving data, processing a payment) while also preventing user interaction, the state class `is-processing` can be added to a disabled button to maintain full opacity.
 
-When replacing a label in a button with a loading icon make sure to keep the width of the button the same to avoid content moving around. The example below has a snippet of JavaScript to demo how to achieve that or you can use the [`ActionButton` React component](https://canonical-web-and-design.github.io/react-components/?path=/docs/actionbutton--default-story) that has this functionality built-in.
+When replacing a label in a button with a loading icon make sure to keep the width of the button the same to avoid content moving around. The example below has a snippet of JavaScript to demo how to achieve that or you can use the [`ActionButton` React component](https://canonical.github.io/react-components/?path=/docs/actionbutton--default-story) that has this functionality built-in.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/buttons/processing/" class="js-example">
 View example of the processing button pattern
@@ -138,6 +138,6 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use buttons in React by installing our react-component library and importing `Button` or `ActionButton` component.
 
-[See the documentation for our React `Button` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/button--base#button)
+[See the documentation for our React `Button` component](https://canonical.github.io/react-components/?path=/docs/button--base#button)
 
-[See the documentation for our React `ActionButton` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/actionbutton--default-story#actionbutton)
+[See the documentation for our React `ActionButton` component](https://canonical.github.io/react-components/?path=/docs/actionbutton--default-story#actionbutton)

--- a/templates/docs/patterns/card/index.md
+++ b/templates/docs/patterns/card/index.md
@@ -73,4 +73,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use cards in React by installing our react-component library and importing `Card` component.
 
-[See the documentation for our React `Card` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/card--default-story)
+[See the documentation for our React `Card` component](https://canonical.github.io/react-components/?path=/docs/card--default-story)

--- a/templates/docs/patterns/chip.md
+++ b/templates/docs/patterns/chip.md
@@ -73,4 +73,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use chips in React by installing our react-component library and importing `Chip` component.
 
-[See the documentation for our React `Chip` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/chip--default-story#chip)
+[See the documentation for our React `Chip` component](https://canonical.github.io/react-components/?path=/docs/chip--default-story#chip)

--- a/templates/docs/patterns/contextual-menu/index.md
+++ b/templates/docs/patterns/contextual-menu/index.md
@@ -80,7 +80,7 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use contextual menu in React by installing our react-component library and importing `ContextualMenu` component.
 
-[See the documentation for our React `ContextualMenu` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/contextualmenu--default-story#contextual-menu)
+[See the documentation for our React `ContextualMenu` component](https://canonical.github.io/react-components/?path=/docs/contextualmenu--default-story#contextual-menu)
 
 ## Related
 

--- a/templates/docs/patterns/divider.md
+++ b/templates/docs/patterns/divider.md
@@ -18,7 +18,7 @@ View example of lists with a responsive divider
 
 ## Theming
 
-The responsive divider is available in a light and a dark theme. The colours used by both themes in the [colour settings file](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/scss/_settings_colors.scss).
+The responsive divider is available in a light and a dark theme. The colours used by both themes in the [colour settings file](https://github.com/canonical/vanilla-framework/blob/main/scss/_settings_colors.scss).
 Overriding the colours of individual elements of the responsive is discouraged, as this may lead to accessibility issues, or inconsistencies with other components that use the same theme.
 
 By default, the responsive divider uses the light theme. To change the global default, set `$theme-default-p-divider` to `dark`.

--- a/templates/docs/patterns/grid/index.md
+++ b/templates/docs/patterns/grid/index.md
@@ -110,6 +110,6 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use grid in React by installing our react-component library and importing `Row` and `Col` components.
 
-[See the documentation for our React `Row` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/row--default-story#row)
+[See the documentation for our React `Row` component](https://canonical.github.io/react-components/?path=/docs/row--default-story#row)
 
-[See the documentation for our React `Col` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/col--default-story#col)
+[See the documentation for our React `Col` component](https://canonical.github.io/react-components/?path=/docs/col--default-story#col)

--- a/templates/docs/patterns/icons/index.md
+++ b/templates/docs/patterns/icons/index.md
@@ -159,4 +159,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use icons in React by installing our react-component library and importing `Icon` component.
 
-[See the documentation for our React `Icon` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/icon--default-story#icon)
+[See the documentation for our React `Icon` component](https://canonical.github.io/react-components/?path=/docs/icon--default-story#icon)

--- a/templates/docs/patterns/icons/index.md
+++ b/templates/docs/patterns/icons/index.md
@@ -151,7 +151,7 @@ In the below example, the `.p-icon--share` class includes the `vf-icon-share` mi
 }
 ```
 
-You can find all of the available icon mixins listed [here](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/scss/_base_icon-definitions.scss).
+You can find all of the available icon mixins listed [here](https://github.com/canonical/vanilla-framework/blob/main/scss/_base_icon-definitions.scss).
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
 

--- a/templates/docs/patterns/links/index.md
+++ b/templates/docs/patterns/links/index.md
@@ -65,4 +65,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use links in React by installing our react-component library and importing `Link` component.
 
-[See the documentation for our React `Link` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/link--default-story#link)
+[See the documentation for our React `Link` component](https://canonical.github.io/react-components/?path=/docs/link--default-story#link)

--- a/templates/docs/patterns/lists/index.md
+++ b/templates/docs/patterns/lists/index.md
@@ -166,4 +166,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use lists in React by installing our react-component library and importing `List` component.
 
-[See the documentation for our React `List` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/list--default-story#list)
+[See the documentation for our React `List` component](https://canonical.github.io/react-components/?path=/docs/list--default-story#list)

--- a/templates/docs/patterns/modal/index.md
+++ b/templates/docs/patterns/modal/index.md
@@ -45,4 +45,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use modal dialogs in React by installing our react-component library and importing `Modal` component.
 
-[See the documentation for our React `Modal` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/modal--default-story#modal)
+[See the documentation for our React `Modal` component](https://canonical.github.io/react-components/?path=/docs/modal--default-story#modal)

--- a/templates/docs/patterns/navigation/index.md
+++ b/templates/docs/patterns/navigation/index.md
@@ -172,7 +172,7 @@ For more information, read the dedicated [application layout documentation](/doc
 
 ### Theming
 
-The side navigation is available in a light and a dark theme. The colours used by both themes in the [colour settings file](https://github.com/canonical-web-and-design/vanilla-framework/blob/main/scss/_settings_colors.scss).
+The side navigation is available in a light and a dark theme. The colours used by both themes in the [colour settings file](https://github.com/canonical/vanilla-framework/blob/main/scss/_settings_colors.scss).
 Overriding the colours of individual elements of the side navigation is discouraged, as this may lead to accessibility issues, or inconsistencies with other components that use the same theme.
 
 By default, the side navigation uses the light theme. To change the global default, set `$theme-default-p-side-navigation` to `dark`.

--- a/templates/docs/patterns/notification/index.md
+++ b/templates/docs/patterns/notification/index.md
@@ -117,7 +117,7 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use notifications in React by installing our react-component library and importing `Notification` component.
 
-[See the documentation for our React `Notification` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/notification--default-story#notification)
+[See the documentation for our React `Notification` component](https://canonical.github.io/react-components/?path=/docs/notification--default-story#notification)
 
 ## Related components
 

--- a/templates/docs/patterns/pagination/index.md
+++ b/templates/docs/patterns/pagination/index.md
@@ -82,6 +82,6 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use pagination in React by installing our react-component library and importing `Pagination` or `ArticlePagination` component.
 
-[See the documentation for our React `Pagination` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/pagination--default-story#pagination)
+[See the documentation for our React `Pagination` component](https://canonical.github.io/react-components/?path=/docs/pagination--default-story#pagination)
 
-[See the documentation for our React `ArticlePagination` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/articlepagination--default-story#articlepagination)
+[See the documentation for our React `ArticlePagination` component](https://canonical.github.io/react-components/?path=/docs/articlepagination--default-story#articlepagination)

--- a/templates/docs/patterns/search-and-filter.md
+++ b/templates/docs/patterns/search-and-filter.md
@@ -88,4 +88,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use search and filter in React by installing our react-component library and importing `SearchAndFilter` component.
 
-[See the documentation for our React `SearchAndFilter` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/search-and-filter--default-story#search-and-filter)
+[See the documentation for our React `SearchAndFilter` component](https://canonical.github.io/react-components/?path=/docs/search-and-filter--default-story#search-and-filter)

--- a/templates/docs/patterns/search-box/index.md
+++ b/templates/docs/patterns/search-box/index.md
@@ -61,7 +61,7 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use search box in React by installing our react-component library and importing `SearchBox` component.
 
-[See the documentation for our React `SearchBox` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/searchbox--default-story#searchbox)
+[See the documentation for our React `SearchBox` component](https://canonical.github.io/react-components/?path=/docs/searchbox--default-story#searchbox)
 
 ## Related
 

--- a/templates/docs/patterns/slider.md
+++ b/templates/docs/patterns/slider.md
@@ -34,4 +34,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use slider in React by installing our react-component library and importing `Slider` component.
 
-[See the documentation for our React `Slider` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/slider--default-story#slider)
+[See the documentation for our React `Slider` component](https://canonical.github.io/react-components/?path=/docs/slider--default-story#slider)

--- a/templates/docs/patterns/strip/index.md
+++ b/templates/docs/patterns/strip/index.md
@@ -113,4 +113,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use strip in React by installing our react-component library and importing `Strip` component.
 
-[See the documentation for our React `Strip` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/strip--light-strip#strip)
+[See the documentation for our React `Strip` component](https://canonical.github.io/react-components/?path=/docs/strip--light-strip#strip)

--- a/templates/docs/patterns/tabs/index.md
+++ b/templates/docs/patterns/tabs/index.md
@@ -54,4 +54,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use tabs in React by installing our react-component library and importing `Tab` component.
 
-[See the documentation for our React `Tab` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/tabs--default-story#tabs)
+[See the documentation for our React `Tab` component](https://canonical.github.io/react-components/?path=/docs/tabs--default-story#tabs)

--- a/templates/docs/patterns/tooltips/index.md
+++ b/templates/docs/patterns/tooltips/index.md
@@ -53,7 +53,7 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use tooltips in React by installing our react-component library and importing `Tooltip` component.
 
-[See the documentation for our React `Tooltip` component](https://canonical-web-and-design.github.io/react-components/?path=/docs/tooltip--default-story)
+[See the documentation for our React `Tooltip` component](https://canonical.github.io/react-components/?path=/docs/tooltip--default-story)
 
 ## Related
 

--- a/templates/docs/settings/color-settings.md
+++ b/templates/docs/settings/color-settings.md
@@ -145,7 +145,7 @@ It’s important for us to meet all web accessibility standards. Vanilla encoura
 
 ## Color theming
 
-Starting with the [2.3.0](https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.3.0) release, Vanilla framework introduces a theming mechanism. The current default for all components is referred to as the light theme. A subset of elements and components now offer a dark theme:
+Starting with the [2.3.0](https://github.com/canonical/vanilla-framework/releases/tag/v2.3.0) release, Vanilla framework introduces a theming mechanism. The current default for all components is referred to as the light theme. A subset of elements and components now offer a dark theme:
 
 - [Checkbox](/docs/base/forms#checkbox) and [radio](/docs/base/forms#radio-button) form inputs
 - Horizontal rule element `<hr />`

--- a/templates/docs/settings/placeholder-settings.md
+++ b/templates/docs/settings/placeholder-settings.md
@@ -21,22 +21,22 @@ Vanilla uses several global placeholders to share common styles between componen
   <tbody>
     <tr>
       <td><code>$bar-thickness</code></td>
-      <td><a href="https://github.com/canonical-web-and-design/vanilla-framework/blob/main/scss/_settings_placeholders.scss#L6-L9"><code>0.1875rem</code></a></td>
+      <td><a href="https://github.com/canonical/vanilla-framework/blob/main/scss/_settings_placeholders.scss#L6-L9"><code>0.1875rem</code></a></td>
       <td>Navigation, notification</td>
     </tr>
     <tr>
       <td><code>$border-radius</code></td>
-      <td><a href="https://github.com/canonical-web-and-design/vanilla-framework/blob/main/scss/_settings_placeholders.scss#L6-L9"><code>$sp-unit * 0.25</code></a></td>
+      <td><a href="https://github.com/canonical/vanilla-framework/blob/main/scss/_settings_placeholders.scss#L6-L9"><code>$sp-unit * 0.25</code></a></td>
       <td>Button, Card, Code, Form, Media object, Switch, Tooltip</td>
     </tr>
     <tr>
       <td><code>$border</code></td>
-      <td><a href="https://github.com/canonical-web-and-design/vanilla-framework/blob/main/scss/_settings_placeholders.scss#L6-L9"><code>1px solid $color-mid-light</code></a></td>
+      <td><a href="https://github.com/canonical/vanilla-framework/blob/main/scss/_settings_placeholders.scss#L6-L9"><code>1px solid $color-mid-light</code></a></td>
       <td>Card, Code, Form, Search box</td>
     </tr>
     <tr>
       <td><code>$box-shadow</code></td>
-      <td class="u-truncate"><a href="https://github.com/canonical-web-and-design/vanilla-framework/blob/main/scss/_settings_placeholders.scss#L6-L9"><code>0 1px 1px 0 transparentize($color-x-dark, 0.85), 0 2px 2px -1px transparentize($color-x-dark, 0.85), 0 0 3px 0 transparentize($color-x-dark, 0.8)</code></a></td>
+      <td class="u-truncate"><a href="https://github.com/canonical/vanilla-framework/blob/main/scss/_settings_placeholders.scss#L6-L9"><code>0 1px 1px 0 transparentize($color-x-dark, 0.85), 0 2px 2px -1px transparentize($color-x-dark, 0.85), 0 0 3px 0 transparentize($color-x-dark, 0.8)</code></a></td>
       <td>Card (highlighted), Modal, Notification, Switch</td>
     </tr>
   </tbody>

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
           <a href="/docs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Get started</a>
         </li>
         <li class="p-inline-list__item">
-          <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download latest', 'eventValue' : undefined });" class="p-button u-no-margin--bottom">Download Vanilla v{{version}}</a>
+          <a href="https://github.com/canonical/vanilla-framework/releases/latest" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download latest', 'eventValue' : undefined });" class="p-button u-no-margin--bottom">Download Vanilla v{{version}}</a>
         </li>
       </ul>
     </div>
@@ -142,8 +142,8 @@
           <h3 class="p-heading-icon__title">Vanilla Framework</h3>
         </div>
         <p>Use our CSS framework to start building&nbsp;your project.</p>
-        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button" href="https://github.com/canonical-web-and-design/vanilla-framework/releases/latest">Download latest Vanilla v{{version}}</a></p>
-        <small>See the <a href="https://github.com/canonical-web-and-design/vanilla-framework/releases">release notes</a> for details on the latest&nbsp;updates.</small>
+        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button" href="https://github.com/canonical/vanilla-framework/releases/latest">Download latest Vanilla v{{version}}</a></p>
+        <small>See the <a href="https://github.com/canonical/vanilla-framework/releases">release notes</a> for details on the latest&nbsp;updates.</small>
       </div>
     </div>
     <div class="p-card--highlighted col-4">
@@ -251,8 +251,8 @@
   <div class="row">
     <div class="col-3">
       <h2>Contribute</h2>
-      <p><a class="github-button" href="https://github.com/canonical-web-and-design/vanilla-framework" data-size="large" data-show-count="true" aria-label="Follow @vanilla-framework on GitHub">Follow @vanilla-framework</a></p>
-      <p><a class="github-button" href="https://github.com/canonical-web-and-design/vanilla-framework/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork vanilla-framework/vanilla-framework on GitHub">Fork</a></p>
+      <p><a class="github-button" href="https://github.com/canonical/vanilla-framework" data-size="large" data-show-count="true" aria-label="Follow @vanilla-framework on GitHub">Follow @vanilla-framework</a></p>
+      <p><a class="github-button" href="https://github.com/canonical/vanilla-framework/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork vanilla-framework/vanilla-framework on GitHub">Fork</a></p>
     </div>
     <div class="col-3">
       <h2>Get involved</h2>
@@ -261,7 +261,7 @@
           <a href="https://twitter.com/vanillaframewrk" class="p-link--soft">Twitter&nbsp;&rsaquo;</a>
         </li>
         <li class="p-list__item is-ticked" style="background-image: url('https://assets.ubuntu.com/v1/f307a122-icon-github.svg'); background-size: 1rem;">
-          <a href="https://github.com/canonical-web-and-design/vanilla-framework" class="p-link--soft">GitHub&nbsp;&rsaquo;</a>
+          <a href="https://github.com/canonical/vanilla-framework" class="p-link--soft">GitHub&nbsp;&rsaquo;</a>
         </li>
       </ul>
     </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -128,7 +128,7 @@ def _get_team_members(contributors):
 
 def _get_contributors():
     contributors = _make_github_request(
-        "repos/canonical-web-and-design/vanilla-framework/contributors"
+        "repos/canonical/vanilla-framework/contributors"
     )
 
     return contributors


### PR DESCRIPTION
## Done

Updates any references of repo URL to new location in Canonical org.

## QA

- Open [demo](https://vanilla-framework-4525.demos.haus/)
- Review [home page](https://vanilla-framework-4525.demos.haus/), make sure all links to GH are to correct org
- Review [contribute page](https://vanilla-framework-4525.demos.haus/contribute), make sure contributors are correctly displayed from API
