### PR TITLE
Fix .u-off-screen utility adding white line on Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.7.0",
+  "version": "3.7.1",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_utilities_off-screen.scss
+++ b/scss/_utilities_off-screen.scss
@@ -3,6 +3,7 @@
 // Positions element out of flow & off screen for screen readers
 @mixin vf-u-off-screen {
   .u-off-screen {
+    height: 0 !important;
     left: -10000px !important;
     overflow: hidden !important;
     position: absolute !important;

--- a/scss/_utilities_off-screen.scss
+++ b/scss/_utilities_off-screen.scss
@@ -3,7 +3,6 @@
 // Positions element out of flow & off screen for screen readers
 @mixin vf-u-off-screen {
   .u-off-screen {
-    height: 1px !important;
     left: -10000px !important;
     overflow: hidden !important;
     position: absolute !important;


### PR DESCRIPTION
## Done

- fix u-off-screen utility class

Fixes https://github.com/canonical/vanilla-framework/issues/4535

## QA

- Open [maas-ui demo with vanilla build based on this PR](https://maas-ui-4364.demos.haus/ ) https://github.com/canonical/maas-ui/pull/4364/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R69
- login
- verify no white line is shown when scrolling to the very bottom in Firefox

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
