### PR TITLE
Change default breakpoint for navigation to large

### DIFF
--- a/scss/_settings_breakpoints.scss
+++ b/scss/_settings_breakpoints.scss
@@ -2,6 +2,6 @@
 $breakpoint-x-small: 460px !default;
 $breakpoint-small: 620px !default;
 $breakpoint-large: 1036px !default;
-$breakpoint-navigation-threshold: $breakpoint-small !default;
+$breakpoint-navigation-threshold: $breakpoint-large !default;
 $breakpoint-heading-threshold: $breakpoint-large !default;
 $breakpoint-x-large: 1681px !default; // exclude most laptops

--- a/templates/docs/migration-guide-to-v3.md
+++ b/templates/docs/migration-guide-to-v3.md
@@ -134,7 +134,7 @@ Additionally some components that require more granular responsiveness use `$bre
 
 The `$breakpoint-medium` variable has been removed from Vanilla. All media queries in components and utilities that used this value have been updated to either `$breakpoint-large` or `$breakpoint-small` (whichever was more relevant). If you use `$breakpoint-medium` in your project it should be replaced with `$breakpoint-large` or `$breakpoint-small`.
 
-The default value of `$breakpoint-navigation-threshold` was previously set to `$breakpoint-medium` and is now `$breakpoint-small`. This value should be overridden in project code to adjust the threshold at which navigation switches to dropdown, based on the number of navigation items.
+The default value of `$breakpoint-navigation-threshold` was previously set to `$breakpoint-medium` and is now, since Vanilla 3.8, `$breakpoint-large` (it used to be `$breakpoint-small` in Vanilla 3.0 - 3.7.1). This value should be overridden in project code to adjust the threshold at which navigation switches to dropdown, based on the number of navigation items.
 
 ### Using min-width and max-width media queries
 

--- a/templates/docs/settings/breakpoint-settings.md
+++ b/templates/docs/settings/breakpoint-settings.md
@@ -16,7 +16,7 @@ Vanilla uses three main breakpoints for screen sizes, below you can see the sett
 | `$breakpoint-small`                | `620px`             | Mobile or tablet  |
 | `$breakpoint-large`                | `1036px`            | Desktop           |
 | `$breakpoint-x-large`              | `1681px`            | Large desktop     |
-| `$breakpoint-navigation-threshold` | `$breakpoint-small` | Mobile or tablet  |
+| `$breakpoint-navigation-threshold` | `$breakpoint-large` | Desktop           |
 | `$breakpoint-heading-threshold`    | `$breakpoint-large` | Desktop           |
 
 <br>


### PR DESCRIPTION
Signed-off-by: David Edler <david.edler@canonical.com>

## Done

Change default breakpoint for navigation from small to large

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
  - **Note**: version was updated to 3.8.0 before, which is not yet released.
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
