### PR TITLE
Fix navigation: close open dropdown on click of toggle item.

### DIFF
--- a/templates/docs/examples/patterns/navigation/_script.js
+++ b/templates/docs/examples/patterns/navigation/_script.js
@@ -37,8 +37,9 @@ function initNavDropdowns(containerClass) {
     toggle.addEventListener('click', function (e) {
       e.preventDefault();
 
+      const shouldOpen = !toggle.parentNode.classList.contains('is-active');
       closeAllDropdowns(toggles);
-      toggleDropdown(toggle, true);
+      toggleDropdown(toggle, shouldOpen);
     });
   });
 }


### PR DESCRIPTION

Signed-off-by: David Edler <david.edler@canonical.com>

## Done

Fix navigation: An open dropdown should be closed on click of toggle item.
Dropdown would always stay open before, no matter how often you click on the toggle.