### PR TITLE
Update accordion vf-transition syntax

### DIFF
--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -64,13 +64,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
   // Navigation panel/drawer
   // -------------------------
   .l-navigation {
-    @include vf-transition(
-      $property: (
-        transform,
-        box-shadow,
-      ),
-      $duration: fast
-    );
+    @include vf-transition($property: #{transform, box-shadow}, $duration: fast);
 
     bottom: 0;
     box-shadow: $panel-drop-shadow;
@@ -117,13 +111,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
     }
 
     .l-navigation {
-      @include vf-transition(
-        $property: (
-          width,
-          box-shadow,
-        ),
-        $duration: fast
-      );
+      @include vf-transition($property: #{width, box-shadow}, $duration: fast);
 
       box-shadow: $panel-drop-shadow-transparent;
       overflow: hidden;
@@ -246,13 +234,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
   }
 
   .l-aside {
-    @include vf-transition(
-      $property: (
-        transform,
-        box-shadow,
-      ),
-      $duration: snap
-    );
+    @include vf-transition($property: #{transform, box-shadow}, $duration: snap);
 
     box-shadow: $panel-drop-shadow;
     grid-area: main;

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -48,7 +48,7 @@
       &:hover {
         background-color: $colors--light-theme--background-hover;
       }
-      @include vf-animation(#{background-color, border-color});
+      @include vf-transition(#{background-color, border-color});
     }
 
     &[aria-expanded='false'] {
@@ -56,7 +56,7 @@
         transform: rotate(-90deg);
       }
 
-      @include vf-animation(#{background-color, border-color});
+      @include vf-transition(#{background-color, border-color});
     }
   }
 
@@ -92,7 +92,7 @@
     overflow: auto; // include child margins into its height
     padding-left: $sph--large + $icon-size + $sph--large * 2;
 
-    @include vf-animation('transform, opacity', fast);
+    @include vf-transition(#{transform, opacity}, fast);
     // Hides panel content
     &[aria-hidden='true'] {
       height: 0;

--- a/scss/_settings_animations.scss
+++ b/scss/_settings_animations.scss
@@ -13,8 +13,11 @@ $animation-easing: (
 );
 
 @mixin vf-transition($property: all, $duration: brisk, $easing: out) {
+  @if (type-of($property) != string) {
+    @error "vf-transition $property must be a string";
+  }
   transition-duration: map-get($animation-duration, $duration);
-  transition-property: $property;
+  transition-property: unquote($property);
   transition-timing-function: map-get($animation-easing, $easing);
 }
 


### PR DESCRIPTION
## Done

- Update accordion to use the new `vf-transition` syntax
- Make vf-transition require a string
- Automatically escape the property string

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
