### PR TITLE
Increase z-index of the modal so that it overlays the navigation drawer

### DIFF
--- a/scss/_patterns_modal.scss
+++ b/scss/_patterns_modal.scss
@@ -17,7 +17,7 @@
     right: 0;
     top: 0;
     width: 100%;
-    z-index: 101;
+    z-index: 150; // render on top of any other content or layout elements
   }
 
   .p-modal__dialog {


### PR DESCRIPTION
## Done

Very small change to let the modal overlay the navigation drawer (`z-index: 103`), by increasing its `z-index` from 101 to 104.

## QA

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

## Screenshots

Before:

![Screenshot from 2022-12-07 10:17:55](https://user-images.githubusercontent.com/56583786/206144802-e1862918-fa9c-4f2e-9a53-ceb563578c97.png)

After:

![Screenshot from 2022-12-07 10:21:22](https://user-images.githubusercontent.com/56583786/206144856-69965e5e-e62f-459c-9472-93741cf71b78.png)