### PR TITLE
fix: stepped list heading levels 

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.7.0",
+  "version": "3.7.1",
   "files": [
     "_index.scss",
     "/scss",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.7.1",
+  "version": "3.7.0",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -291,12 +291,6 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
     }
   }
 
-  .p-stepped-list--detailed .p-stepped-list__title + .p-stepped-list__content {
-    @media (min-width: $threshold-6-12-col) {
-      margin-left: 0;
-    }
-  }
-
   @for $i from 6 through 1 {
     // Bullet sizes for each heading level
     $bullet-width: map-get($line-heights, default-text);
@@ -307,6 +301,7 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
       $bullet-width-mobile: map-get($line-heights, h#{$i}-mobile);
     }
 
+    .p-heading--#{$i}.p-stepped-list__title,
     h#{$i}.p-stepped-list__title {
       padding-left: $bullet-width-mobile + $sph--large;
 
@@ -324,12 +319,19 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
       }
     }
 
+    .p-heading--#{$i}.p-stepped-list__title + .p-stepped-list__content,
     h#{$i}.p-stepped-list__title + .p-stepped-list__content {
       margin-left: $bullet-width-mobile + $sph--large;
 
       @media (min-width: $breakpoint-heading-threshold) {
         margin-left: $bullet-width + $sph--large;
       }
+    }
+  }
+
+  .p-stepped-list--detailed .p-stepped-list__title + .p-stepped-list__content {
+    @media (min-width: $threshold-6-12-col) {
+      margin-left: 0;
     }
   }
 }

--- a/scss/standalone/patterns_lists-heading-classes.scss
+++ b/scss/standalone/patterns_lists-heading-classes.scss
@@ -1,0 +1,5 @@
+@import '../vanilla';
+@include vf-base;
+
+@include vf-p-lists;
+@include vf-p-headings;

--- a/templates/docs/examples/patterns/lists/lists-stepped-heading-classes.html
+++ b/templates/docs/examples/patterns/lists/lists-stepped-heading-classes.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% block title %}Lists / Stepped heading classes{% endblock %}
 
-{% block standalone_css %}patterns_lists{% endblock %}
+{% block standalone_css %}patterns_lists-heading-classes{% endblock %}
 
 {% block content %}
 <ol class="p-stepped-list--detailed">

--- a/templates/docs/examples/patterns/lists/lists-stepped-heading-classes.html
+++ b/templates/docs/examples/patterns/lists/lists-stepped-heading-classes.html
@@ -1,0 +1,29 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Lists / Stepped heading classes{% endblock %}
+
+{% block standalone_css %}patterns_lists{% endblock %}
+
+{% block content %}
+<ol class="p-stepped-list--detailed">
+  <li class="p-stepped-list__item">
+    <h3 class="p-stepped-list__title p-heading--2">
+      Log in to JAAS
+    </h3>
+    <p class="p-stepped-list__content">Ensure you have an Ubuntu SSO account before contacting JAAS. Log in to JAAS now.</p>
+  </li>
+
+  <li class="p-stepped-list__item">
+    <h3 class="p-stepped-list__title p-heading--2">
+      Configure a model
+    </h3>
+    <p class="p-stepped-list__content">Applications are contained within models and are installed via charms. Configure your model by pressing the "Start a new model" button.</p>
+  </li>
+
+  <li class="p-stepped-list__item">
+    <h3 class="p-stepped-list__title p-heading--2">
+      Credentials and SSH keys
+    </h3>
+    <p class="p-stepped-list__content">After having selected a cloud, a form will appear for submitting your credentials to JAAS. The below resources are available if you need help with gathering credentials.</p>
+  </li>
+</ol>
+{% endblock %}


### PR DESCRIPTION
## Done

- fix: stepped list heading levels via modifier class (`.p-heading--n`)

Fixes #4544

## QA

- Open [[demo](https://vanilla-framework-4546.demos.haus/docs/examples/patterns/lists/lists-stepped-heading-classes)](https://vanilla-framework-4546.demos.haus/docs/examples/patterns/lists/lists-stepped-heading-classes)
- ensure the styling is correct

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

### Before
added`.p-heading--2` to `h3`:

<img width="570" alt="image" src="https://user-images.githubusercontent.com/7452681/185906924-a95a865b-dce2-4aa5-9eab-f8a616feab6f.png">

changed `h3` to `h2`:

<img width="570" alt="image" src="https://user-images.githubusercontent.com/7452681/185907048-5eabb384-b984-4069-9289-8d6eed439c0a.png">


### After
after either adding`.p-heading--2` to `h3` or changing `h3` to `h2`
<img width="570" alt="image" src="https://user-images.githubusercontent.com/7452681/185907048-5eabb384-b984-4069-9289-8d6eed439c0a.png">


