### PR TITLE
Bring back upload-assets CLI tool for release

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -58,11 +58,7 @@ jobs:
         with:
           name: css
           path: css
-      - name: Save file name to env
-        run: echo "ASSET_URL_PATH=vanilla-framework-version-$(cat css/VANILLA_VERSION).min.css" >> $GITHUB_ENV
+      - name: Install upload-assets snap
+        run: sudo snap install upload-assets
       - name: Upload to assets server
-        run: python scripts/upload-assets.py
-        env:
-          UPLOAD_ASSETS_API_TOKEN: ${{secrets.UPLOAD_ASSETS_API_TOKEN}}
-          ASSET_FILE_PATH: css/build.css
-          ASSET_URL_PATH: ${{env.ASSET_URL_PATH}}
+        run: upload-assets --url-path vanilla-framework-version-$(cat css/VANILLA_VERSION).min.css css/build.css


### PR DESCRIPTION
## Done

Now that new version of `upload-assets` have been released we can revert our temporary fix.