### PR TITLE
Fix logo and logo tag height and width values

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.8.2",
+  "version": "3.8.1",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -651,6 +651,7 @@ $spv-navigation-logo: 0.3125rem;
 
   .p-navigation__logo-title {
     color: $color-navigation-text;
+    padding-left: $sph--small;
   }
 
   .p-navigation__item--dropdown-toggle {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -1,14 +1,13 @@
 @import 'settings';
 
 $lightness-threshold: 70;
-$navigation-logo-tag-width: 1.313rem;
+$navigation-logo-tag-width: 1.313rem; // 21px when 1rem is 16px
 $navigation-logo-tag-height: 2rem;
-$navigation-logo-tag-height-desktop: 2.4rem;
-$navigation-logo-height: 1.1rem;
+$navigation-logo-tag-height-desktop: 2.3rem;
 $navigation-logo-height-desktop: 3.5rem;
-$navigation-logo-width: 1.1rem;
+$navigation-logo-size: 1rem;
 $sph-navigation-link: 0.3rem;
-$spv-navigation-logo: 0.3125rem;
+$spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
 
 @mixin vf-p-navigation {
   // placeholders
@@ -200,7 +199,7 @@ $spv-navigation-logo: 0.3125rem;
   .p-navigation__logo {
     display: flex;
     flex: 0 0 auto;
-    height: $navigation-logo-height;
+    height: $navigation-logo-size;
     margin: 0 $sph--large 0 0;
 
     @media (min-width: $breakpoint-navigation-threshold) {
@@ -233,12 +232,12 @@ $spv-navigation-logo: 0.3125rem;
     }
 
     .p-navigation__logo-icon {
-      bottom: $spv-navigation-logo;
-      height: $navigation-logo-height;
+      bottom: $spv-navigation-logo-bottom-position;
+      height: $navigation-logo-size;
       left: 50%;
       position: absolute;
       transform: translate(-50%, 0);
-      width: $navigation-logo-width;
+      width: $navigation-logo-size;
     }
 
     .p-navigation__logo-title {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -250,6 +250,8 @@ $spv-navigation-logo: 0.3125rem;
     .p-navigation__link {
       @extend %navigation-link;
 
+      padding-left: $sph--x-large;
+
       &:hover {
         background-color: transparent !important;
       }
@@ -651,7 +653,6 @@ $spv-navigation-logo: 0.3125rem;
 
   .p-navigation__logo-title {
     color: $color-navigation-text;
-    padding-left: $sph--small;
   }
 
   .p-navigation__item--dropdown-toggle {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -1,12 +1,13 @@
 @import 'settings';
 
 $lightness-threshold: 70;
-$navigation-logo-tag-width: 1.5rem;
-$navigation-logo-tag-height: 2.2rem;
+$navigation-logo-tag-width: 1.313rem;
+$navigation-logo-tag-height: 2rem;
 $navigation-logo-tag-height-desktop: 2.4rem;
 $navigation-logo-height: 3rem;
 $navigation-logo-height-desktop: 3.5rem;
-$navigation-logo-width: 1.1rem;
+$navigation-logo-width: 1rem;
+$navigation-logo-height: 1rem;
 $sph-navigation-link: 0.3rem;
 $spv-navigation-logo: 0.3125rem;
 
@@ -238,6 +239,7 @@ $spv-navigation-logo: 0.3125rem;
       position: absolute;
       transform: translate(-50%, 0);
       width: $navigation-logo-width;
+      height: $navigation-logo-height;
     }
 
     .p-navigation__logo-title {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -4,10 +4,9 @@ $lightness-threshold: 70;
 $navigation-logo-tag-width: 1.313rem;
 $navigation-logo-tag-height: 2rem;
 $navigation-logo-tag-height-desktop: 2.4rem;
-$navigation-logo-height: 3rem;
+$navigation-logo-height: 1rem;
 $navigation-logo-height-desktop: 3.5rem;
 $navigation-logo-width: 1rem;
-$navigation-logo-height: 1rem;
 $sph-navigation-link: 0.3rem;
 $spv-navigation-logo: 0.3125rem;
 
@@ -235,11 +234,11 @@ $spv-navigation-logo: 0.3125rem;
 
     .p-navigation__logo-icon {
       bottom: $spv-navigation-logo;
+      height: $navigation-logo-height;
       left: 50%;
       position: absolute;
       transform: translate(-50%, 0);
       width: $navigation-logo-width;
-      height: $navigation-logo-height;
     }
 
     .p-navigation__logo-title {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -4,9 +4,9 @@ $lightness-threshold: 70;
 $navigation-logo-tag-width: 1.313rem;
 $navigation-logo-tag-height: 2rem;
 $navigation-logo-tag-height-desktop: 2.4rem;
-$navigation-logo-height: 1rem;
+$navigation-logo-height: 1.1rem;
 $navigation-logo-height-desktop: 3.5rem;
-$navigation-logo-width: 1rem;
+$navigation-logo-width: 1.1rem;
 $sph-navigation-link: 0.3rem;
 $spv-navigation-logo: 0.3125rem;
 
@@ -249,8 +249,6 @@ $spv-navigation-logo: 0.3125rem;
 
     .p-navigation__link {
       @extend %navigation-link;
-
-      padding-left: $navigation-logo-tag-width + $sph-navigation-link;
 
       &:hover {
         background-color: transparent !important;


### PR DESCRIPTION
## Done

- Adjusted the logo and logo tag height and width values to match the design :
![Image Pasted at 2022-10-19 12-58](https://user-images.githubusercontent.com/17607612/196694776-cb567328-5a8f-4561-b3fe-9228bcff1579.jpg)


Fixes https://github.com/canonical/vanilla-framework/issues/4585

## QA

- Open [demo](https://vanilla-framework-4598.demos.haus/docs/examples/patterns/navigation/default#)
- Inspect the logo and logo tag and see that they match the above specifications 
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.
