### PR TITLE
Update font files and use small caps in table headers

### DIFF
--- a/scss/_base_fontfaces.scss
+++ b/scss/_base_fontfaces.scss
@@ -7,7 +7,7 @@
         font-stretch: 100%; /*  min and max value for the width axis, expressed as percentage */
         font-style: normal;
         font-weight: 100 800; /*  min and max value for the weight axis */
-        src: url('#{$assets-path}e32ab0c8-Ubuntu[wdth,wght]-latin-extended.woff2') format('woff2-variations');
+        src: url('#{$assets-path}15be2ffe-UbuntuBeta0.865[wdth,wght]-latin.woff2') format('woff2-variations');
       }
 
       @font-face {
@@ -15,14 +15,14 @@
         font-stretch: 100%; /*  min and max value for the width axis, expressed as percentage */
         font-style: italic;
         font-weight: 100 800; /*  min and max value for the weight axis */
-        src: url('#{$assets-path}6eb6d574-Ubuntu-Italic[wdth,wght]-latin-extended.woff2') format('woff2-variations');
+        src: url('#{$assets-path}a84821f4-UbuntuBeta0.865-Italic[wdth,wght]-latin.woff2') format('woff2-variations');
       }
 
       @font-face {
         font-family: 'Ubuntu Mono variable';
         font-style: normal;
         font-weight: 100 800; /*  min and max value for the weight axis */
-        src: url('#{$assets-path}d0a5ca3a-UbuntuMono-Regular-latin.woff2') format('woff2-variations');
+        src: url('#{$assets-path}ec568c8f-UbuntuMonoBeta0.865[wght]-latin.woff2') format('woff2-variations');
       }
 
       @if $font-allow-cyrillic-greek-latin {
@@ -32,7 +32,7 @@
           font-stretch: 100%; /*  min and max value for the width axis, expressed as percentage */
           font-style: normal;
           font-weight: 100 800; /*  min and max value for the weight axis */
-          src: url('#{$assets-path}7d55b1fc-Ubuntu[wdth,wght]-cyrillic-extended.woff2') format('woff2-variations');
+          src: url('#{$assets-path}929e5b64-UbuntuBeta0.865[wdth,wght]-cyrillic-extended.woff2') format('woff2-variations');
           unicode-range: U+0460-052F, U+20B4, U+2DE0-2DFF, U+A640-A69F;
         }
 
@@ -42,7 +42,7 @@
           font-stretch: 100%; /*  min and max value for the width axis, expressed as percentage */
           font-style: normal;
           font-weight: 100 800; /*  min and max value for the weight axis */
-          src: url('#{$assets-path}086e42aa-Ubuntu[wdth,wght]-cyrillic.woff2') format('woff2-variations');
+          src: url('#{$assets-path}ec29c093-UbuntuBeta0.865[wdth,wght]-cyrillic.woff2') format('woff2-variations');
           unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
         }
 
@@ -52,7 +52,7 @@
           font-stretch: 100%; /*  min and max value for the width axis, expressed as percentage */
           font-style: normal;
           font-weight: 100 800; /*  min and max value for the weight axis */
-          src: url('#{$assets-path}77e5f6a2-Ubuntu[wdth,wght]-greek-extended.woff2') format('woff2-variations');
+          src: url('#{$assets-path}0a8276a6-UbuntuBeta0.865[wdth,wght]-greek-extended.woff2') format('woff2-variations');
           unicode-range: U+1F00-1FFF;
         }
 
@@ -62,7 +62,7 @@
           font-stretch: 100%; /*  min and max value for the width axis, expressed as percentage */
           font-style: normal;
           font-weight: 100 800; /*  min and max value for the weight axis */
-          src: url('#{$assets-path}57fdffc1-Ubuntu[wdth,wght]-greek.woff2') format('woff2-variations');
+          src: url('#{$assets-path}16acdbb4-UbuntuBeta0.865[wdth,wght]-greek.woff2') format('woff2-variations');
           unicode-range: U+0370-03FF;
         }
 
@@ -72,7 +72,7 @@
           font-stretch: 100%; /*  min and max value for the width axis, expressed as percentage */
           font-style: normal;
           font-weight: 100 800; /*  min and max value for the weight axis */
-          src: url('#{$assets-path}a312a7ed-Ubuntu[wdth,wght]-latin-extended.woff2') format('woff2-variations');
+          src: url('#{$assets-path}c81d0142-UbuntuBeta0.865[wdth,wght]-latin-extended.woff2') format('woff2-variations');
           unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
         }
       }

--- a/scss/_base_fontfaces.scss
+++ b/scss/_base_fontfaces.scss
@@ -7,7 +7,7 @@
         font-stretch: 100%; /*  min and max value for the width axis, expressed as percentage */
         font-style: normal;
         font-weight: 100 800; /*  min and max value for the weight axis */
-        src: url('#{$assets-path}f3b9cc97-Ubuntu[wdth,wght]-latin.woff2') format('woff2-variations');
+        src: url('#{$assets-path}e32ab0c8-Ubuntu[wdth,wght]-latin-extended.woff2') format('woff2-variations');
       }
 
       @font-face {
@@ -15,14 +15,14 @@
         font-stretch: 100%; /*  min and max value for the width axis, expressed as percentage */
         font-style: italic;
         font-weight: 100 800; /*  min and max value for the weight axis */
-        src: url('#{$assets-path}c1b12cdf-Ubuntu-Italic[wdth,wght]-latin.woff2') format('woff2-variations');
+        src: url('#{$assets-path}6eb6d574-Ubuntu-Italic[wdth,wght]-latin-extended.woff2') format('woff2-variations');
       }
 
       @font-face {
         font-family: 'Ubuntu Mono variable';
         font-style: normal;
         font-weight: 100 800; /*  min and max value for the weight axis */
-        src: url('#{$assets-path}0bd4277a-UbuntuMono[wght]-latin.woff2') format('woff2-variations');
+        src: url('#{$assets-path}d0a5ca3a-UbuntuMono-Regular-latin.woff2') format('woff2-variations');
       }
 
       @if $font-allow-cyrillic-greek-latin {

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -205,10 +205,9 @@
 
   %table-header-label {
     @extend %common-default-text-properties;
-    font-variant: small-caps;
+    font-variant-caps: all-small-caps;
     letter-spacing: 0.07em;
     margin-bottom: map-get($sp-after, default-text) - map-get($nudges, p);
-    text-transform: lowercase;
   }
 
   %muted-heading {

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -206,7 +206,7 @@
   %table-header-label {
     @extend %common-default-text-properties;
     font-variant-caps: all-small-caps;
-    letter-spacing: 0.07em;
+    letter-spacing: 0.05em;
     margin-bottom: map-get($sp-after, default-text) - map-get($nudges, p);
   }
 

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -203,11 +203,19 @@
     color: $colors--light-theme--text-muted;
   }
 
-  %table-header-label {
+  %small-caps-text {
     @extend %common-default-text-properties;
     font-variant-caps: all-small-caps;
     letter-spacing: 0.05em;
     margin-bottom: map-get($sp-after, default-text) - map-get($nudges, p);
+  }
+
+  %table-header-label {
+    // TODO: table header should use %small-caps-text,
+    // but we need to test it in the context of MAAS dense tables first
+    @extend %x-small-text;
+
+    text-transform: uppercase;
   }
 
   %muted-heading {

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -204,9 +204,11 @@
   }
 
   %table-header-label {
-    @extend %x-small-text;
-
-    text-transform: uppercase;
+    @extend %common-default-text-properties;
+    font-variant: small-caps;
+    letter-spacing: 0.07em;
+    margin-bottom: map-get($sp-after, default-text) - map-get($nudges, p);
+    text-transform: lowercase;
   }
 
   %muted-heading {

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -79,10 +79,7 @@
   }
 
   .p-text--x-small-capitalised {
-    @extend %x-small-text;
-
-    font-weight: $font-weight-bold;
-    text-transform: uppercase;
+    @extend %table-header-label;
   }
 
   //@section Adjusted spacing for headings (or a p) following a paragraph

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -79,7 +79,7 @@
   }
 
   .p-text--x-small-capitalised {
-    @extend %table-header-label;
+    @extend %small-caps-text;
   }
 
   //@section Adjusted spacing for headings (or a p) following a paragraph


### PR DESCRIPTION
## Done

Use the latest (0.864) beta of the Ubuntu Variable font, which now includes true small caps.


## QA

- Open [demo](https://vanilla-framework-4648.demos.haus/docs/examples/base/table)
- Check the table erxamples, see that the headings use true small caps instead of the previous faux small caps. 
