### PR TITLE
Fix responsive grid bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.8.1",
+  "version": "3.8.2",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_base_grid-definitions.scss
+++ b/scss/_base_grid-definitions.scss
@@ -11,24 +11,6 @@
     display: block;
   }
 
-  %span-full-grid-on-mobile {
-    @media (max-width: $threshold-4-6-col - 1) {
-      grid-column: auto / span $grid-columns-small;
-    }
-  }
-
-  %span-full-grid-on-tablet {
-    @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col - 1) {
-      grid-column: auto / span $grid-columns-medium;
-    }
-  }
-
-  %span-full-grid-on-desktop {
-    @media (min-width: $threshold-6-12-col) {
-      grid-column: auto / span $grid-columns;
-    }
-  }
-
   %fixed-width-container--common-properties {
     @extend %vf-grid-container-padding;
 

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -27,7 +27,7 @@
   }
 
   // mobile grid
-  @media (max-width: $threshold-4-6-col - 1) {
+  @media (max-width: $threshold-4-6-col) {
     @for $i from $grid-columns-small through 1 {
       .#{$grid-small-col-prefix}#{$i} {
         @include vf-grid-column($i);
@@ -38,7 +38,7 @@
   }
 
   // tablet grid
-  @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col - 1) {
+  @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
     @for $i from $grid-columns-medium through 1 {
       .#{$grid-medium-col-prefix}#{$i} {
         @include vf-grid-column($i);
@@ -94,11 +94,11 @@
   @each $label, $breakpoint-min, $breakpoint-max, $col-count in $offsets {
     $query: null;
     @if $breakpoint-min == 0 {
-      $query: '(max-width: #{$breakpoint-max - 1})';
+      $query: '(max-width: #{$breakpoint-max})';
     } @else if $breakpoint-max == -1 {
       $query: '(min-width: #{$breakpoint-min})';
     } @else {
-      $query: '(min-width: #{$breakpoint-min}) and (max-width: #{$breakpoint-max - 1})';
+      $query: '(min-width: #{$breakpoint-min}) and (max-width: #{$breakpoint-max})';
     }
 
     @media #{$query} {
@@ -127,7 +127,7 @@
       position: absolute;
       right: map-get($grid-margin-widths, small);
 
-      @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col - 1) {
+      @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
         left: map-get($grid-margin-widths, default);
         right: map-get($grid-margin-widths, default);
       }

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -27,18 +27,59 @@
   }
 
   // mobile grid
-  @media (max-width: $threshold-4-6-col) {
-    @for $i from $grid-columns-small through 1 {
-      .#{$grid-small-col-prefix}#{$i} {
-        @include vf-grid-column($i);
 
-        width: 100%;
-      }
+  // by default medium and large screen col classes should span full width on mobile (to match block level element behaviour)
+  %span-full-grid-on-mobile {
+    grid-column: auto / span $grid-columns-small;
+  }
+
+  @for $i from 1 through $grid-columns-medium {
+    .#{$grid-medium-col-prefix}#{$i} {
+      @extend %span-full-grid-on-mobile;
+      @extend %display-block;
+    }
+  }
+
+  @for $i from 1 through $grid-columns {
+    .#{$grid-large-col-prefix}#{$i} {
+      @extend %span-full-grid-on-mobile;
+      @extend %display-block;
+    }
+  }
+
+  // col-small-X classes define grid for small screen
+  @for $i from $grid-columns-small through 1 {
+    .#{$grid-small-col-prefix}#{$i} {
+      @extend %display-block;
+      @include vf-grid-column($i);
+
+      width: 100%;
     }
   }
 
   // tablet grid
-  @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
+
+  // on medium/tablet screens, small and large grid class names span full width (to match block level element behaviour)
+  %span-full-grid-on-tablet {
+    @media (min-width: $threshold-4-6-col) {
+      grid-column: auto / span $grid-columns-medium;
+    }
+  }
+
+  @for $i from 1 through $grid-columns-small {
+    .#{$grid-small-col-prefix}#{$i} {
+      @extend %span-full-grid-on-tablet;
+    }
+  }
+
+  @for $i from 1 through $grid-columns {
+    .#{$grid-large-col-prefix}#{$i} {
+      @extend %span-full-grid-on-tablet;
+    }
+  }
+
+  // col-medium-X classes define grid for medium screens
+  @media (min-width: $threshold-4-6-col) {
     @for $i from $grid-columns-medium through 1 {
       .#{$grid-medium-col-prefix}#{$i} {
         @include vf-grid-column($i);
@@ -49,6 +90,27 @@
   }
 
   // desktop grid
+
+  // on desktop screens small and medium grid class names span full width (to match block level element behaviour)
+  %span-full-grid-on-desktop {
+    @media (min-width: $threshold-6-12-col) {
+      grid-column: auto / span $grid-columns;
+    }
+  }
+
+  @for $i from 1 through $grid-columns-small {
+    .#{$grid-small-col-prefix}#{$i} {
+      @extend %span-full-grid-on-desktop;
+    }
+  }
+
+  @for $i from 1 through $grid-columns-medium {
+    .#{$grid-medium-col-prefix}#{$i} {
+      @extend %span-full-grid-on-desktop;
+    }
+  }
+
+  // col-X class names define grid on large/desktop screens
   @media (min-width: $threshold-6-12-col) {
     @for $i from $grid-columns through 1 {
       // set col-* to span respective number of columns on desktop
@@ -56,31 +118,6 @@
         // on smaller screens let them display full width one under another
         @include vf-grid-column($i);
       }
-    }
-  }
-
-  // span full grid on other breakpoints; (to match block level element behaviour)
-  @for $i from 1 through $grid-columns-small {
-    .#{$grid-small-col-prefix}#{$i} {
-      @extend %span-full-grid-on-tablet;
-      @extend %span-full-grid-on-desktop;
-      @extend %display-block;
-    }
-  }
-
-  @for $i from 1 through $grid-columns-medium {
-    .#{$grid-medium-col-prefix}#{$i} {
-      @extend %span-full-grid-on-mobile;
-      @extend %span-full-grid-on-desktop;
-      @extend %display-block;
-    }
-  }
-
-  @for $i from 1 through $grid-columns {
-    .#{$grid-large-col-prefix}#{$i} {
-      @extend %span-full-grid-on-mobile;
-      @extend %span-full-grid-on-tablet;
-      @extend %display-block;
     }
   }
 

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -14,6 +14,26 @@
   }
 }
 
+@mixin vf-grid-column-reordering($label, $col-count, $reset: false) {
+  @for $i from 1 through $col-count {
+    .row [class*='#{$grid-column-prefix}'].#{$grid-column-prefix}start-#{$label}-#{$i} {
+      @if $reset {
+        grid-column-start: initial;
+      } @else {
+        grid-column-start: #{$i};
+      }
+    }
+
+    .#{$grid-column-prefix}order-#{$label}-#{$i} {
+      @if $reset {
+        order: initial;
+      } @else {
+        order: #{$i};
+      }
+    }
+  }
+}
+
 @mixin vf-p-grid {
   // FIXME: this should be removed from framework SCSS
   // (see https://github.com/canonical/vanilla-framework/issues/3199)
@@ -125,28 +145,21 @@
   $offsets: (
     (small, 0, $threshold-4-6-col, $grid-columns-small - 1),
     (medium, $threshold-4-6-col, $threshold-6-12-col, $grid-columns-medium - 1),
-    (large, $threshold-6-12-col, -1, $grid-columns - 1)
+    (large, $threshold-6-12-col, false, $grid-columns - 1)
   );
 
-  @each $label, $breakpoint-min, $breakpoint-max, $col-count in $offsets {
-    $query: null;
+  @each $label, $breakpoint-min, $breakpoint-reset, $col-count in $offsets {
     @if $breakpoint-min == 0 {
-      $query: '(max-width: #{$breakpoint-max})';
-    } @else if $breakpoint-max == -1 {
-      $query: '(min-width: #{$breakpoint-min})';
+      @include vf-grid-column-reordering($label, $col-count);
     } @else {
-      $query: '(min-width: #{$breakpoint-min}) and (max-width: #{$breakpoint-max})';
+      @media (min-width: #{$breakpoint-min}) {
+        @include vf-grid-column-reordering($label, $col-count);
+      }
     }
 
-    @media #{$query} {
-      @for $i from 1 through $col-count {
-        .row [class*='#{$grid-column-prefix}'].#{$grid-column-prefix}start-#{$label}-#{$i} {
-          grid-column-start: #{$i};
-        }
-
-        .#{$grid-column-prefix}order-#{$label}-#{$i} {
-          order: #{$i};
-        }
+    @if $breakpoint-reset {
+      @media (min-width: #{$breakpoint-reset}) {
+        @include vf-grid-column-reordering($label, $col-count, $reset: true);
       }
     }
   }
@@ -164,7 +177,7 @@
       position: absolute;
       right: map-get($grid-margin-widths, small);
 
-      @media (min-width: $threshold-4-6-col) and (max-width: $threshold-6-12-col) {
+      @media (min-width: $threshold-4-6-col) {
         left: map-get($grid-margin-widths, default);
         right: map-get($grid-margin-widths, default);
       }


### PR DESCRIPTION
## Done

- Removed `-  1` from media queries

Fixes  #4592

## QA

- Open [demo](https://vanilla-framework-4597.demos.haus/docs/examples/patterns/grid/responsive)
- See that the grid behaves as expected

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.
