### PR TITLE
Add hover states for checkboxes

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.9.0",
+  "version": "3.9.1",
   "files": [
     "_index.scss",
     "/scss",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.9.1",
+  "version": "3.9.0",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_patterns_form-tick-elements.scss
+++ b/scss/_patterns_form-tick-elements.scss
@@ -41,6 +41,10 @@
     .p-muted-heading & {
       color: $colors--light-theme--text-muted;
     }
+
+    &:hover::before {
+      background-color: $colors--light-theme--background-hover;
+    }
   }
 
   %vf-pseudo-tick-box-checked {
@@ -51,19 +55,6 @@
 
     &::after {
       opacity: 1;
-    }
-  }
-
-  %vf-pseudo-tick-box-checked-hover {
-    @extend %vf-pseudo-tick-box-checked;
-    &::before {
-      background-color: darken($color-link, 10%);
-    }
-  }
-
-  %vf-pseudo-tick-box-hover {
-    &::before {
-      background-color: $colors--light-theme--background-hover;
     }
   }
 
@@ -189,28 +180,10 @@
     display: inline;
   }
 
-  // fake tick hover state
-  .p-checkbox__input:hover + .p-checkbox__label,
-  .p-radio__input:hover + .p-radio__label {
-    @extend %vf-pseudo-tick-box-hover;
-  }
-
   // fake tick checked state
   .p-checkbox__input:checked + .p-checkbox__label,
   .p-radio__input:checked + .p-radio__label {
     @extend %vf-pseudo-tick-box-checked;
-  }
-
-  // fake tick checked hover state
-  .p-checkbox__input:checked:hover + .p-checkbox__label,
-  .p-radio__input:checked:hover + .p-radio__label {
-    @extend %vf-pseudo-tick-box-checked-hover;
-  }
-
-  // fake tick indeterminate hover state
-  [aria-checked='mixed'] + .p-checkbox__label:hover,
-  :indeterminate + .p-checkbox__label:hover {
-    @extend %vf-pseudo-tick-box-checked-hover;
   }
 
   // fake tick focused state

--- a/scss/_patterns_form-tick-elements.scss
+++ b/scss/_patterns_form-tick-elements.scss
@@ -54,6 +54,19 @@
     }
   }
 
+  %vf-pseudo-tick-box-checked-hover {
+    @extend %vf-pseudo-tick-box-checked;
+    &::before {
+      background-color: darken($color-link, 10%);
+    }
+  }
+
+  %vf-pseudo-tick-box-hover {
+    &::before {
+      background-color: $colors--light-theme--background-hover;
+    }
+  }
+
   %vf-pseudo-tick-box-focused {
     &::before {
       outline: $bar-thickness solid $color-focus;
@@ -176,10 +189,28 @@
     display: inline;
   }
 
+  // fake tick hover state
+  .p-checkbox__input:hover + .p-checkbox__label,
+  .p-radio__input:hover + .p-radio__label {
+    @extend %vf-pseudo-tick-box-hover;
+  }
+
   // fake tick checked state
   .p-checkbox__input:checked + .p-checkbox__label,
   .p-radio__input:checked + .p-radio__label {
     @extend %vf-pseudo-tick-box-checked;
+  }
+
+  // fake tick checked hover state
+  .p-checkbox__input:checked:hover + .p-checkbox__label,
+  .p-radio__input:checked:hover + .p-radio__label {
+    @extend %vf-pseudo-tick-box-checked-hover;
+  }
+
+  // fake tick indeterminate hover state
+  [aria-checked='mixed'] + .p-checkbox__label:hover,
+  :indeterminate + .p-checkbox__label:hover {
+    @extend %vf-pseudo-tick-box-checked-hover;
   }
 
   // fake tick focused state


### PR DESCRIPTION
## Done

Added hover state for checkboxes

Fixes https://warthogs.atlassian.net/browse/WD-888

I didn't manage to target the indeterminate state for the checkbox so it looks broken at the moment. If anyone can help!

## QA

- Open [demo](https://vanilla-framework-4615.demos.haus/docs/examples/patterns/forms/tick-variants)
- hover over the checkboxes and radio buttons

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

