### PR TITLE
Update hacking to dotrun

### DIFF
--- a/guides/hacking.md
+++ b/guides/hacking.md
@@ -14,11 +14,12 @@
 
 ## Running the project
 
-### Via dotrun
-
-The simplest way to run the Vanilla framework on Linux is with the [dotrun snap](https://github.com/canonical/dotrun/), and using the `dotrun` command to build the project:
+The simplest way to run the Vanilla framework on all operating systems is by [installing Docker](https://docs.docker.com/engine/installation/) (Linux users may need to [add your user to the `docker` group](https://docs.docker.com/engine/installation/linux/linux-postinstall/)) and [dotrun](https://github.com/canonical/dotrun/), and using the `dotrun` command to build or serve the project:
 
 ```bash
+# Build CSS into the ./build/ directory:
+dotrun build
+
 # Build CSS into the ./build/ directory,
 # and start the server:
 dotrun
@@ -26,25 +27,12 @@ dotrun
 # Dynamically watch for changes to the
 # Sass files and build automatically:
 dotrun watch
+
+# See a full list of commands:
+dotrun exec yarn run --non-interactive
 ```
 
-When writing SCSS, it's useful to run both commands in separate terminals so changes are quickly built and ready for the browser to pick up on page reload.
-
-### Via Docker
-
-It can also be run on other operating systems by first [installing Docker](https://docs.docker.com/engine/installation/) (Linux users may need to [add your user to the `docker` group](https://docs.docker.com/engine/installation/linux/linux-postinstall/)) and then [installing dotrun](https://github.com/canonical/dotrun#installation):
-
-```bash
-# Build CSS into the ./build/ directory:
-dotrun build
-
-# Start the server:
-dotrun serve
-
-# Dynamically watch for changes to the
-# Sass files and build automatically:
-dotrun watch
-```
+When writing SCSS, it's useful to run `dotrun` and `dotrun watch` in separate terminals so changes are quickly built and ready for the browser to pick up on page reload.
 
 If you want to speed up the build or watch scripts you can run the project without including the standalone examples, using `dotrun build:essential` or `dotrun watch:essential`.
 

--- a/guides/hacking.md
+++ b/guides/hacking.md
@@ -32,21 +32,21 @@ When writing SCSS, it's useful to run both commands in separate terminals so cha
 
 ### Via Docker
 
-It can also be run on other operating systems by first [installing Docker](https://docs.docker.com/engine/installation/) (Linux users may need to [add your user to the `docker` group](https://docs.docker.com/engine/installation/linux/linux-postinstall/)), and then using the `./run` script:
+It can also be run on other operating systems by first [installing Docker](https://docs.docker.com/engine/installation/) (Linux users may need to [add your user to the `docker` group](https://docs.docker.com/engine/installation/linux/linux-postinstall/)) and then [installing dotrun](https://github.com/canonical/dotrun#installation):
 
 ```bash
 # Build CSS into the ./build/ directory:
-./run build
+dotrun build
 
 # Start the server:
-./run serve
+dotrun serve
 
 # Dynamically watch for changes to the
 # Sass files and build automatically:
-./run watch
+dotrun watch
 ```
 
-If you want to speed up the build or watch scripts you can run the project without including the standalone examples, using `./run build:essential` or `./run watch:essential`.
+If you want to speed up the build or watch scripts you can run the project without including the standalone examples, using `dotrun build:essential` or `dotrun watch:essential`.
 
 ## Viewing documentation and examples
 

--- a/guides/release-process.md
+++ b/guides/release-process.md
@@ -21,9 +21,9 @@
 ## Releasing
 
 - Pull locally latest version from the main branch
-- `./run build`
+- `dotrun build`
   - make sure everything builds without any errors
-- `./run test`
+- `dotrun test`
   - make sure all test pass
 
 ### Releasing on GitHub
@@ -47,7 +47,7 @@ This should happen automatically after publishing the release on GH (thanks to [
 
 In case that fails, here are manual steps to release to assets server:
 
-- `./run build`
+- `dotrun build`
 - `upload-assets --url-path vanilla-framework-version-X.X.X.min.css build/css/build.css`
 
 ## Deploying vanillaframework.io

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -115,7 +115,7 @@
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
           <svg width="60" height="60" class="p-heading-icon__img" viewBox="0 0 12 16" version="1.1" aria-hidden="true">
-            <title>GitHub pull requist icon</title>
+            <title>GitHub pull request icon</title>
             <path fill-rule="evenodd"
               d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z">
             </path>
@@ -123,8 +123,8 @@
           <h3 class="p-heading-icon__title">Running tests locally</h3>
         </div>
       </div>
-      <p>The simplest way to run Vanilla framework is to first <a href="https://docs.docker.com/install/">install Docker</a>, and then use the <code>./run</code> script to <a
-          href="https://github.com/canonical/vanilla-framework#vanilla-local-development">build the site</a>. Before proposing a pull request, ensure that the tests pass on your local fork. To kick off the tests for your project, in the terminal <code>./run test</code>.</p>
+      <p>The simplest way to run Vanilla framework is to first <a href="https://docs.docker.com/install/">install Docker</a> and <a href="https://github.com/canonical/dotrun#installation">dotrun</a>, and then use the <code>dotrun</code> script to <a
+          href="https://github.com/canonical/vanilla-framework#vanilla-local-development">build the site</a>. Before proposing a pull request, ensure that the tests pass on your local fork. To kick off the tests for your project, in the terminal <code>dotrun test</code>.</p>
     </div>
     <div class="col-6">
       <div class="p-heading-icon">


### PR DESCRIPTION
## Done

- Replace ./run instructions with dotrun

Fixes: #4576.

## QA

n/a

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


