### PR TITLE
Update accordion docs to not imply navigation

### DIFF
--- a/cypress/e2e/patterns/accordion.cy.js
+++ b/cypress/e2e/patterns/accordion.cy.js
@@ -4,12 +4,12 @@ describe('accordion', () => {
   });
   it('opens and closes a single list item on click', () => {
     cy.findByRole('list').should('be.visible');
-    cy.findByRole('region', {name: /Networking/}).should('not.exist');
-    cy.findByRole('button', {name: /Networking/}).click();
-    cy.findByRole('region', {name: /Networking/}).should('exist');
+    cy.findByRole('region', {name: /What MAAS offers/}).should('not.exist');
+    cy.findByRole('button', {name: /What MAAS offers/}).click();
+    cy.findByRole('region', {name: /What MAAS offers/}).should('exist');
     cy.findAllByRole('region').should('have.length', 1);
-    cy.findByRole('button', {name: /Networking/}).click();
-    cy.findByRole('region', {name: /Networking/}).should('not.exist');
+    cy.findByRole('button', {name: /What MAAS offers/}).click();
+    cy.findByRole('region', {name: /What MAAS offers/}).should('not.exist');
     cy.findAllByRole('region').should('have.length', 0);
   });
 });

--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -90,7 +90,7 @@
   .p-accordion__panel {
     margin: 0;
     overflow: auto; // include child margins into its height
-    padding-left: $sph--large + $icon-size + $sph--large * 2;
+    padding-left: $icon-size + $sph--large * 2;
 
     @include vf-animation('transform, opacity', fast);
     // Hides panel content

--- a/templates/docs/examples/patterns/accordion/default.html
+++ b/templates/docs/examples/patterns/accordion/default.html
@@ -8,37 +8,26 @@
   <ul class="p-accordion__list">
     <li class="p-accordion__group">
       <div role="heading" aria-level="3" class="p-accordion__heading">
-        <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="true">Advanced topics</button>
+        <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="true">What is MAAS?</button>
       </div>
       <section class="p-accordion__panel" id="tab1-section" aria-hidden="false" aria-labelledby="tab1">
-        <p>Charm bundles</p>
-        <p>Machine authentication</p>
-        <p>Migrating models</p>
-        <p>Using storage</p>
-        <p>Working with actions</p>
-        <p>Working with resources</p>
-        <p>Cloud image metadata</p>
-        <p>Tools</p>
+        <p>MAAS expands to “Metal As A Service” – it converts bare-metal servers into cloud instances of virtual machines. There is no need to manage individual units. You can quickly provision or destroy machines, as if they were instances hosted in a public cloud like Amazon AWS, Google GCE, or Microsoft Azure.</p>
       </section>
     </li>
     <li class="p-accordion__group">
       <div role="heading" aria-level="3" class="p-accordion__heading">
-        <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="false">Networking</button>
+        <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="false">What MAAS offers</button>
       </div>
       <section class="p-accordion__panel" id="tab2-section" aria-hidden="true" aria-labelledby="tab2">
-        <p>Working offline</p>
-        <p>Fan container networking</p>
-        <p>Network spaces</p>
+        <p>MAAS can manage a large number of physical machines by merging them into user-defined resource pools. MAAS automatically provisions participating machines and makes them available for use. You can return unused machines to the assigned pool at any time.</p>
       </section>
     </li>
     <li class="p-accordion__group">
       <div role="heading" aria-level="3" class="p-accordion__heading">
-        <button type="button" class="p-accordion__tab" id="tab3" aria-controls="tab3-section" aria-expanded="false">Miscellaneous</button>
+        <button type="button" class="p-accordion__tab" id="tab3" aria-controls="tab3-section" aria-expanded="false">How MAAS works</button>
       </div>
       <section class="p-accordion__panel" id="tab3-section" aria-hidden="true" aria-labelledby="tab3">
-        <p>Juju GUI</p>
-        <p>CentOS support</p>
-        <p>Collecting Juju metrics</p>
+        <p>When you add a new machine to MAAS, or elect to add a machine that MAAS has enlisted, MAAS commissions it for service and adds it to the pool. At that point, the machine is ready for use. MAAS keeps things simple, marking machines as “New,” “Commissioning,” “Ready,” and so on.</p>
       </section>
     </li>
   </ul>

--- a/templates/docs/examples/patterns/accordion/headings.html
+++ b/templates/docs/examples/patterns/accordion/headings.html
@@ -8,52 +8,34 @@
   <ul class="p-accordion__list">
     <li class="p-accordion__group">
       <h2 class="p-accordion__heading">
-        <button type="button" class="p-accordion__tab" id="tab0" aria-controls="tab0-section" aria-expanded="true">Basic topics</button>
+        <button type="button" class="p-accordion__tab" id="tab0" aria-controls="tab0-section" aria-expanded="true">What is MAAS?</button>
       </h2>
       <section class="p-accordion__panel" id="tab0-section" aria-hidden="false" aria-labelledby="tab0">
-        <p>Charm bundles</p>
-        <p>Machine authentication</p>
-        <p>Migrating models</p>
-        <p>Using storage</p>
-        <p>Working with actions</p>
-        <p>Working with resources</p>
-        <p>Cloud image metadata</p>
-        <p>Tools</p>
+        <p>MAAS expands to “Metal As A Service” – it converts bare-metal servers into cloud instances of virtual machines. There is no need to manage individual units. You can quickly provision or destroy machines, as if they were instances hosted in a public cloud like Amazon AWS, Google GCE, or Microsoft Azure.</p>
       </section>
     </li>
     <li class="p-accordion__group">
       <h3 class="p-accordion__heading">
-        <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="false">Advanced topics</button>
+        <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="false">What MAAS offers</button>
       </h3>
       <section class="p-accordion__panel" id="tab1-section" aria-hidden="true" aria-labelledby="tab1">
-        <p>Charm bundles</p>
-        <p>Machine authentication</p>
-        <p>Migrating models</p>
-        <p>Using storage</p>
-        <p>Working with actions</p>
-        <p>Working with resources</p>
-        <p>Cloud image metadata</p>
-        <p>Tools</p>
+        <p>MAAS can manage a large number of physical machines by merging them into user-defined resource pools. MAAS automatically provisions participating machines and makes them available for use. You can return unused machines to the assigned pool at any time.</p>
       </section>
     </li>
     <li class="p-accordion__group">
       <h4 class="p-accordion__heading">
-        <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="false">Networking</button>
+        <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="false">How MAAS works</button>
       </h4>
       <section class="p-accordion__panel" id="tab2-section" aria-hidden="true" aria-labelledby="tab2">
-        <p>Working offline</p>
-        <p>Fan container networking</p>
-        <p>Network spaces</p>
+        <p>When you add a new machine to MAAS, or elect to add a machine that MAAS has enlisted, MAAS commissions it for service and adds it to the pool. At that point, the machine is ready for use. MAAS keeps things simple, marking machines as “New,” “Commissioning,” “Ready,” and so on.</p>
       </section>
     </li>
     <li class="p-accordion__group">
       <h5 class="p-accordion__heading">
-        <button type="button" class="p-accordion__tab" id="tab3" aria-controls="tab3-section" aria-expanded="false">Miscellaneous</button>
+        <button type="button" class="p-accordion__tab" id="tab3" aria-controls="tab3-section" aria-expanded="false">Colocation of key components</button>
       </h5>
       <section class="p-accordion__panel" id="tab3-section" aria-hidden="true" aria-labelledby="tab3">
-        <p>Juju GUI</p>
-        <p>CentOS support</p>
-        <p>Collecting Juju metrics</p>
+        <p>MAAS relies on two key components: the region controller and the rack controller. The region controller handles operator requests; the rack controller provides high-bandwidth services to multiple racks.</p>
       </section>
     </li>
   </ul>


### PR DESCRIPTION
## Done

- Update accordion docs to not imply navigation

Fixes #4547

## QA

- Open https://vanilla-framework-4549.demos.haus/docs/patterns/accordion

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots
![image](https://user-images.githubusercontent.com/7452681/186113817-05fc0b51-d4c5-4ec9-8845-2e3b733564e8.png)
