### PR TITLE
Fix u-hide--large on table cells on medium screens.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.8.0",
+  "version": "3.8.1",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_utilities_hide.scss
+++ b/scss/_utilities_hide.scss
@@ -57,7 +57,7 @@
     }
 
     &--large {
-      @media (min-width: $breakpoint-small) {
+      @media (min-width: $breakpoint-large) {
         @include vf-hide-table-column;
       }
     }


### PR DESCRIPTION
## Done

- Fix u-hide--large hiding tds and ths on medium screens.

Fixes: #4589.

## QA

- Open [the mobile table card](https://vanilla-framework-4590.demos.haus/docs/examples/patterns/tables/table-mobile-card)
- Inspect one of the table cells and add `class="u-hide--large"`.
- With your window at full size the cell should be hidden.
- Resize your window to medium and small sizes and the cell should be visible.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

Large screen:

<img width="1168" alt="Screen Shot 2022-10-17 at 11 23 43 am" src="https://user-images.githubusercontent.com/361637/196066406-302ca2ae-92dd-4169-b5cb-7426370080a3.png">

Medium screen:

<img width="233" alt="Screen Shot 2022-10-17 at 11 23 54 am" src="https://user-images.githubusercontent.com/361637/196066416-0666ae85-4f1a-4a75-893a-1095fd0f402c.png">

