### PR TITLE
Update u-off-screen utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.11.0",
+  "version": "3.11.1",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_utilities_off-screen.scss
+++ b/scss/_utilities_off-screen.scss
@@ -2,12 +2,12 @@
 
 // Positions element out of flow & off screen for screen readers
 @mixin vf-u-off-screen {
-  .u-off-screen {
-    height: 0 !important;
-    left: -10000px !important;
-    overflow: hidden !important;
-    position: absolute !important;
-    top: auto !important;
-    width: 1px !important;
+  .u-off-screen:not(:focus):not(:active) {
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
   }
 }


### PR DESCRIPTION
## Done

Updated the `u-off-screen` utility to reflect the recommend standard as recommended here: https://www.tpgi.com/the-anatomy-of-visually-hidden/

## QA
- Go to https://vanilla-framework-4639.demos.haus/docs/examples/utilities/off-screen
- Check that the `u-off-screen` example still hides the content
- Review updated documentation:
  - https://vanilla-framework-4639.demos.haus/docs/utilities/off-screen

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.

