### PR TITLE
Fix link for Chrome Accessibility Developer Tools

### DIFF
--- a/templates/accessibility.html
+++ b/templates/accessibility.html
@@ -110,7 +110,7 @@
     </div>
     <div class="col-6">
       <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://chrome.google.com/webstore/detail/accessibility-developer-t/fpkknkljclfencbdbgkenhalefipecmb/related?hl=en">Chrome Accessibility Developer Tools</a></li>
+        <li class="p-list__item"><a href="https://developer.chrome.com/docs/devtools/accessibility/reference/">Chrome Accessibility Developer Tools</a></li>
         <li class="p-list__item"><a href="https://webaim.org/resources/contrastchecker/">Contrast checker tool</a></li>
         <li class="p-list__item"><a href="http://www.chromevox.com/">ChromeVox: a screen reader for Chrome</a></li>
         <li class="p-list__item"><a href="https://the-pastry-box-project.net/anne-gibson/2014-july-31">Accessibility Alphabet</a></li>


### PR DESCRIPTION
## Done

* Fixed the 404 link from the Accessibility page under "Chrome Accessibility Developer Tools" to a new one.