### PR TITLE
Temporary script to fix the upload assets job

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -53,13 +53,16 @@ jobs:
     needs: [build, publish-npm]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
           name: css
           path: css
-      - name: Install upload-assets snap
-        run: sudo snap install upload-assets
+      - name: Save file name to env
+        run: echo "ASSET_URL_PATH=vanilla-framework-version-$(cat css/VANILLA_VERSION).min.css" >> $GITHUB_ENV
       - name: Upload to assets server
-        run: upload-assets --url-path vanilla-framework-version-$(cat css/VANILLA_VERSION).min.css css/build.css
+        run: python scripts/upload-assets.py
         env:
           UPLOAD_ASSETS_API_TOKEN: ${{secrets.UPLOAD_ASSETS_API_TOKEN}}
+          ASSET_FILE_PATH: css/build.css
+          ASSET_URL_PATH: ${{env.ASSET_URL_PATH}}

--- a/scripts/upload_assets.py
+++ b/scripts/upload_assets.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+
+import os
+import requests
+import base64
+api_token = os.getenv('UPLOAD_ASSETS_API_TOKEN')
+file_path = os.getenv('ASSET_FILE_PATH')
+url_path = os.getenv('ASSET_URL_PATH')
+tags = os.getenv('ASSET_TAGS')
+print(file_path)
+filename = os.path.basename(file_path)
+api_url = "https://assets.ubuntu.com/v1"
+content = open(file_path, 'rb').read()
+response = requests.post(
+    api_url,
+    data={
+        'asset': base64.b64encode(content),
+        'friendly-name': filename.replace(' ', '+'),
+        'url-path': url_path,
+        'tags': tags,
+        'type': 'base64',
+        'token': api_token
+    }
+)
+print(response.text)


### PR DESCRIPTION
This fixes issues with uploading assets to asset server when we release Vanilla.

Let's not merge it for now, but when we will need to next release Vanilla, and uploading to assets server is not fixed yet, we could merge this to be able to release.

### QA

- just code review… we won't know if it works until we run it in GH actions…