### PR TITLE
Update the underline style of links on hover

### DIFF
--- a/scss/_base_links.scss
+++ b/scss/_base_links.scss
@@ -12,7 +12,6 @@
 
     color: $color-link;
     text-decoration: none;
-   
 
     &:focus {
       outline-offset: 0;

--- a/scss/_base_links.scss
+++ b/scss/_base_links.scss
@@ -12,6 +12,8 @@
 
     color: $color-link;
     text-decoration: none;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.075em;
 
     &:focus {
       outline-offset: 0;


### PR DESCRIPTION
## Done

Updates the style of link hover

Fixes #4600

## QA

- Open [demo](https://vanilla-framework-4603.demos.haus/)
- Hover over links and see if the updated style is as expected

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
