### PR TITLE
Stepped counter size

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -17,12 +17,15 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
 
     &::before {
       align-self: start;
-      background-color: $color-mid-x-light;
+      background-color: $color-x-light;
+      border: 1px solid $color-x-dark;
       border-radius: 100%;
       content: counter(li);
       counter-increment: li;
       direction: rtl;
       display: block;
+      font-size: map-get($base-font-sizes, base);
+      font-weight: $font-weight-bold;
       left: 0;
       position: absolute;
       text-align: center;
@@ -276,9 +279,13 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
     &::before {
       margin-right: $sph--large;
       width: $bullet-width-mobile;
+      // Need to account for the 1px border:
+      line-height: calc(#{$bullet-width-mobile} - 2px);
 
       @media (min-width: $breakpoint-heading-threshold) {
         width: $bullet-width;
+        // Need to account for the 1px border:
+        line-height: calc(#{$bullet-width} - 2px);
       }
     }
   }
@@ -312,9 +319,13 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
       &::before {
         margin-right: $sph--large;
         width: $bullet-width-mobile;
+        // Need to account for the 1px border:
+        line-height: calc(#{$bullet-width-mobile} - 2px);
 
         @media (min-width: $breakpoint-heading-threshold) {
           width: $bullet-width;
+          // Need to account for the 1px border:
+          line-height: calc(#{$bullet-width} - 2px);
         }
       }
     }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -25,7 +25,7 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
       direction: rtl;
       display: block;
       font-size: map-get($base-font-sizes, base);
-      font-weight: $font-weight-bold;
+      font-weight: $font-weight-regular-text;
       left: 0;
       position: absolute;
       text-align: center;
@@ -302,10 +302,16 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
     // Bullet sizes for each heading level
     $bullet-width: map-get($line-heights, default-text);
     $bullet-width-mobile: map-get($line-heights, default-text);
+    // h6 line height is the same as the bullet width so no need to apply any margin:
+    $bullet-margin: 0;
+    $bullet-margin-mobile: 0;
 
     @if $i < 5 {
-      $bullet-width: map-get($line-heights, h#{$i});
-      $bullet-width-mobile: map-get($line-heights, h#{$i}-mobile);
+      // To align the bullet with the title we need to use half
+      // the height difference between the bullet and the title and then add the
+      // nudge to position it with the lower case text.
+      $bullet-margin: ((map-get($line-heights, h#{$i}) - $bullet-width) / 2) + map-get($nudges, h#{$i});
+      $bullet-margin-mobile: ((map-get($line-heights, h#{$i}-mobile) - $bullet-width-mobile) / 2) + map-get($nudges, h#{$i});
     }
 
     .p-heading--#{$i}.p-stepped-list__title,
@@ -320,11 +326,13 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
         // Need to account for the 1px border:
         line-height: calc(#{$bullet-width-mobile} - 2px);
         margin-right: $sph--large;
+        margin-top: $bullet-margin-mobile;
         width: $bullet-width-mobile;
 
         @media (min-width: $breakpoint-heading-threshold) {
           // Need to account for the 1px border:
           line-height: calc(#{$bullet-width} - 2px);
+          margin-top: $bullet-margin;
           width: $bullet-width;
         }
       }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -278,14 +278,14 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
 
     &::before {
       margin-right: $sph--large;
-      width: $bullet-width-mobile;
       // Need to account for the 1px border:
       line-height: calc(#{$bullet-width-mobile} - 2px);
+      width: $bullet-width-mobile;
 
       @media (min-width: $breakpoint-heading-threshold) {
-        width: $bullet-width;
         // Need to account for the 1px border:
         line-height: calc(#{$bullet-width} - 2px);
+        width: $bullet-width;
       }
     }
   }
@@ -318,14 +318,14 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
 
       &::before {
         margin-right: $sph--large;
-        width: $bullet-width-mobile;
         // Need to account for the 1px border:
         line-height: calc(#{$bullet-width-mobile} - 2px);
+        width: $bullet-width-mobile;
 
         @media (min-width: $breakpoint-heading-threshold) {
-          width: $bullet-width;
           // Need to account for the 1px border:
           line-height: calc(#{$bullet-width} - 2px);
+          width: $bullet-width;
         }
       }
     }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -277,9 +277,9 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
     }
 
     &::before {
-      margin-right: $sph--large;
       // Need to account for the 1px border:
       line-height: calc(#{$bullet-width-mobile} - 2px);
+      margin-right: $sph--large;
       width: $bullet-width-mobile;
 
       @media (min-width: $breakpoint-heading-threshold) {
@@ -317,9 +317,9 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
       }
 
       &::before {
-        margin-right: $sph--large;
         // Need to account for the 1px border:
         line-height: calc(#{$bullet-width-mobile} - 2px);
+        margin-right: $sph--large;
         width: $bullet-width-mobile;
 
         @media (min-width: $breakpoint-heading-threshold) {


### PR DESCRIPTION
## Done

- Update stepped lists to use a fixed font size for the counters.

Fixes #4561.

## QA

- Open all the list examples:
  - https://vanilla-framework-4584.demos.haus/docs/examples/patterns/lists/lists-stepped
  - https://vanilla-framework-4584.demos.haus/docs/examples/patterns/lists/lists-stepped-without-headings
  - https://vanilla-framework-4584.demos.haus/docs/examples/patterns/lists/lists-stepped-heading-classes
  - https://vanilla-framework-4584.demos.haus/docs/examples/patterns/lists/lists-stepped-detailed
- Check that the font size is always the same.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

<img width="1382" alt="Screen Shot 2022-10-13 at 2 18 58 pm" src="https://user-images.githubusercontent.com/361637/195491480-b6f95961-e8df-4f4d-b34e-1b897dda84f5.png">

