### PR TITLE
Fix command for git submodule example

### DIFF
--- a/templates/docs/building-vanilla.md
+++ b/templates/docs/building-vanilla.md
@@ -276,7 +276,7 @@ Creating a submodule in the git repo does not add all the code to the project bu
 Run this command at the root of your project (replacing vX.X.X with the [release](https://github.com/canonical/vanilla-framework/releases) you wish to use)
 
 ```
-git submodule add -b vX.X.X -- git@github.com:vanilla-framework/vanilla-framework.git _sass/vanilla-framework
+git submodule add -- git@github.com:canonical/vanilla-framework.git _sass/vanilla-framework && cd _sass/vanilla-framework && git checkout vX.X.X
 ```
 
 By running the following command it will pull down the framework into the correct location.


### PR DESCRIPTION
## Done

### Error  

- Error like below, as release version is not branch name
  - tags that written with version name cannot be selected

```bash
# git submodule add -b vX.X.X -- git@github.com:vanilla-framework/vanilla-framework.git _sass/vanilla-framework
fatal: 'origin/vX.X.X' is not a commit and a branch 'vX.X.X' cannot be created from it
fatal: unable to checkout submodule '_sass/vanilla-frameworks'
```
  
### Fixed

- Fix command to select specific version
- (etc.) Update github repository name
  - From: vanilla-framework/vanilla-framework  
  - To: canonical/vanila-framework


```bash
# git submodule add -- git@github.com:canonical/vanilla-framework.git _sass/vanilla-framework && cd _sass/vanilla-framework && git checkout vX.X.X  
Note: switching to 'vX.X.X'.
# IF `v3.11.0`
HEAD is now at 744a1016 New full-width layout for Design System website [WD-775] (#4621)
```

[WD-775]: https://warthogs.atlassian.net/browse/WD-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ