### PR TITLE
Override responsive divider orientation for medium screens with col-m…

### DIFF
--- a/scss/_patterns_divider.scss
+++ b/scss/_patterns_divider.scss
@@ -5,21 +5,28 @@
   padding-top: $spv--large;
 
   &:not(:first-child)::before {
+    bottom: auto;
     content: '';
     height: 1px;
     left: 0;
     position: absolute;
     right: 0;
     top: 0;
+    width: auto;
   }
 }
 
 @mixin vertical-dividers() {
+  padding-bottom: 0;
+  padding-top: 0;
+
   &:not(:first-child)::before {
     bottom: 0;
     content: '';
-    left: map-get($grid-gutter-widths, default) * -0.5; // "large" here is not a typo. The grid switches to 12 columns at breakpoint medium. Hence the use of large-screen gutter
+    height: auto;
+    left: map-get($grid-gutter-widths, default) * -0.5;
     position: absolute;
+    right: auto;
     top: 0;
     width: 1px;
   }
@@ -35,18 +42,11 @@
   .p-divider__block {
     position: relative;
 
-    @media (max-width: $breakpoint-small) {
-      @include horizontal-dividers();
-    }
+    @include horizontal-dividers();
 
     // Medium screens will have horizontal dividers unless col-medium-...
     // classes have been applied.
-    @media (min-width: $breakpoint-small) and (max-width: $breakpoint-large - 1) {
-      // When there are no medium col overrides then set the dividers to horizontal
-      &:not([class*='#{$grid-medium-col-prefix}']) {
-        @include horizontal-dividers();
-      }
-
+    @media (min-width: $threshold-4-6-col) {
       // If a col-medium- class has been applied then use vertical dividers.
       &[class*='#{$grid-medium-col-prefix}'] {
         @include vertical-dividers();

--- a/scss/_patterns_divider.scss
+++ b/scss/_patterns_divider.scss
@@ -1,5 +1,30 @@
 @import 'settings';
 
+@mixin horizontal-dividers() {
+  padding-bottom: $spv--large;
+  padding-top: $spv--large;
+
+  &:not(:first-child)::before {
+    content: '';
+    height: 1px;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+}
+
+@mixin vertical-dividers() {
+  &:not(:first-child)::before {
+    bottom: 0;
+    content: '';
+    left: map-get($grid-gutter-widths, default) * -0.5; // "large" here is not a typo. The grid switches to 12 columns at breakpoint medium. Hence the use of large-screen gutter
+    position: absolute;
+    top: 0;
+    width: 1px;
+  }
+}
+
 @mixin vf-p-divider {
   .p-divider {
     @extend %vf-row;
@@ -10,29 +35,26 @@
   .p-divider__block {
     position: relative;
 
-    @media (max-width: $threshold-6-12-col - 1) {
-      padding-bottom: $spv--large;
-      padding-top: $spv--large;
+    @media (max-width: $breakpoint-small) {
+      @include horizontal-dividers();
+    }
 
-      &:not(:first-child)::before {
-        content: '';
-        height: 1px;
-        left: 0;
-        position: absolute;
-        right: 0;
-        top: 0;
+    // Medium screens will have horizontal dividers unless col-medium-...
+    // classes have been applied.
+    @media (min-width: $breakpoint-small) and (max-width: $breakpoint-large - 1) {
+      // When there are no medium col overrides then set the dividers to horizontal
+      &:not([class*='#{$grid-medium-col-prefix}']) {
+        @include horizontal-dividers();
+      }
+
+      // If a col-medium- class has been applied then use vertical dividers.
+      &[class*='#{$grid-medium-col-prefix}'] {
+        @include vertical-dividers();
       }
     }
 
     @media (min-width: $threshold-6-12-col) {
-      &:not(:first-child)::before {
-        bottom: 0;
-        content: '';
-        left: map-get($grid-gutter-widths, default) * -0.5; // "large" here is not a typo. The grid switches to 12 columns at breakpoint medium. Hence the use of large-screen gutter
-        position: absolute;
-        top: 0;
-        width: 1px;
-      }
+      @include vertical-dividers();
     }
   }
 

--- a/templates/docs/examples/patterns/divider/responsive-columns.html
+++ b/templates/docs/examples/patterns/divider/responsive-columns.html
@@ -1,0 +1,21 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Divider / Responsive columns{% endblock %}
+
+{% block standalone_css %}patterns_divider{% endblock %}
+
+{% block content %}
+<div class="row p-divider">
+  <div class="col-4 col-medium-2 p-divider__block">
+    <h2>Lorem ipsum</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit.</p>
+  </div>
+  <div class="col-4 col-medium-2 p-divider__block">
+    <h2>Dolor sit</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit.</p>
+  </div>
+  <div class="col-4 col-medium-2 p-divider__block">
+    <h2>Cumque commodi</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit.</p>
+  </div>
+</div>
+{% endblock %}

--- a/templates/docs/patterns/divider.md
+++ b/templates/docs/patterns/divider.md
@@ -10,7 +10,7 @@ context:
 
 ## Responsive divider
 
-A responsive divider inserts divider lines between sections of content. On small screens (up to `$breakpoint-large`), the divider lines appear horizontally. On screens bigger than `$breakpoint-large`, the divider lines appear vertically, centered in the column gutters. This behaviour can be overriden for medium screens by applying `col-medium-...` to each column which will cause the divider lines to remain vertical for medium and large screens.
+A responsive divider inserts divider lines between sections of content. On small screens (up to `$breakpoint-large`), the divider lines appear horizontally. On screens bigger than `$breakpoint-large`, the divider lines appear vertically, centered in the column gutters. This behaviour can be overridden for medium screens by applying `col-medium-...` to each column which will cause the divider lines to remain vertical for medium and large screens.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/divider/default/" class="js-example">
 View example of lists with a responsive divider

--- a/templates/docs/patterns/divider.md
+++ b/templates/docs/patterns/divider.md
@@ -10,7 +10,7 @@ context:
 
 ## Responsive divider
 
-A responsive divider inserts divider lines between sections of content. On small screens (up to `$breakpoint-large`), the divider lines appear horizontally. On screens bigger than `$breakpoint-large`, the divider lines appear vertically, centered in the column gutters.
+A responsive divider inserts divider lines between sections of content. On small screens (up to `$breakpoint-large`), the divider lines appear horizontally. On screens bigger than `$breakpoint-large`, the divider lines appear vertically, centered in the column gutters. This behaviour can be overriden for medium screens by applying `col-medium-...` to each column which will cause the divider lines to remain vertical for medium and large screens.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/divider/default/" class="js-example">
 View example of lists with a responsive divider


### PR DESCRIPTION
## Done

Override responsive divider orientation for medium screens with col-medium- applied.

Fixes: #4438.

## QA

- Open the default divider [demo](https://vanilla-framework-4594.demos.haus/docs/examples/patterns/divider/default)
- Check that at large screens you see vertical dividers but medium and small screens show horizontal dividers.
- Open the responsive columns [demo](https://vanilla-framework-4594.demos.haus/docs/examples/patterns/divider/responsive-columns)
- Check that at large and medium screens you see vertical dividers but small screens show horizontal dividers.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

These screenshots have `col-medium-2` applied to the columns.

Large:

<img width="1084" alt="Screen Shot 2022-10-19 at 12 31 17 pm" src="https://user-images.githubusercontent.com/361637/196576199-ef54ee39-a68f-4826-9f32-980102397ff4.png">

Medium:

<img width="764" alt="Screen Shot 2022-10-19 at 12 31 29 pm" src="https://user-images.githubusercontent.com/361637/196576225-307d93a1-6cdb-481d-8ebb-811456911364.png">

Small:

<img width="347" alt="Screen Shot 2022-10-19 at 12 31 38 pm" src="https://user-images.githubusercontent.com/361637/196576238-0a709797-c22f-486e-9ffb-68e4b48eb51c.png">

