### PR TITLE
Fix warning for division operator

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -310,8 +310,8 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
       // To align the bullet with the title we need to use half
       // the height difference between the bullet and the title and then add the
       // nudge to position it with the lower case text.
-      $bullet-margin: ((map-get($line-heights, h#{$i}) - $bullet-width) / 2) + map-get($nudges, h#{$i});
-      $bullet-margin-mobile: ((map-get($line-heights, h#{$i}-mobile) - $bullet-width-mobile) / 2) + map-get($nudges, h#{$i});
+      $bullet-margin: calc((map-get($line-heights, h#{$i}) - $bullet-width) / 2) + map-get($nudges, h#{$i});
+      $bullet-margin-mobile: calc((map-get($line-heights, h#{$i}-mobile) - $bullet-width-mobile) / 2) + map-get($nudges, h#{$i});
     }
 
     .p-heading--#{$i}.p-stepped-list__title,


### PR DESCRIPTION
## Done

- Fixed warning regarding depreciated use of the division operator 

Fixes [list issues/bugs if needed]
![image](https://user-images.githubusercontent.com/17607612/197481522-2c07b99e-996f-41b7-a152-89f1d4637042.png)


## QA

- Run the site and see that you do not get the above error on your terminal
- Open [demo](insert-demo-url)
- See that site runs as expected


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
