### PR TITLE
Make password text easier to read when toggled

### DIFF
--- a/scss/_patterns_form-password-toggle.scss
+++ b/scss/_patterns_form-password-toggle.scss
@@ -11,4 +11,14 @@
     display: inline-block;
     margin-right: $sp-xx-small;
   }
+
+  // Override the input text so that it is more easy to read when it
+  // has been toggled to display the text. This expects that the input
+  // immediately follows the .p-form-password-toggle element.
+  .p-form-password-toggle + [type='text'] {
+    &[readonly],
+    &[readonly='readonly'] {
+      color: $color-dark;
+    }
+  }
 }


### PR DESCRIPTION
## Done

- Improve the legibility of readonly passwords that have been displayed via the password toggle component.

Fixes #3975.

## QA

- Open the [password toggle example](https://vanilla-framework-4591.demos.haus/docs/examples/patterns/forms/password-toggle)
- Inspect one of the inputs and add `readonly` to the input element.
- You should see the dots in the password field become light grey.
- Click the show button and the password should be displayed and the text should be the same as the default text colour.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

Hidden:

<img width="869" alt="Screen Shot 2022-10-17 at 1 53 42 pm" src="https://user-images.githubusercontent.com/361637/196079304-2eb104be-9c54-494a-8dfe-cf283e486bd2.png">

Visible:

<img width="870" alt="Screen Shot 2022-10-17 at 1 53 51 pm" src="https://user-images.githubusercontent.com/361637/196079316-06c3262c-1281-4429-adaa-d443fef33721.png">

