### PR TITLE
feat: accordion transition

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.6.1",
+  "version": "3.6.2",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -28,7 +28,6 @@
     padding-right: $sph--large;
     position: relative;
     text-align: left;
-    transition-duration: 0s;
     width: 100%;
     z-index: 2;
 
@@ -49,12 +48,15 @@
       &:hover {
         background-color: $colors--light-theme--background-hover;
       }
+      @include vf-animation(#{background-color, border-color});
     }
 
     &[aria-expanded='false'] {
       &::before {
         transform: rotate(-90deg);
       }
+
+      @include vf-animation(#{background-color, border-color});
     }
   }
 
@@ -97,6 +99,15 @@
 
     &.has-tick-elements {
       padding-left: 1em;
+    }
+
+    // transition
+    @include vf-animation("transform, opacity");
+    opacity: 0;
+    transform: translate3d(0, -20px, 0);
+    &.has-transitioned--in {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
     }
   }
 }

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -92,22 +92,24 @@
     overflow: auto; // include child margins into its height
     padding-left: $sph--large + $icon-size + $sph--large * 2;
 
+    @include vf-animation('transform, opacity', fast);
     // Hides panel content
     &[aria-hidden='true'] {
-      display: none;
+      height: 0;
+      opacity: 0;
+      transform: translate3d(0, -0.5rem, 0);
+      visibility: hidden;
+    }
+
+    &[aria-hidden='false'] {
+      height: auto;
+      opacity: 1;
+      transform: translate3d(0, 0, 0);
+      visibility: visible;
     }
 
     &.has-tick-elements {
       padding-left: 1em;
-    }
-
-    // transition
-    @include vf-animation("transform, opacity", fast);
-    opacity: 0;
-    transform: translate3d(0, -0.5rem, 0);
-    &.has-transitioned--in {
-        opacity: 1;
-        transform: translate3d(0, 0, 0);
     }
   }
 }

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -102,9 +102,9 @@
     }
 
     // transition
-    @include vf-animation("transform, opacity");
+    @include vf-animation("transform, opacity", fast);
     opacity: 0;
-    transform: translate3d(0, -20px, 0);
+    transform: translate3d(0, -0.5rem, 0);
     &.has-transitioned--in {
         opacity: 1;
         transform: translate3d(0, 0, 0);

--- a/templates/docs/examples/patterns/accordion/_script.js
+++ b/templates/docs/examples/patterns/accordion/_script.js
@@ -4,7 +4,7 @@
   @param {HTMLElement} element The tab that acts as the handles.
   @param {Boolean} show Whether to show or hide the accordion panel.
 */
-function toggleExpanded(element, show) {
+function handleToggleExpanded(element, show) {
   var target = document.getElementById(element.getAttribute('aria-controls'));
 
   if (target) {
@@ -12,6 +12,29 @@ function toggleExpanded(element, show) {
     target.setAttribute('aria-hidden', !show);
   }
 }
+
+const withTransition = (toggleFunc) => {
+  document.querySelectorAll('.p-accordion__panel').forEach((el) => {
+    el.getAttribute('aria-hidden') === 'false' && el.classList.add('has-transitioned--in');
+  });
+  return (element, show) => {
+    var target = document.getElementById(element.getAttribute('aria-controls'));
+    const handleToggle = () => toggleFunc(element, show);
+    if (show) {
+      handleToggle();
+      if (!target.className.includes('has-transitioned--in')) {
+        requestAnimationFrame(() => target.classList.add('has-transitioned--in'));
+      }
+    } else {
+      if (target.className.includes('has-transitioned--in')) {
+        target.classList.remove('has-transitioned--in');
+        handleToggle();
+      }
+    }
+  };
+};
+
+const toggleExpanded = withTransition(handleToggleExpanded);
 
 /**
   Attaches event listeners for the accordion open and close click events.

--- a/templates/docs/examples/patterns/accordion/_script.js
+++ b/templates/docs/examples/patterns/accordion/_script.js
@@ -4,7 +4,7 @@
   @param {HTMLElement} element The tab that acts as the handles.
   @param {Boolean} show Whether to show or hide the accordion panel.
 */
-function handleToggleExpanded(element, show) {
+function toggleExpanded(element, show) {
   var target = document.getElementById(element.getAttribute('aria-controls'));
 
   if (target) {
@@ -12,29 +12,6 @@ function handleToggleExpanded(element, show) {
     target.setAttribute('aria-hidden', !show);
   }
 }
-
-const withTransition = (toggleFunc) => {
-  document.querySelectorAll('.p-accordion__panel').forEach((el) => {
-    el.getAttribute('aria-hidden') === 'false' && el.classList.add('has-transitioned--in');
-  });
-  return (element, show) => {
-    var target = document.getElementById(element.getAttribute('aria-controls'));
-    const handleToggle = () => toggleFunc(element, show);
-    if (show) {
-      handleToggle();
-      if (!target.className.includes('has-transitioned--in')) {
-        requestAnimationFrame(() => target.classList.add('has-transitioned--in'));
-      }
-    } else {
-      if (target.className.includes('has-transitioned--in')) {
-        target.classList.remove('has-transitioned--in');
-        handleToggle();
-      }
-    }
-  };
-};
-
-const toggleExpanded = withTransition(handleToggleExpanded);
 
 /**
   Attaches event listeners for the accordion open and close click events.


### PR DESCRIPTION
## Done

- add a transition to the accordion pattern

Fixes https://github.com/canonical/vanilla-framework/issues/4539

## QA

- Open https://vanilla-framework-4542.demos.haus//docs/examples/patterns/accordion/default
- Verify the accordion works as before with the addition of having a transition on expand.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![accordion-transition](https://user-images.githubusercontent.com/7452681/185588678-ecdc5af4-23fa-411f-a4da-6ae159bbc9c5.gif)

