### PR TITLE
fix: remove collapsed side panel from accessibility tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.10.0",
+  "version": "3.10.1",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -260,6 +260,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
     &.is-collapsed {
       box-shadow: $panel-drop-shadow-transparent;
       transform: translateX(100%);
+      visibility: hidden;
     }
 
     @media (min-width: $application-layout--breakpoint-side-nav-collapsed) {

--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -235,7 +235,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
   }
 
   .l-aside {
-    @include vf-transition($property: #{transform, box-shadow}, $duration: snap);
+    @include vf-transition($property: #{transform, box-shadow, visibility}, $duration: snap);
 
     box-shadow: $panel-drop-shadow;
     grid-area: main;


### PR DESCRIPTION
## Done

- fix:  remove collapsed side panel from accessibility tree
  - set .l-aside .is-collapsed visibility to hidden

Fixes: https://github.com/canonical/vanilla-framework/issues/4629

## QA

- Open [demo](https://vanilla-framework-4628.demos.haus/docs/layouts/application)
- Verify that collapsed side panel contents are hidden for accessibility APIs (you can check that in Chrome devtools accessibility tab and verify that the elements are ignored)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
