### PR TITLE
Fix slider input height

### DIFF
--- a/scss/_patterns_slider.scss
+++ b/scss/_patterns_slider.scss
@@ -8,7 +8,6 @@
   }
 
   .p-slider__input {
-    height: 2.625rem;
     margin: 0 0 0 $sp-medium;
     min-width: 5rem;
     text-align: center;

--- a/templates/docs/examples/patterns/slider/slider-input.html
+++ b/templates/docs/examples/patterns/slider/slider-input.html
@@ -15,7 +15,7 @@
     id="slider3"
     aria-label="Example slider, range 0 to 100">
   <input class="p-slider__input"
-    type="number"
+    type="text"
     maxlength="3"
     id="slider3-input"
     tabindex="0">
@@ -31,7 +31,7 @@
     disabled
     aria-label="Example of a disabled slider, range 0 to 100">
   <input class="p-slider__input"
-    type="number"
+    type="text"
     maxlength="3"
     id="slider4-input"
     disabled

--- a/templates/docs/examples/patterns/slider/slider-input.html
+++ b/templates/docs/examples/patterns/slider/slider-input.html
@@ -15,10 +15,10 @@
     id="slider3"
     aria-label="Example slider, range 0 to 100">
   <input class="p-slider__input"
-    type="text"
+    type="number"
     maxlength="3"
     id="slider3-input"
-  tabindex="0">
+    tabindex="0">
 </div>
 <div class="p-slider__wrapper">
   <input
@@ -31,7 +31,7 @@
     disabled
     aria-label="Example of a disabled slider, range 0 to 100">
   <input class="p-slider__input"
-    type="text"
+    type="number"
     maxlength="3"
     id="slider4-input"
     disabled


### PR DESCRIPTION
## Done

- Remove slider input height to make it the same height as standard inputs.

Fixes: #3163.

## QA

- Open the [input demo](https://vanilla-framework-4575.demos.haus/docs/examples/base/forms/input)
- inspect the input and take note of the height.
- Open [slider demo](https://vanilla-framework-4575.demos.haus/docs/examples/patterns/slider/slider-input)
- Inspect the number input and check that it is the same height as the previous input.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

<img width="904" alt="Screen Shot 2022-10-11 at 12 56 53 pm" src="https://user-images.githubusercontent.com/361637/194980252-504fb562-4249-4032-912d-a93376d7d9cd.png">

