### PR TITLE
New nav logo padding does not align with content #4530

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -191,11 +191,8 @@ $spv-navigation-logo: 0.3125rem;
     padding-right: 0;
 
     @media (min-width: $threshold-4-6-col) {
+      padding-left: map-get($grid-margin-widths, default);
       padding-right: 0;
-    }
-
-    @media (min-width: $breakpoint-navigation-threshold) {
-      padding-left: map-get($grid-margin-widths, small);
     }
   }
 


### PR DESCRIPTION
## Done

New nav logo padding does not align with content #4530

Fixes https://github.com/canonical/vanilla-framework/issues/4530

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

Added col-12 with a black background to the examples below to demonstrate correct alignment

![image](https://user-images.githubusercontent.com/7452681/186639446-14fbda7c-0c0e-4100-b4fc-251e0fc47ba6.png)
![image](https://user-images.githubusercontent.com/7452681/186639469-916171dc-1985-4aac-ad0c-6740b8c03ddd.png)![image](https://user-images.githubusercontent.com/7452681/186639491-d4e6baa8-dc52-4020-8089-3bdb5ce9ea96.png)