### PR TITLE
Add example of grouped rows

### DIFF
--- a/templates/docs/examples/patterns/tables/table-grouped-rows.html
+++ b/templates/docs/examples/patterns/tables/table-grouped-rows.html
@@ -1,0 +1,47 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Table / Grouped rows{% endblock %}
+
+{% block content %}
+<table class="p-table--mobile-card" aria-label="Table of CPU compatibility matrix for Ubuntu">
+  <thead>
+    <tr>
+      <th>Vendor</th>
+      <th>CPU family</th>
+      <th>Code name</th>
+      <th class="u-align--right">Initial support in Ubuntu LTS</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td data-heading="Vendor" rowspan="3">AMD</td>
+      <td data-heading="CPU family">EPYC 7xx3</td>
+      <td data-heading="Code name">Milan (Zen 3)</td>
+      <td data-heading="Initial support in Ubuntu LTS" class="u-align--right">18.04.5</td>
+    </tr>
+    <tr>
+      <td data-heading="Vendor" class="u-hide--large">AMD</td>
+      <td data-heading="CPU family">EPYC 7xx2</td>
+      <td data-heading="Code name">Rome (Zen 2)</td>
+      <td data-heading="Initial support in Ubuntu LTS" class="u-align--right">16.04.5</td>
+    </tr>
+    <tr>
+      <td data-heading="Vendor" class="u-hide--large">AMD</td>
+      <td data-heading="CPU family">EPYC 7xx1</td>
+      <td data-heading="Code name">Naples (Zen1)</td>
+      <td data-heading="Initial support in Ubuntu LTS" class="u-align--right">16.04.5</td>
+    </tr>
+    <tr>
+      <td data-heading="Vendor" rowspan="2">Intel</td>
+      <td data-heading="CPU family">Xeon</td>
+      <td data-heading="Code name">Ice Lake (SP)</td>
+      <td data-heading="Initial support in Ubuntu LTS" class="u-align--right">18.04</td>
+    </tr>
+    <tr>
+      <td data-heading="Vendor" class="u-hide--large">Intel</td>
+      <td data-heading="CPU family">Xeon</td>
+      <td data-heading="Code name">Cooper Lake</td>
+      <td data-heading="Initial support in Ubuntu LTS" class="u-align--right">18.04</td>
+    </tr>
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Done

- Add example of grouping table rows using existing classes.

Fixes: #4100.

## QA

- Open [/docs/examples/patterns/tables/table-grouped-rows](https://vanilla-framework-4588.demos.haus/docs/examples/patterns/tables/table-grouped-rows) (you might need to do this locally as the demo doesn't seem to be working).
- Check that the AMD and Intel columns span multiple rows (the borders get inset for the subsequent rows).
- Resize to medium and small screens and check that the vendor is displayed on all cards.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

<img width="1223" alt="Screen Shot 2022-10-18 at 10 41 05 am" src="https://user-images.githubusercontent.com/361637/196303779-c4e39470-2704-4868-a73a-b00684cca909.png">
<img width="870" alt="Screen Shot 2022-10-18 at 10 41 24 am" src="https://user-images.githubusercontent.com/361637/196303789-e6f5f04b-b624-4031-9aed-2eadce7b1374.png">
<img width="368" alt="Screen Shot 2022-10-18 at 10 41 45 am" src="https://user-images.githubusercontent.com/361637/196303795-1ad90d03-8de8-433a-ab7c-5ee278a142ba.png">

