### PR TITLE
WD-778 Use new full width layout on Vanilla site

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.11.0",
+  "version": "3.11.1",
   "files": [
     "_index.scss",
     "/scss",

--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -223,18 +223,18 @@ $application-layout--side-nav-width-expanded: 15rem !default;
 
   // Other panels
   // --------------
-  .l-main {
+  .l-application .l-main {
     grid-area: main;
     overflow-y: auto;
   }
 
-  .l-status {
+  .l-application .l-status {
     border-top: 1px solid $colors--light-theme--border-low-contrast;
     grid-area: status;
     z-index: 102;
   }
 
-  .l-aside {
+  .l-application .l-aside {
     @include vf-transition($property: #{transform, box-shadow, visibility}, $duration: snap);
 
     box-shadow: $panel-drop-shadow;

--- a/scss/_layouts_full-width.scss
+++ b/scss/_layouts_full-width.scss
@@ -11,6 +11,11 @@
   // like: https://github.com/canonical/jaas-dashboard/blob/b9ca3876d054c48dc2da74df0080cd14a0f15740/src/scss/index.scss#L28
 
   @media (min-width: $breakpoint-large) {
+    // stylelint-disable-next-line selector-max-type
+    body {
+      position: relative;
+    }
+
     .l-full-width__sidebar {
       background: $color-light;
 

--- a/scss/docs/site.scss
+++ b/scss/docs/site.scss
@@ -1,7 +1,6 @@
 @charset 'utf-8';
 
 // settings
-$breakpoint-navigation-threshold: 900px;
 
 // colors for Vanilla-branded suru strips
 $color-brand: #d94b14;

--- a/templates/_layouts/_footer.html
+++ b/templates/_layouts/_footer.html
@@ -1,6 +1,6 @@
-<footer class="p-strip--light">
-  <div class="row p-content__row">
-    <div class="col-12">
+<footer class="p-strip--light l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
       <p class="u-no-margin--bottom">&copy; {{ now("%Y") }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
       <nav aria-label="Footer">
         <ul class="p-inline-list--middot u-no-margin--bottom">

--- a/templates/_layouts/_header.html
+++ b/templates/_layouts/_header.html
@@ -1,7 +1,8 @@
 <a href="#main-content" class="p-link--skip">Jump to main content</a>
 
 <header id="navigation" class="p-navigation is-dark">
-  <div class="p-navigation__row">
+  <div class=" l-full-width">
+  <div class="l-start">
     <div class="p-navigation__banner">
       <div class="p-navigation__tagged-logo">
         <a class="p-navigation__link" href="/">
@@ -22,29 +23,35 @@
         </li>
       </ul>
     </div>
-    <nav class="p-navigation__nav" aria-label="Main">
-      <ul class="p-navigation__items">
-        <li class="p-navigation__item {% if (path.startswith('/docs') or path.startswith('/design')) and not path.startswith('/docs/examples') %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs">Docs</a></li>
-        <li class="p-navigation__item {% if '/docs/examples' in path %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs/examples">Examples</a></li>
-        <li class="p-navigation__item{% if path == '/accessibility' %} is-selected{% endif %}"><a class="p-navigation__link" href="/accessibility">Accessibility</a></li>
-        <li class="p-navigation__item{% if path == '/browser-support' %} is-selected{% endif %}"><a class="p-navigation__link" href="/browser-support">Browser support</a></li>
-        <li class="p-navigation__item{% if path == '/contribute' %} is-selected{% endif %}"><a class="p-navigation__link" href="/contribute">Contribute</a></li>
-      </ul>
-      <ul class="p-navigation__items">
-        <li class="p-navigation__item">
-          <button class="js-search-button p-navigation__link--search-toggle">
-            <span class="p-navigation__search-label">Search</span>
-          </button>
-        </li>
-      </ul>
-      <div class="p-navigation__search">
-        <form class="p-search-box" action="/docs/search">
-          <input type="search" id="search-docs" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search the docs" title="Search the documentation"  autocomplete="on" aria-label="Search the docs" required />
-          <button type="reset" id="search-docs-reset" class="p-search-box__reset u-no-margin--right" name="close"><i class="p-icon--close">Clear input</i></button>
-          <button type="submit" class="p-search-box__button" name="submit"><i class="p-icon--search">Submit</i></button>
-        </form>
-      </div>
-    </nav>
   </div>
+  <div class="l-main">
+    <div class="p-navigation__row u-fixed-width">
+      <nav class="p-navigation__nav" aria-label="Main">
+        <ul class="p-navigation__items">
+          <li class="p-navigation__item {% if (path.startswith('/docs') or path.startswith('/design')) and not path.startswith('/docs/examples') %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs">Docs</a></li>
+          <li class="p-navigation__item {% if '/docs/examples' in path %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs/examples">Examples</a></li>
+          <li class="p-navigation__item{% if path == '/accessibility' %} is-selected{% endif %}"><a class="p-navigation__link" href="/accessibility">Accessibility</a></li>
+          <li class="p-navigation__item{% if path == '/browser-support' %} is-selected{% endif %}"><a class="p-navigation__link" href="/browser-support">Browser support</a></li>
+          <li class="p-navigation__item{% if path == '/contribute' %} is-selected{% endif %}"><a class="p-navigation__link" href="/contribute">Contribute</a></li>
+        </ul>
+        <ul class="p-navigation__items">
+          <li class="p-navigation__item">
+            <button class="js-search-button p-navigation__link--search-toggle">
+              <span class="p-navigation__search-label">Search</span>
+            </button>
+          </li>
+        </ul>
+        <div class="p-navigation__search">
+          <form class="p-search-box" action="/docs/search">
+            <input type="search" id="search-docs" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search the docs" title="Search the documentation"  autocomplete="on" aria-label="Search the docs" required />
+            <button type="reset" id="search-docs-reset" class="p-search-box__reset u-no-margin--right" name="close"><i class="p-icon--close">Clear input</i></button>
+            <button type="submit" class="p-search-box__button" name="submit"><i class="p-icon--search">Submit</i></button>
+          </form>
+        </div>
+      </nav>
+    </div>
+  </div>
+  </div>
+
   <div class="p-navigation__search-overlay"></div>
 </header>

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -9,167 +9,190 @@
 
     {% block banner %}{% endblock %}
 
-    <div class="p-strip is-shallow">
-    <div class="row">
-      <aside class="col-3">
-        <nav class="p-side-navigation" id="side-navigation-drawer" aria-label="Side">
-          <a href="#side-navigation-drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="side-navigation-drawer">
-            Toggle side navigation
-          </a>
+    <aside class="l-full-width__sidebar">
 
-          <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="side-navigation-drawer"></div>
+      <nav class="p-side-navigation is-sticky is-drawer-hidden" id="side-navigation-drawer" aria-label="Side">
+
+        <div class="u-hide--large p-strip--light is-shallow">
+          <div class="u-fixed-width">
+            <a href="#side-navigation-drawer" class="p-button has-icon u-no-margin js-drawer-toggle" aria-expanded="false"><i class="p-icon--menu"></i><span>Contents</span></a>
+          </div>
+        </div>
+
+        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="side-navigation-drawer" aria-expanded="false"></div>
 
           <div class="p-side-navigation__drawer">
-            <div class="p-side-navigation__drawer-header">
-              <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="side-navigation-drawer">
-                Toggle side navigation
-              </a>
-            </div>
+            <div class="p-strip is-shallow">
+              <div class="p-side-navigation__drawer-header">
+                <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="side-navigation-drawer">
+                  Toggle side navigation
+                </a>
+              </div>
 
-            {% macro side_nav_item(url, title, label, type) -%}
-                <li class="p-side-navigation__item">
-                  <a class="p-side-navigation__link" href="{{ url }}" {% if (slug and slug in url) or (url == path) %}aria-current="page"{% endif %}>
-                    {{ title }}
-                    {% if label %}
-                      <span class="p-side-navigation__status">
-                        <span class="p-status-label--{{ type|lower }}">
-                          {{ label|capitalize }}
+              {% macro side_nav_item(url, title, label, type) -%}
+                  <li class="p-side-navigation__item">
+                    <a class="p-side-navigation__link" href="{{ url }}" {% if (slug and slug in url) or (url == path) %}aria-current="page"{% endif %}>
+                      {{ title }}
+                      {% if label %}
+                        <span class="p-side-navigation__status">
+                          <span class="p-status-label--{{ type|lower }}">
+                            {{ label|capitalize }}
+                          </span>
                         </span>
-                      </span>
-                    {% endif %}
-                  </a>
-                </li>
-            {%- endmacro %}
+                      {% endif %}
+                    </a>
+                  </li>
+              {%- endmacro %}
 
-            <ul class="p-side-navigation__list">
-              <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Welcome</span></li>
-              {{ side_nav_item("/docs", "Get started") }}
-              {{ side_nav_item("/docs/building-vanilla", "Building with Vanilla") }}
-              {{ side_nav_item("/docs/customising-vanilla", "Customising Vanilla") }}
-              {{ side_nav_item("/docs/whats-new", "What’s new in " ~ version) }}
-              {{ side_nav_item("/docs/migration-guide-to-v3", "Migrating to v3.0") }}
-            </ul>
+              <ul class="p-side-navigation__list">
+                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Welcome</span></li>
+                {{ side_nav_item("/docs", "Get started") }}
+                {{ side_nav_item("/docs/building-vanilla", "Building with Vanilla") }}
+                {{ side_nav_item("/docs/customising-vanilla", "Customising Vanilla") }}
+                {{ side_nav_item("/docs/whats-new", "What’s new in " ~ version) }}
+                {{ side_nav_item("/docs/migration-guide-to-v3", "Migrating to v3.0") }}
+              </ul>
 
-            <ul class="p-side-navigation__list">
-              <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Base elements</span></li>
-              {{ side_nav_item("/docs/base/code", "Code") }}
-              {{ side_nav_item("/docs/base/forms", "Forms") }}
-              {{ side_nav_item("/docs/base/reset", "Reset") }}
-              {{ side_nav_item("/docs/base/separators", "Separators") }}
-              {{ side_nav_item("/docs/base/tables", "Tables") }}
-              {{ side_nav_item("/docs/base/typography", "Typography", "Updated", "information") }}
-            </ul>
+              <ul class="p-side-navigation__list">
+                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Base elements</span></li>
+                {{ side_nav_item("/docs/base/code", "Code") }}
+                {{ side_nav_item("/docs/base/forms", "Forms") }}
+                {{ side_nav_item("/docs/base/reset", "Reset") }}
+                {{ side_nav_item("/docs/base/separators", "Separators") }}
+                {{ side_nav_item("/docs/base/tables", "Tables") }}
+                {{ side_nav_item("/docs/base/typography", "Typography", "Updated", "information") }}
+              </ul>
 
-            <ul class="p-side-navigation__list">
-              <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Components</span></li>
-              {{ side_nav_item("/docs/patterns/accordion", "Accordion") }}
-              {{ side_nav_item("/docs/patterns/badge", "Badge") }}
-              {{ side_nav_item("/docs/patterns/breadcrumbs", "Breadcrumbs") }}
-              {{ side_nav_item("/docs/patterns/buttons", "Buttons") }}
-              {{ side_nav_item("/docs/patterns/card", "Cards") }}
-              {{ side_nav_item("/docs/patterns/chip", "Chips") }}
-              {{ side_nav_item("/docs/patterns/contextual-menu", "Contextual menu") }}
-              {{ side_nav_item("/docs/patterns/divider", "Divider") }}
-              {{ side_nav_item("/docs/patterns/empty-state", "Empty state") }}
-              {{ side_nav_item("/docs/patterns/grid", "Grid") }}
-              {{ side_nav_item("/docs/patterns/heading-icon", "Heading icon") }}
-              {{ side_nav_item("/docs/patterns/icons", "Icons", "Updated", "information") }}
-              {{ side_nav_item("/docs/patterns/images", "Images") }}
-              {{ side_nav_item("/docs/patterns/links", "Links") }}
-              {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
-              {{ side_nav_item("/docs/patterns/lists", "Lists") }}
-              {{ side_nav_item("/docs/patterns/logo-section", "Logo section") }}
-              {{ side_nav_item("/docs/patterns/matrix", "Matrix") }}
-              {{ side_nav_item("/docs/patterns/media-object", "Media object") }}
-              {{ side_nav_item("/docs/patterns/modal", "Modal") }}
-              {{ side_nav_item("/docs/patterns/muted-heading", "Muted heading") }}
-              {{ side_nav_item("/docs/patterns/navigation", "Navigation") }}
-              {{ side_nav_item("/docs/patterns/notification", "Notifications") }}
-              {{ side_nav_item("/docs/patterns/pagination", "Pagination") }}
-              {{ side_nav_item("/docs/patterns/pull-quote", "Quotes") }}
-              {{ side_nav_item("/docs/patterns/search-and-filter", "Search and filter") }}
-              {{ side_nav_item("/docs/patterns/search-box", "Search box") }}
-              {{ side_nav_item("/docs/patterns/segmented-control", "Segmented control") }}
-              {{ side_nav_item("/docs/patterns/slider", "Slider") }}
-              {{ side_nav_item("/docs/patterns/status-labels", "Status labels") }}
-              {{ side_nav_item("/docs/patterns/strip", "Strip") }}
-              {{ side_nav_item("/docs/patterns/switch", "Switch") }}
-              {{ side_nav_item("/docs/patterns/table-of-contents", "Table of contents") }}
-              {{ side_nav_item("/docs/patterns/tabs", "Tabs") }}
-              {{ side_nav_item("/docs/patterns/tooltips", "Tooltips") }}
-            </ul>
+              <ul class="p-side-navigation__list">
+                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Components</span></li>
+                {{ side_nav_item("/docs/patterns/accordion", "Accordion") }}
+                {{ side_nav_item("/docs/patterns/badge", "Badge") }}
+                {{ side_nav_item("/docs/patterns/breadcrumbs", "Breadcrumbs") }}
+                {{ side_nav_item("/docs/patterns/buttons", "Buttons") }}
+                {{ side_nav_item("/docs/patterns/card", "Cards") }}
+                {{ side_nav_item("/docs/patterns/chip", "Chips") }}
+                {{ side_nav_item("/docs/patterns/contextual-menu", "Contextual menu") }}
+                {{ side_nav_item("/docs/patterns/divider", "Divider") }}
+                {{ side_nav_item("/docs/patterns/empty-state", "Empty state") }}
+                {{ side_nav_item("/docs/patterns/grid", "Grid") }}
+                {{ side_nav_item("/docs/patterns/heading-icon", "Heading icon") }}
+                {{ side_nav_item("/docs/patterns/icons", "Icons", "Updated", "information") }}
+                {{ side_nav_item("/docs/patterns/images", "Images") }}
+                {{ side_nav_item("/docs/patterns/links", "Links") }}
+                {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
+                {{ side_nav_item("/docs/patterns/lists", "Lists") }}
+                {{ side_nav_item("/docs/patterns/logo-section", "Logo section") }}
+                {{ side_nav_item("/docs/patterns/matrix", "Matrix") }}
+                {{ side_nav_item("/docs/patterns/media-object", "Media object") }}
+                {{ side_nav_item("/docs/patterns/modal", "Modal") }}
+                {{ side_nav_item("/docs/patterns/muted-heading", "Muted heading") }}
+                {{ side_nav_item("/docs/patterns/navigation", "Navigation") }}
+                {{ side_nav_item("/docs/patterns/notification", "Notifications") }}
+                {{ side_nav_item("/docs/patterns/pagination", "Pagination") }}
+                {{ side_nav_item("/docs/patterns/pull-quote", "Quotes") }}
+                {{ side_nav_item("/docs/patterns/search-and-filter", "Search and filter") }}
+                {{ side_nav_item("/docs/patterns/search-box", "Search box") }}
+                {{ side_nav_item("/docs/patterns/segmented-control", "Segmented control") }}
+                {{ side_nav_item("/docs/patterns/slider", "Slider") }}
+                {{ side_nav_item("/docs/patterns/status-labels", "Status labels") }}
+                {{ side_nav_item("/docs/patterns/strip", "Strip") }}
+                {{ side_nav_item("/docs/patterns/switch", "Switch") }}
+                {{ side_nav_item("/docs/patterns/table-of-contents", "Table of contents") }}
+                {{ side_nav_item("/docs/patterns/tabs", "Tabs") }}
+                {{ side_nav_item("/docs/patterns/tooltips", "Tooltips") }}
+              </ul>
 
-            <ul class="p-side-navigation__list">
-              <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Utilities</span></li>
-              {{ side_nav_item("/docs/utilities/align", "Align") }}
-              {{ side_nav_item("/docs/utilities/baseline-grid", "Baseline grid") }}
-              {{ side_nav_item("/docs/utilities/clearfix", "Clearfix") }}
-              {{ side_nav_item("/docs/utilities/embedded-media", "Embedded media") }}
-              {{ side_nav_item("/docs/utilities/equal-height", "Equal height") }}
-              {{ side_nav_item("/docs/utilities/floats", "Floats") }}
-              {{ side_nav_item("/docs/utilities/font-metrics", "Font metrics") }}
-              {{ side_nav_item("/docs/utilities/functions", "Functions") }}
-              {{ side_nav_item("/docs/utilities/hide", "Hide") }}
-              {{ side_nav_item("/docs/utilities/image-position", "Image position") }}
-              {{ side_nav_item("/docs/utilities/margin-collapse", "Margin collapse") }}
-              {{ side_nav_item("/docs/utilities/no-print", "No print") }}
-              {{ side_nav_item("/docs/utilities/off-screen", "Off-screen") }}
-              {{ side_nav_item("/docs/utilities/padding-collapse", "Padding collapse") }}
-              {{ side_nav_item("/docs/utilities/table-cell-padding-overlap", "Table cell padding overlap") }}
-              {{ side_nav_item("/docs/utilities/truncate", "Truncation") }}
-              {{ side_nav_item("/docs/utilities/show", "Show") }}
-              {{ side_nav_item("/docs/utilities/vertical-spacing", "Vertical spacing") }}
-              {{ side_nav_item("/docs/utilities/vertically-center", "Vertically center") }}
-            </ul>
+              <ul class="p-side-navigation__list">
+                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Utilities</span></li>
+                {{ side_nav_item("/docs/utilities/align", "Align") }}
+                {{ side_nav_item("/docs/utilities/baseline-grid", "Baseline grid") }}
+                {{ side_nav_item("/docs/utilities/clearfix", "Clearfix") }}
+                {{ side_nav_item("/docs/utilities/embedded-media", "Embedded media") }}
+                {{ side_nav_item("/docs/utilities/equal-height", "Equal height") }}
+                {{ side_nav_item("/docs/utilities/floats", "Floats") }}
+                {{ side_nav_item("/docs/utilities/font-metrics", "Font metrics") }}
+                {{ side_nav_item("/docs/utilities/functions", "Functions") }}
+                {{ side_nav_item("/docs/utilities/hide", "Hide") }}
+                {{ side_nav_item("/docs/utilities/image-position", "Image position") }}
+                {{ side_nav_item("/docs/utilities/margin-collapse", "Margin collapse") }}
+                {{ side_nav_item("/docs/utilities/no-print", "No print") }}
+                {{ side_nav_item("/docs/utilities/off-screen", "Off-screen") }}
+                {{ side_nav_item("/docs/utilities/padding-collapse", "Padding collapse") }}
+                {{ side_nav_item("/docs/utilities/table-cell-padding-overlap", "Table cell padding overlap") }}
+                {{ side_nav_item("/docs/utilities/truncate", "Truncation") }}
+                {{ side_nav_item("/docs/utilities/show", "Show") }}
+                {{ side_nav_item("/docs/utilities/vertical-spacing", "Vertical spacing") }}
+                {{ side_nav_item("/docs/utilities/vertically-center", "Vertically center") }}
+              </ul>
 
-            <ul class="p-side-navigation__list">
-              <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Layouts</span></li>
-              {{ side_nav_item("/docs/layouts/application", "Application") }}
-              {{ side_nav_item("/docs/layouts/documentation", "Documentation") }}
-              {{ side_nav_item("/docs/layouts/fluid-breakout", "Fluid breakout") }}
-              {{ side_nav_item("/docs/layouts/sticky-footer", "Sticky footer") }}
-            </ul>
+              <ul class="p-side-navigation__list">
+                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Layouts</span></li>
+                {{ side_nav_item("/docs/layouts/application", "Application") }}
+                {{ side_nav_item("/docs/layouts/documentation", "Documentation") }}
+                {{ side_nav_item("/docs/layouts/fluid-breakout", "Fluid breakout") }}
+                {{ side_nav_item("/docs/layouts/sticky-footer", "Sticky footer") }}
+              </ul>
 
-            <ul class="p-side-navigation__list">
-              <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Settings</span></li>
-              {{ side_nav_item("/docs/settings/animation-settings", "Animations") }}
-              {{ side_nav_item("/docs/settings/assets-settings", "Assets") }}
-              {{ side_nav_item("/docs/settings/breakpoint-settings", "Breakpoints") }}
-              {{ side_nav_item("/docs/settings/color-settings", "Color") }}
-              {{ side_nav_item("/docs/settings/font-settings", "Font") }}
-              {{ side_nav_item("/docs/settings/layout-settings", "Layout") }}
-              {{ side_nav_item("/docs/settings/placeholder-settings", "Placeholders") }}
-              {{ side_nav_item("/docs/settings/spacing-settings", "Spacing") }}
-              {{ side_nav_item("/docs/settings/table-layout", "Table layout") }}
-            </ul>
+              <ul class="p-side-navigation__list">
+                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Settings</span></li>
+                {{ side_nav_item("/docs/settings/animation-settings", "Animations") }}
+                {{ side_nav_item("/docs/settings/assets-settings", "Assets") }}
+                {{ side_nav_item("/docs/settings/breakpoint-settings", "Breakpoints") }}
+                {{ side_nav_item("/docs/settings/color-settings", "Color") }}
+                {{ side_nav_item("/docs/settings/font-settings", "Font") }}
+                {{ side_nav_item("/docs/settings/layout-settings", "Layout") }}
+                {{ side_nav_item("/docs/settings/placeholder-settings", "Placeholders") }}
+                {{ side_nav_item("/docs/settings/spacing-settings", "Spacing") }}
+                {{ side_nav_item("/docs/settings/table-layout", "Table layout") }}
+              </ul>
 
-            <ul class="p-side-navigation__list">
-              <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Resources</span></li>
-              {{ side_nav_item("/docs/examples", "Component examples") }}
-              {{ side_nav_item("https://github.com/canonical/vanilla-framework/releases/latest", "Release notes for " ~ version) }}
-              {{ side_nav_item("https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch", "Download Sketch UI Kit") }}
-            </ul>
-
+              <ul class="p-side-navigation__list">
+                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Resources</span></li>
+                {{ side_nav_item("/docs/examples", "Component examples") }}
+                {{ side_nav_item("https://github.com/canonical/vanilla-framework/releases/latest", "Release notes for " ~ version) }}
+                {{ side_nav_item("https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch", "Download Sketch UI Kit") }}
+              </ul>
+            </div>
           </div>
-        </nav>
+      </div>
 
-      </aside>
+      <!-- <nav class="p-side-navigation is-sticky is-drawer-hidden" id="side-navigation-drawer" aria-label="Side">
+        <a href="#side-navigation-drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="side-navigation-drawer">
+          Toggle side navigation
+        </a>
 
-      <main class="col-9" id="main-content">
-        {% block content %}
-          {% if page_tabs %}
-          <div class="p-strip u-no-padding--top">
-            <h1>{{ title.split('|')[0] }}</h1>
+        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="side-navigation-drawer"></div>
+
+        <div class="p-side-navigation__drawer">
+          <div class="p-side-navigation__drawer-header">
+            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="side-navigation-drawer">
+              Toggle side navigation
+            </a>
           </div>
-          {% endif %}
 
-          {% include "_layouts/_component_tabs.html" %}
 
-          {{ content | safe }}
-        {% endblock content %}
-      </main>
 
-    </div>
+        </div>
+      </nav> -->
+    </aside>
+    <div class="p-strip is-shallow l-full-width">
+      <div class="l-main">
+        <div class="row">
+          <main class="col-12" id="main-content">
+            {% block content %}
+              {% if page_tabs %}
+              <div class="p-strip u-no-padding--top">
+                <h1>{{ title.split('|')[0] }}</h1>
+              </div>
+              {% endif %}
+
+              {% include "_layouts/_component_tabs.html" %}
+
+              {{ content | safe }}
+            {% endblock content %}
+          </main>
+        </div>
+      </div>
     </div>
 
     <script>

--- a/templates/accessibility.html
+++ b/templates/accessibility.html
@@ -5,127 +5,171 @@
 {% block copydoc %}https://docs.google.com/document/d/1_cCvuHSwS9i0pzD_4WHDFoTenVAfZVr9qGxG-rSHHGY/edit{% endblock %}
 
 {% block content %}
-<div id="main-content" class="p-strip--suru-topped">
-  <div class="row">
-    <div class="col-12">
-      <h1>Accessibility guidelines</h1>
-      <p>Vanilla Framework aims for Level AA conformance with the <br><a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines (WCAG) 2.1</a></p>
+<div id="main-content" class="p-strip--suru-topped l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-12">
+        <h1>Accessibility guidelines</h1>
+        <p>Vanilla Framework aims for Level AA conformance with the <br><a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines (WCAG) 2.1</a></p>
+      </div>
     </div>
   </div>
 </div>
 
-<div class="u-fixed-width">
-  <hr class="u-no-margin--bottom">
-</div>
-
-<div class="p-strip">
-  <div class="row">
-    <div class="col-6">
-      <h2>Ensuring conformance</h2>
-      <p>We use the following tools to continually audit the framework:</p>
-    </div>
-    <div class="col-6">
-      <p class="p-heading--5 u-no-margin--bottom"><a href="https://www.w3.org/WAI/eval/report-tool/#!/evaluation/audit">Accessibility report tool</a></p>
-      <p>A checklist that can be filtered by A / AA / AAA level, with a short description and links to the related "Understanding" and "How to Meet" articles that accompany each criterion.</p>
-      <p class="p-heading--5 u-no-margin--bottom"><a href="https://www.w3.org/TR/wai-aria-practices">WAI-ARIA Authoring Practices 1.1</a></p>
-      <p>
-        <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> A guide for understanding how to use <cite><a href="https://www.w3.org/TR/wai-aria-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.1</a></cite> to create an accessible Rich Internet Application. It provides guidance on the appropriate application of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>, describes recommended <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> usage patterns, and explains concepts behind them.</p>
-      <p class="p-heading--5 u-no-margin--bottom"><a href="https://validator.w3.org/nu/">The W3 Markup Validation Service</a></p>
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr>
     </div>
   </div>
 </div>
 
-<div class="u-fixed-width">
-  <hr class="u-no-margin--bottom">
+<div class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-6">
+        <h2>Ensuring conformance</h2>
+        <p>We use the following tools to continually audit the framework:</p>
+      </div>
+      <div class="col-6">
+        <p class="p-heading--5 u-no-margin--bottom"><a href="https://www.w3.org/WAI/eval/report-tool/#!/evaluation/audit">Accessibility report tool</a></p>
+        <p>A checklist that can be filtered by A / AA / AAA level, with a short description and links to the related "Understanding" and "How to Meet" articles that accompany each criterion.</p>
+        <p class="p-heading--5 u-no-margin--bottom"><a href="https://www.w3.org/TR/wai-aria-practices">WAI-ARIA Authoring Practices 1.1</a></p>
+        <p>
+          <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> A guide for understanding how to use <cite><a href="https://www.w3.org/TR/wai-aria-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.1</a></cite> to create an accessible Rich Internet Application. It provides guidance on the appropriate application of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>, describes recommended <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> usage patterns, and explains concepts behind them.</p>
+        <p class="p-heading--5 u-no-margin--bottom"><a href="https://validator.w3.org/nu/">The W3 Markup Validation Service</a></p>
+      </div>
+    </div>
+  </div>
 </div>
 
-<div class="p-strip">
-  <div class="row">
-    <div class="col-6">
-      <h2>Curated criteria checklist</h2>
-      <p class="u-no-padding--bottom">The scope of the WCAG spec can be overwhelming. We find the following checklist a good starting point if you're new to accessibility:</p>
-    </div>
-    <div class="col-6">
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr>
     </div>
   </div>
 </div>
-<div class="p-strip u-no-padding--top">
-  <div class="u-fixed-width">
-    <ul class="p-list is-split">
-      <li class="p-list__item is-ticked">Make sure there is enough contrast between text and its background color</li>
-      <li class="p-list__item is-ticked">Don't indicate important information using colour alone</li>
-      <li class="p-list__item is-ticked">Design focus states to help users navigate and understand where they are</li>
-      <li class="p-list__item is-ticked">Links should be visually identifiable and have clearly distinct states</li>
-      <li class="p-list__item is-ticked">Be as consistent and clear as possible in layout and copy</li>
-      <li class="p-list__item is-ticked">The general architecture and hierarchy of the content should make sense</li>
 
-      <li class="p-list__item is-ticked">Help users understand inputs, and help them avoid and correct mistakes</li>
-      <li class="p-list__item is-ticked">Write good alt text for your images</li>
-      <li class="p-list__item is-ticked">Make links descriptive</li>
-      <li class="p-list__item is-ticked">Users should be able to navigate content using a screen reader</li>
-      <li class="p-list__item is-ticked">If an experience cannot be made accessible, create another route for users to get that information</li>
+<div class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-6">
+        <h2>Curated criteria checklist</h2>
+        <p class="u-no-padding--bottom">The scope of the WCAG spec can be overwhelming. We find the following checklist a good starting point if you're new to accessibility:</p>
+      </div>
+      <div class="col-6">
+      </div>
+    </div>
+  </div>
+</div>
 
-      <li class="p-list__item is-ticked">Use the correct HTML element for your content</li>
-      <li class="p-list__item is-ticked">Support keyboard navigation</li>
-      <li class="p-list__item is-ticked">Understand and use region landmarks</li>
-      <li class="p-list__item is-ticked">Unless all your content is inside region markups, give users a way to skip top level navigation to access main content</li>
-      <li class="p-list__item is-ticked">Use ARIA roles, properties and states when applicable</li>
-      <li class="p-list__item is-ticked">Avoid images and iconography in pseudo-elements</li>
-      <li class="p-list__item is-ticked">Hide decorative elements from screen readers</li>
-      <li class="p-list__item is-ticked">Make SVGs accessible to assistive technology</li>
-      <li class="p-list__item is-ticked">HTML document should have a language attribute</li>
-    </ul>
-    <p>*Adapted from <a href="http://accessibility.voxmedia.com">Accessibility Guidelines</a> checklist and <a href="http://a11yproject.com/checklist.html">Web Accessibility Checklist</a></p>
-  </div>
-</div>
-<div class="u-fixed-width">
-  <hr class="u-no-margin--bottom">
-</div>
-<div class="p-strip">
-  <div class="row">
-    <div class="col-6">
-      <h2>Key WCAG documents</h2>
-      <p>The volume of information on the WCAG 2.0 website can be disorienting. <br>We keep the following links handy for quick reference:</p>
+<div class="p-strip u-no-padding--top l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <ul class="p-list is-split">
+        <li class="p-list__item is-ticked">Make sure there is enough contrast between text and its background color</li>
+        <li class="p-list__item is-ticked">Don't indicate important information using colour alone</li>
+        <li class="p-list__item is-ticked">Design focus states to help users navigate and understand where they are</li>
+        <li class="p-list__item is-ticked">Links should be visually identifiable and have clearly distinct states</li>
+        <li class="p-list__item is-ticked">Be as consistent and clear as possible in layout and copy</li>
+        <li class="p-list__item is-ticked">The general architecture and hierarchy of the content should make sense</li>
+
+        <li class="p-list__item is-ticked">Help users understand inputs, and help them avoid and correct mistakes</li>
+        <li class="p-list__item is-ticked">Write good alt text for your images</li>
+        <li class="p-list__item is-ticked">Make links descriptive</li>
+        <li class="p-list__item is-ticked">Users should be able to navigate content using a screen reader</li>
+        <li class="p-list__item is-ticked">If an experience cannot be made accessible, create another route for users to get that information</li>
+
+        <li class="p-list__item is-ticked">Use the correct HTML element for your content</li>
+        <li class="p-list__item is-ticked">Support keyboard navigation</li>
+        <li class="p-list__item is-ticked">Understand and use region landmarks</li>
+        <li class="p-list__item is-ticked">Unless all your content is inside region markups, give users a way to skip top level navigation to access main content</li>
+        <li class="p-list__item is-ticked">Use ARIA roles, properties and states when applicable</li>
+        <li class="p-list__item is-ticked">Avoid images and iconography in pseudo-elements</li>
+        <li class="p-list__item is-ticked">Hide decorative elements from screen readers</li>
+        <li class="p-list__item is-ticked">Make SVGs accessible to assistive technology</li>
+        <li class="p-list__item is-ticked">HTML document should have a language attribute</li>
+      </ul>
+      <p>*Adapted from <a href="http://accessibility.voxmedia.com">Accessibility Guidelines</a> checklist and <a href="http://a11yproject.com/checklist.html">Web Accessibility Checklist</a></p>
     </div>
   </div>
 </div>
-<div class="p-strip u-no-padding--top">
-  <div class="row">
-    <ul class="p-list is-split">
-      <li class="p-list__item"><a href="https://www.w3.org/TR/WCAG20/">WCAG 2.0</a>: the W3C standard, includes principles, guidelines and success criteria</li>
-      <li class="p-list__item"><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/">Understanding WCAG 2.0</a>: detailed reference, includes intent, benefits to people with disabilities, examples, resources and techniques</li>
-      <li class="p-list__item"><a href="https://www.w3.org/WAI/WCAG20/quickref/">How to Meet WCAG 2.0</a>: a customisable quick reference, includes guidelines, success criteria and techniques</li>
-      <li class="p-list__item"><a href="https://www.w3.org/TR/WCAG20-TECHS/">Techniques for WCAG 2.0</a>: instructions for developers, includes browser and assistive technology support notes, examples, code, resources and test procedures</li>
-    </ul>
+
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr>
+    </div>
   </div>
 </div>
-<div class="u-fixed-width">
-  <hr class="u-no-margin--bottom">
-</div>
-<div class="p-strip">
-  <div class="row">
-    <div class="col-6">
-      <h2>Useful tools</h2>
-      <p>The web is abundant in tools that help to create and test for accessible sites. We find the following particularly useful:</p>
+
+<div class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-6">
+        <h2>Key WCAG documents</h2>
+        <p>The volume of information on the WCAG 2.0 website can be disorienting. <br>We keep the following links handy for quick reference:</p>
+      </div>
     </div>
-    <div class="col-6">
-      <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://developer.chrome.com/docs/devtools/accessibility/reference/">Chrome Accessibility Developer Tools</a></li>
-        <li class="p-list__item"><a href="https://webaim.org/resources/contrastchecker/">Contrast checker tool</a></li>
-        <li class="p-list__item"><a href="http://www.chromevox.com/">ChromeVox: a screen reader for Chrome</a></li>
-        <li class="p-list__item"><a href="https://the-pastry-box-project.net/anne-gibson/2014-july-31">Accessibility Alphabet</a></li>
-        <li class="p-list__item"><a href="https://webaim.org/">Web Accessibility in Mind</a></li>
+  </div>
+</div>
+
+<div class="p-strip u-no-padding--top l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <ul class="p-list is-split">
+        <li class="p-list__item"><a href="https://www.w3.org/TR/WCAG20/">WCAG 2.0</a>: the W3C standard, includes principles, guidelines and success criteria</li>
+        <li class="p-list__item"><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/">Understanding WCAG 2.0</a>: detailed reference, includes intent, benefits to people with disabilities, examples, resources and techniques</li>
+        <li class="p-list__item"><a href="https://www.w3.org/WAI/WCAG20/quickref/">How to Meet WCAG 2.0</a>: a customisable quick reference, includes guidelines, success criteria and techniques</li>
+        <li class="p-list__item"><a href="https://www.w3.org/TR/WCAG20-TECHS/">Techniques for WCAG 2.0</a>: instructions for developers, includes browser and assistive technology support notes, examples, code, resources and test procedures</li>
       </ul>
     </div>
   </div>
 </div>
-<div class="u-fixed-width">
-  <hr class="u-no-margin--bottom">
+
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr>
+    </div>
+  </div>
 </div>
-<div class="p-strip">
-  <div class="u-fixed-width">
-    <h2>Noticed an issue?</h2>
-    <p>If you spot an accessibility problem in Vanilla, let us know <br> by <a href="https://github.com/canonical/vanilla-framework/issues">filing&nbsp;an&nbsp;issue</a> on GitHub.</p>
+
+<div class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-6">
+        <h2>Useful tools</h2>
+        <p>The web is abundant in tools that help to create and test for accessible sites. We find the following particularly useful:</p>
+      </div>
+      <div class="col-6">
+        <ul class="p-list--divided">
+          <li class="p-list__item"><a href="https://developer.chrome.com/docs/devtools/accessibility/reference/">Chrome Accessibility Developer Tools</a></li>
+          <li class="p-list__item"><a href="https://webaim.org/resources/contrastchecker/">Contrast checker tool</a></li>
+          <li class="p-list__item"><a href="http://www.chromevox.com/">ChromeVox: a screen reader for Chrome</a></li>
+          <li class="p-list__item"><a href="https://the-pastry-box-project.net/anne-gibson/2014-july-31">Accessibility Alphabet</a></li>
+          <li class="p-list__item"><a href="https://webaim.org/">Web Accessibility in Mind</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <h2>Noticed an issue?</h2>
+      <p>If you spot an accessibility problem in Vanilla, let us know <br> by <a href="https://github.com/canonical/vanilla-framework/issues">filing&nbsp;an&nbsp;issue</a> on GitHub.</p>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/templates/browser-support.html
+++ b/templates/browser-support.html
@@ -6,83 +6,104 @@
 
 
 {% block content %}
-<div id="main-content" class="p-strip--suru-topped">
-  <div class="row">
-    <div class="col-12">
-      <h1 class="u-no-margin--bottom">Browser support</h1>
+<div id="main-content" class="p-strip--suru-topped l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-6">
+        <h1 class="u-no-margin--bottom">Browser support</h1>
+      </div>
+      <div class="col-6">
+        <p>Vanilla framework follows the principles of progressive enhancement and web standards. Users should be able to access core content and functionality from any browser or operating system, with varying degrees of access to visual and other enhancements — design components do not have to look exactly the same on every browser.</p>
+      </div>
     </div>
   </div>
 </div>
 
-<div class="u-fixed-width">
-  <hr class="u-no-margin--bottom">
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr class="u-no-margin--bottom">
+    </div>
+  </div>
 </div>
 
-<div class="p-strip u-no-padding--bottom">
-  <div class="row">
-    <div class="col-8">
-      <p class="p-heading--4">Vanilla framework follows the principles of progressive enhancement and web standards. Users should be able to access core content and functionality from any browser or operating system, with varying degrees of access to visual and other enhancements — design components do not have to look exactly the same on every browser.</p>
+<div class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-6">
+        <h2>Bugs and prioritisation</h2>
+      </div>
+      <div class="col-6">
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">If the bug prevents access to core content (for example, by hiding it or covering it), it should be prioritised</li>
+          <li class="p-list__item is-ticked">If the bug relates to visual differences that do not affect access to content on modern browsers, it should be queued up</li>
+          <li class="p-list__item is-ticked">Priority level should be determined case by case</li>
+          <li class="p-list__item is-ticked">If the bug relates to visual differences that do not affect access to content on old browsers, it should be deprioritised</li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>
-<div class="p-strip is-shallow">
-  <div class="row">
-    <div class="col-8">
-      <h2>Bugs and prioritisation</h2>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">If the bug prevents access to core content (for example, by hiding it or covering it), it should be prioritised</li>
-        <li class="p-list__item is-ticked">If the bug relates to visual differences that do not affect access to content on modern browsers, it should be queued up</li>
-        <li class="p-list__item is-ticked">Priority level should be determined case by case</li>
-        <li class="p-list__item is-ticked">If the bug relates to visual differences that do not affect access to content on old browsers, it should be deprioritised</li>
-      </ul>
+
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr class="u-no-margin--bottom">
     </div>
   </div>
-  <div class="row">
-    <div class="col-8">
-      <h2>Supported browsers</h2>
-      <p>The following are the browsers that we actively test all components on. That does not mean other browsers are not supported or that bugs reported are not acted on.</p>
-      <ul class="p-list is-split">
-        <li class="p-list__item">
-          <div class="p-heading-icon--small">
-            <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/09a6a50e-vf.io-chrome.png" alt="" />
-              <p class="p-heading-icon__title">Chrome 62 or greater</p>
+</div>
+
+<div class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-6">
+        <h2>Supported browsers</h2>
+        <p>The following are the browsers that we actively test all components on. That does not mean other browsers are not supported or that bugs reported are not acted on.</p>
+      </div>
+      <div class="col-6">
+        <ul class="p-list is-split">
+          <li class="p-list__item">
+            <div class="p-heading-icon--small">
+              <div class="p-heading-icon__header">
+                <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/09a6a50e-vf.io-chrome.png" alt="" />
+                <p class="p-heading-icon__title">Chrome 62 or greater</p>
+              </div>
             </div>
-          </div>
-        </li>
-        <li class="p-list__item">
-          <div class="p-heading-icon--small">
-            <div class="p-heading-icon__header">
-              <img src="https://assets.ubuntu.com/v1/a45d30aa-vf.io-firefox.svg" class="p-heading-icon__img" alt="" />
-              <p class="p-heading-icon__title">Firefox 56 or greater</p>
+          </li>
+          <li class="p-list__item">
+            <div class="p-heading-icon--small">
+              <div class="p-heading-icon__header">
+                <img src="https://assets.ubuntu.com/v1/a45d30aa-vf.io-firefox.svg" class="p-heading-icon__img" alt="" />
+                <p class="p-heading-icon__title">Firefox 56 or greater</p>
+              </div>
             </div>
-          </div>
-        </li>
-        <li class="p-list__item">
-          <div class="p-heading-icon--small">
-            <div class="p-heading-icon__header">
-              <img src="https://assets.ubuntu.com/v1/a030d872-vf.io-safari.svg" class="p-heading-icon__img" alt="" />
-              <p class="p-heading-icon__title">Safari 11 or greater</p>
+          </li>
+          <li class="p-list__item">
+            <div class="p-heading-icon--small">
+              <div class="p-heading-icon__header">
+                <img src="https://assets.ubuntu.com/v1/a030d872-vf.io-safari.svg" class="p-heading-icon__img" alt="" />
+                <p class="p-heading-icon__title">Safari 11 or greater</p>
+              </div>
             </div>
-          </div>
-        </li>
-        <li class="p-list__item">
-          <div class="p-heading-icon--small">
-            <div class="p-heading-icon__header">
-              <img src="https://assets.ubuntu.com/v1/de0673bb-vf.io-edge.svg" class="p-heading-icon__img" alt="" />
-              <p class="p-heading-icon__title">Edge 16 or greater</p>
+          </li>
+          <li class="p-list__item">
+            <div class="p-heading-icon--small">
+              <div class="p-heading-icon__header">
+                <img src="https://assets.ubuntu.com/v1/de0673bb-vf.io-edge.svg" class="p-heading-icon__img" alt="" />
+                <p class="p-heading-icon__title">Edge 16 or greater</p>
+              </div>
             </div>
-          </div>
-        </li>
-        <li class="p-list__item">
-          <div class="p-heading-icon--small">
-            <div class="p-heading-icon__header">
-              <img src="https://assets.ubuntu.com/v1/74738acc-vf.io-opera.svg" class="p-heading-icon__img" alt="" />
-              <p class="p-heading-icon__title">Opera 48 or greater</p>
+          </li>
+          <li class="p-list__item">
+            <div class="p-heading-icon--small">
+              <div class="p-heading-icon__header">
+                <img src="https://assets.ubuntu.com/v1/74738acc-vf.io-opera.svg" class="p-heading-icon__img" alt="" />
+                <p class="p-heading-icon__title">Opera 48 or greater</p>
+              </div>
             </div>
-          </div>
-        </li>
-      </ul>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -5,135 +5,165 @@
 {% block copydoc %}https://docs.google.com/document/d/1FIYkjR9Xu6Or0WUCi6EQGaZsiTq8ESk8Kv39CW4kkwo/edit{% endblock %}
 
 {% block content %}
-<div id="main-content" class="p-strip--suru-topped">
-  <div class="row">
-    <div class="col-12">
-      <h1 class="u-no-margin--bottom">Contribute</h1>
-    </div>
-  </div>
-</div>
-
-<div class="u-fixed-width">
-  <hr class="u-no-margin--bottom">
-</div>
-
-<div class="p-strip">
-  <div class="row">
-    <div class="p-strip u-no-padding--top"><h2>Meet the team</h2></div>
-    {% for team_member in team_members %}
-      <div class="col-3 p-media-object">
-        {% if team_member.avatar_url %}
-          <img src="{{ team_member.avatar_url }}" class="p-media-object__image is-round" alt="">
-        {% endif %}
-        <div class="p-media-object__details">
-          <h3 class="p-media-object__title">
-            <a href="https://github.com/{{ team_member.login }}">{{ team_member.login }}</a>
-          </h3>
-          <p class="p-media-object__content u-no-margin--bottom">{{ team_member.role }}</p>
-
-          {% if team_member.contributions %}
-            <small>Contributions: {{ team_member.contributions }}</small>
-          {% endif %}
-        </div>
+<div id="main-content" class="p-strip--suru-topped l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-12">
+        <h1 class="u-no-margin--bottom">Contribute</h1>
       </div>
-    {% endfor %}
+    </div>
   </div>
 </div>
 
-{% if contributors %}
-  <div class="u-fixed-width">
-    <hr>
-  </div>
-
-  <div class="p-strip">
-    <div class="row">
-      <div class="p-strip u-no-padding--top"><h2>Contributors</h2></div>
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr>
     </div>
+  </div>
+</div>
+
+<div class="p-strip l-full-width">
+  <div class="l-main">
     <div class="row">
-      {% for contributor in contributors%}
+      <div class="p-strip u-no-padding--top"><h2>Meet the team</h2></div>
+      {% for team_member in team_members %}
         <div class="col-3 p-media-object">
-          <img src="{{ contributor.avatar_url }}" class="p-media-object__image is-round" alt="">
+          {% if team_member.avatar_url %}
+            <img src="{{ team_member.avatar_url }}" class="p-media-object__image is-round" alt="">
+          {% endif %}
           <div class="p-media-object__details">
             <h3 class="p-media-object__title">
-              <a href="https://github.com/{{ contributor.login }}">{{ contributor.login }}</a>
+              <a href="https://github.com/{{ team_member.login }}">{{ team_member.login }}</a>
             </h3>
-            <p class="p-media-object__content u-no-margin--bottom">{{ contributor.role }}</p>
+            <p class="p-media-object__content u-no-margin--bottom">{{ team_member.role }}</p>
 
-            {% if contributor.contributions %}
-              <small>Contributions: {{ contributor.contributions }}</small>
+            {% if team_member.contributions %}
+              <small>Contributions: {{ team_member.contributions }}</small>
             {% endif %}
           </div>
         </div>
       {% endfor %}
     </div>
-  {% endif %}
-</div>
-<div class="u-fixed-width">
-  <hr>
-</div>
-<div class="p-strip">
-  <div class="row">
-    <div class="p-strip u-no-padding--top"><h2>Contribute</h2></div>
   </div>
-  <div class="row">
-    <div class="col-6">
-      <p>When <a href="https://github.com/canonical/vanilla-framework/issues/new/choose">submitting a new issue</a>, please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.</p>
-      <p>Please provide as much information possible detailing what you're currently experiencing and what you'd expect to experience.</p>
-      <p>To work on an issue, please fork this repo and create a new branch on your local fork. When you're happy and would like to propose that changeset to be merged back upstream, open a pull request to merge from your local origin/master to upstream/master.</p>
-      <p>When committing changes, make sure to group related changes so that the project is always in a working state. Use succinct yet descriptive commit messages to allow for easy reading of the commit log.</p>
-    </div>
-    <div class="col-6">
-      <div class="row">
-        <div class="col-6 p-card">
-          <h3>Guidelines</h3>
-          <p>We follow two guideline documents that align with the practices that the Canonical Web Team follows across all projects.
-            <ul class="p-inline-list--middot u-no-margin--bottom">
-              <li class="p-inline-list__item"> <a href="https://webteam.canonical.com/practices/html-code-standards">HTML code standards</a> </li>
-              <li class="p-inline-list__item"> <a href="https://webteam.canonical.com/practices/css">Stylesheets code standards</a> </li>
-            </ul>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-3 p-card">
-          <h3>File a bug</h3>
-          <p>We use <a href="https://github.com/canonical/vanilla-framework/issues">GitHub issues</a> to track all our bugs and feature requests.</p>
-        </div>
-        <div class="col-3 p-card">
-          <h3>Chat with us</h3>
-          <p>Find out about new releases, latest features and get help on <a href="https://twitter.com/vanillaframewrk">Twitter</a>.</p>
-        </div>
+</div>
+
+{% if contributors %}
+  <div class="l-full-width">
+    <div class="l-main">
+      <div class="u-fixed-width">
+        <hr>
       </div>
     </div>
   </div>
-</div>
-<div class="u-fixed-width">
-  <hr>
-</div>
-<div class="p-strip">
-  <div class="row">
-    <div class="col-6">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header is-stacked">
-          <svg width="60" height="60" class="p-heading-icon__img" viewBox="0 0 12 16" version="1.1" aria-hidden="true">
-            <title>GitHub pull request icon</title>
-            <path fill-rule="evenodd"
-              d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z">
-            </path>
-          </svg>
-          <h3 class="p-heading-icon__title">Running tests locally</h3>
-        </div>
+
+  <div class="p-strip l-full-width">
+    <div class="l-main">
+      <div class="row">
+        <div class="p-strip u-no-padding--top"><h2>Contributors</h2></div>
       </div>
-      <p>The simplest way to run Vanilla framework is to first <a href="https://docs.docker.com/install/">install Docker</a> and <a href="https://github.com/canonical/dotrun#installation">dotrun</a>, and then use the <code>dotrun</code> script to <a
-          href="https://github.com/canonical/vanilla-framework#vanilla-local-development">build the site</a>. Before proposing a pull request, ensure that the tests pass on your local fork. To kick off the tests for your project, in the terminal <code>dotrun test</code>.</p>
+      <div class="row">
+        {% for contributor in contributors%}
+          <div class="col-3 p-media-object">
+            <img src="{{ contributor.avatar_url }}" class="p-media-object__image is-round" alt="">
+            <div class="p-media-object__details">
+              <h3 class="p-media-object__title">
+                <a href="https://github.com/{{ contributor.login }}">{{ contributor.login }}</a>
+              </h3>
+              <p class="p-media-object__content u-no-margin--bottom">{{ contributor.role }}</p>
+
+              {% if contributor.contributions %}
+                <small>Contributions: {{ contributor.contributions }}</small>
+              {% endif %}
+            </div>
+          </div>
+        {% endfor %}
+      </div>
     </div>
-    <div class="col-6">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header is-stacked">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt=""/>
-          <h3 class="p-heading-icon__title">Licences</h3>
+  </div>
+{% endif %}
+
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="p-strip u-no-padding--top"><h2>Contribute</h2></div>
+    </div>
+    <div class="row">
+      <div class="col-6">
+        <p>When <a href="https://github.com/canonical/vanilla-framework/issues/new/choose">submitting a new issue</a>, please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.</p>
+        <p>Please provide as much information possible detailing what you're currently experiencing and what you'd expect to experience.</p>
+        <p>To work on an issue, please fork this repo and create a new branch on your local fork. When you're happy and would like to propose that changeset to be merged back upstream, open a pull request to merge from your local origin/master to upstream/master.</p>
+        <p>When committing changes, make sure to group related changes so that the project is always in a working state. Use succinct yet descriptive commit messages to allow for easy reading of the commit log.</p>
+      </div>
+      <div class="col-6">
+        <div class="row">
+          <div class="col-6 p-card">
+            <h3>Guidelines</h3>
+            <p>We follow two guideline documents that align with the practices that the Canonical Web Team follows across all projects.
+              <ul class="p-inline-list--middot u-no-margin--bottom">
+                <li class="p-inline-list__item"> <a href="https://webteam.canonical.com/practices/html-code-standards">HTML code standards</a> </li>
+                <li class="p-inline-list__item"> <a href="https://webteam.canonical.com/practices/css">Stylesheets code standards</a> </li>
+              </ul>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-3 p-card">
+            <h3>File a bug</h3>
+            <p>We use <a href="https://github.com/canonical/vanilla-framework/issues">GitHub issues</a> to track all our bugs and feature requests.</p>
+          </div>
+          <div class="col-3 p-card">
+            <h3>Chat with us</h3>
+            <p>Find out about new releases, latest features and get help on <a href="https://twitter.com/vanillaframewrk">Twitter</a>.</p>
+          </div>
         </div>
       </div>
-      <p>The content of this project is licensed under the <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International license</a>, and the underlying code used to format and display that content is licensed under the <a href="https://opensource.org/licenses/lgpl-3.0.html">LGPLv3</a> by <a href="https://canonical.com">Canonical Ltd</a>.</p>
+    </div>
+  </div>
+</div>
+
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-6">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header is-stacked">
+            <svg width="60" height="60" class="p-heading-icon__img" viewBox="0 0 12 16" version="1.1" aria-hidden="true">
+              <title>GitHub pull request icon</title>
+              <path fill-rule="evenodd"
+                d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z">
+              </path>
+            </svg>
+            <h3 class="p-heading-icon__title">Running tests locally</h3>
+          </div>
+        </div>
+        <p>The simplest way to run Vanilla framework is to first <a href="https://docs.docker.com/install/">install Docker</a> and <a href="https://github.com/canonical/dotrun#installation">dotrun</a>, and then use the <code>dotrun</code> script to <a
+            href="https://github.com/canonical/vanilla-framework#vanilla-local-development">build the site</a>. Before proposing a pull request, ensure that the tests pass on your local fork. To kick off the tests for your project, in the terminal <code>dotrun test</code>.</p>
+      </div>
+      <div class="col-6">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header is-stacked">
+            <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt=""/>
+            <h3 class="p-heading-icon__title">Licences</h3>
+          </div>
+        </div>
+        <p>The content of this project is licensed under the <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International license</a>, and the underlying code used to format and display that content is licensed under the <a href="https://opensource.org/licenses/lgpl-3.0.html">LGPLv3</a> by <a href="https://canonical.com">Canonical Ltd</a>.</p>
+      </div>
     </div>
   </div>
 </div>

--- a/templates/docs/examples/index.html
+++ b/templates/docs/examples/index.html
@@ -7,75 +7,77 @@
 {% block title %}Component examples{% endblock %}
 
 {% block body %}
-<main id="main-content" class="p-strip is-bordered">
-  <div class="u-fixed-width">
-    <h1>Component examples</h1>
-    <hr>
-  </div>
+<main id="main-content" class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <h1>Component examples</h1>
+      <hr>
+    </div>
 
-  <div class="row">
-    <div class="col-3">
-      <h2>Base elements</h2>
-      <nav aria-label="Documentation: base elements">
-        <ul class="p-list">
-          {% for example in examples.base %}
-            <li class="p-list__item">
-              <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
-            </li>
-          {% endfor %}
-        </ul>
-      </nav>
+    <div class="row">
+      <div class="col-3">
+        <h2>Base elements</h2>
+        <nav aria-label="Documentation: base elements">
+          <ul class="p-list">
+            {% for example in examples.base %}
+              <li class="p-list__item">
+                <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
+              </li>
+            {% endfor %}
+          </ul>
+        </nav>
+      </div>
+      <div class="col-3">
+        <h2>Components</h2>
+        <nav aria-label="Documentation: components">
+          <ul class="p-list">
+            {% for example in examples.patterns %}
+              <li class="p-list__item">
+                <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
+              </li>
+            {% endfor %}
+          </ul>
+        </nav>
+      </div>
+      <div class="col-3">
+        <h2>Utilities</h2>
+        <nav aria-label="Documentation: utilities">
+          <ul class="p-list">
+            {% for example in examples.utilities %}
+              <li class="p-list__item">
+                <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
+              </li>
+            {% endfor %}
+          </ul>
+        </nav>
+      </div>
+      <div class="col-3">
+        <h2>Layouts</h2>
+        <nav aria-label="Documentation: layouts">
+          <ul class="p-list">
+            {% for example in examples.layouts %}
+              <li class="p-list__item">
+                <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
+              </li>
+            {% endfor %}
+          </ul>
+        </nav>
+        <h2>Templates</h2>
+        <nav aria-label="Documentation: templates">
+          <ul class="p-list">
+            {% for example in examples.templates %}
+              <li class="p-list__item">
+                <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
+              </li>
+            {% endfor %}
+          </ul>
+        </nav>
+      </div>
     </div>
-    <div class="col-3">
-      <h2>Components</h2>
-      <nav aria-label="Documentation: components">
-        <ul class="p-list">
-          {% for example in examples.patterns %}
-            <li class="p-list__item">
-              <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
-            </li>
-          {% endfor %}
-        </ul>
-      </nav>
-    </div>
-    <div class="col-3">
-      <h2>Utilities</h2>
-      <nav aria-label="Documentation: utilities">
-        <ul class="p-list">
-          {% for example in examples.utilities %}
-            <li class="p-list__item">
-              <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
-            </li>
-          {% endfor %}
-        </ul>
-      </nav>
-    </div>
-    <div class="col-3">
-      <h2>Layouts</h2>
-      <nav aria-label="Documentation: layouts">
-        <ul class="p-list">
-          {% for example in examples.layouts %}
-            <li class="p-list__item">
-              <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
-            </li>
-          {% endfor %}
-        </ul>
-      </nav>
-      <h2>Templates</h2>
-      <nav aria-label="Documentation: templates">
-        <ul class="p-list">
-          {% for example in examples.templates %}
-            <li class="p-list__item">
-              <a href="/docs/examples/{{ example.path }}" class="p-link">{{ example.title }}</a>
-            </li>
-          {% endfor %}
-        </ul>
-      </nav>
-    </div>
-  </div>
 
-  <div class="u-fixed-width">
-    <p><a href="/docs/examples/standalone">Examples using standalone component CSS for testing/debugging</a></p>
+    <div class="u-fixed-width">
+      <p><a href="/docs/examples/standalone">Examples using standalone component CSS for testing/debugging</a></p>
+    </div>
   </div>
 </main>
 {% endblock %}

--- a/templates/docs/examples/standalone.html
+++ b/templates/docs/examples/standalone.html
@@ -7,38 +7,40 @@
 {% block title %}Standalone component examples{% endblock %}
 
 {% block body %}
-<main id="main-content" class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-12">
-      <h1>Standalone component examples</h1>
-      <hr>
-      <p>Examples below use CSS built with single pattern included with base styles instead of the whole Vanilla framework CSS file.</p>
+<main id="main-content" class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-12">
+        <h1>Standalone component examples</h1>
+        <hr>
+        <p>Examples below use CSS built with single pattern included with base styles instead of the whole Vanilla framework CSS file.</p>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-3">
-      <h2>Base elements</h2>
-      <nav aria-label="Documentation: base elements">
-        <ul class="p-list">
-          {% for example in examples.base %}
-            <li class="p-list__item">
-              <a href="/docs/examples/standalone/{{ example.path }}" class="p-link">{{ example.title }}</a>
-            </li>
-          {% endfor %}
-        </ul>
-      </nav>
-    </div>
-    <div class="col-3">
-      <h2>Components</h2>
-      <nav aria-label="Documentation: components">
-        <ul class="p-list">
-          {% for example in examples.patterns %}
-            <li class="p-list__item">
-              <a href="/docs/examples/standalone/{{ example.path }}" class="p-link">{{ example.title }}</a>
-            </li>
-          {% endfor %}
-        </ul>
-      </nav>
+    <div class="row">
+      <div class="col-3">
+        <h2>Base elements</h2>
+        <nav aria-label="Documentation: base elements">
+          <ul class="p-list">
+            {% for example in examples.base %}
+              <li class="p-list__item">
+                <a href="/docs/examples/standalone/{{ example.path }}" class="p-link">{{ example.title }}</a>
+              </li>
+            {% endfor %}
+          </ul>
+        </nav>
+      </div>
+      <div class="col-3">
+        <h2>Components</h2>
+        <nav aria-label="Documentation: components">
+          <ul class="p-list">
+            {% for example in examples.patterns %}
+              <li class="p-list__item">
+                <a href="/docs/examples/standalone/{{ example.path }}" class="p-link">{{ example.title }}</a>
+              </li>
+            {% endfor %}
+          </ul>
+        </nav>
+      </div>
     </div>
   </div>
 </main>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,9 +6,9 @@
 {% block content %}
 <script defer src="https://buttons.github.io/buttons.js"></script>
 
-<div id="main-content" class="p-strip--suru is-deep">
-  <div class="row">
-    <div class="col-12">
+<div id="main-content" class="p-strip--suru is-deep l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
       <h1>A simple, extensible CSS framework</h1>
       <p>Backed by open-source code and written in Sass by the Canonical Web Team.</p>
       <ul class="p-inline-list u-no-margin--bottom">
@@ -23,259 +23,320 @@
   </div>
 </div>
 
-<div class="p-strip is-bordered is-deep">
-  <div class="row">
-    <div class="col-4">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header is-stacked">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/1958451f-pictogram_lightweight01b-dark.svg",
-            alt="",
-            width="96",
-            height="96",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-heading-icon__img"}
-            ) | safe
-          }}
-          <h2 class="p-heading-icon__title">Lightweight</h2>
+<div class="p-strip is-deep l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-4 col-medium-2">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header is-stacked">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/1958451f-pictogram_lightweight01b-dark.svg",
+              alt="",
+              width="96",
+              height="96",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-heading-icon__img"}
+              ) | safe
+            }}
+            <h2 class="p-heading-icon__title">Lightweight</h2>
+          </div>
+          <p>Vanilla contains a responsive CSS grid, basic style for HTML elements and a selection of key useful patterns and utility classes that you can extend.</p>
         </div>
-        <p>Vanilla contains a responsive CSS grid, basic style for HTML elements and a selection of key useful patterns and utility classes that you can extend.</p>
       </div>
-    </div>
-    <div class="col-4">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header is-stacked">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/730b14b9-pictogram_extension01-dark.svg",
-            alt="",
-            width="96",
-            height="96",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-heading-icon__img"}
-            ) | safe
-          }}
-          <h2 class="p-heading-icon__title">Composable</h2>
+      <div class="col-4 col-medium-2">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header is-stacked">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/730b14b9-pictogram_extension01-dark.svg",
+              alt="",
+              width="96",
+              height="96",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-heading-icon__img"}
+              ) | safe
+            }}
+            <h2 class="p-heading-icon__title">Composable</h2>
+          </div>
+          <p>Designed to be composable — you can include the whole framework to avail of all styles or you can use only what you need for your project.</p>
         </div>
-        <p>Designed to be composable — you can include the whole framework to avail of all styles or you can use only what you need for your project.</p>
       </div>
-    </div>
-    <div class="col-4">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header is-stacked">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/ff78e55c-pictogram_opensource01-dark.svg",
-            alt="",
-            width="96",
-            height="96",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-heading-icon__img"}
-            ) | safe
-          }}
-          <h2 class="p-heading-icon__title">Open source</h2>
+      <div class="col-4 col-medium-2">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header is-stacked">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/ff78e55c-pictogram_opensource01-dark.svg",
+              alt="",
+              width="96",
+              height="96",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-heading-icon__img"}
+              ) | safe
+            }}
+            <h2 class="p-heading-icon__title">Open source</h2>
+          </div>
+          <p>Anyone can contribute to Vanilla, improve it and extend it. All the code is available on GitHub and is licensed under LGPLv3 by Canonical.</p>
         </div>
-        <p>Anyone can contribute to Vanilla, improve it and extend it. All the code is available on GitHub and is licensed under LGPLv3 by Canonical.</p>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div id="quick-start" class="p-strip is-bordered is-deep">
-  <div class="row">
-    <div class="col-12">
-      <h2>Quick start</h2>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-6">
-      <p>The recommended method of including Vanilla Framework in your project is via <a href="https://www.npmjs.com/package/vanilla-framework">npm</a> or <a href="https://yarnpkg.com/package/vanilla-framework">yarn</a>. You can then simply include the framework in your SCSS files and compile.</p>
-      <p>For other methods, please see the <a href="/docs">advanced usage docs.</a></p>
-    </div>
-    <div class="col-6">
-      <pre><code>yarn add sass vanilla-framework</code></pre>
-      <pre><code><span class="token keyword">@import</span> <span class="token string">"vanilla-framework"</span><span class="token punctuation">;</span><br><span class="token keyword">@include</span> vanilla<span class="token punctuation">;</span></code></pre>
-    </div>
-  </div>
-</div>
-
-<div class="p-strip is-bordered is-deep">
-  <div class="row u-equal-height">
-    <div class="col-4">
-      <h2>Guidelines</h2>
-      <p>If you are <a href="https://vanillaframework.io/contribute">contributing to Vanilla</a>, make sure to read and follow these guidelines.</p>
-      <ul class="p-list--divided">
-        <li class="p-list__item">
-          <a href="/accessibility" class="p-link">Accessibility</a>
-        </li>
-        <li class="p-list__item">
-          <a href="/browser-support" class="p-link">Browser support</a>
-        </li>
-      </ul>
-    </div>
-    <div class="col-8 u-vertically-center u-align--center">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/af1e0f04-guidelines-illustration.svg",
-        alt="",
-        width="378",
-        height="200",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-  </div>
-</div>
-
-<div class="p-strip is-bordered is-deep">
-  <div class="row">
-    <div class="col-4">
-      <h2>Downloads</h2>
-    </div>
-  </div>
-  <div class="row">
-    <div class="p-card--highlighted col-4">
-      <div class="p-heading-icon--small">
-        <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/0276b842-github-icon.svg" alt="GitHub repo:" />
-          <h3 class="p-heading-icon__title">Vanilla Framework</h3>
-        </div>
-        <p>Use our CSS framework to start building&nbsp;your project.</p>
-        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button" href="https://github.com/canonical/vanilla-framework/releases/latest">Download latest Vanilla v{{version}}</a></p>
-        <small>See the <a href="https://github.com/canonical/vanilla-framework/releases">release notes</a> for details on the latest&nbsp;updates.</small>
-      </div>
-    </div>
-    <div class="p-card--highlighted col-4">
-      <div class="p-heading-icon--small">
-        <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9a5b9c51-sketch-icon.svg" alt="Sketch library:" />
-          <h3 class="p-heading-icon__title">Vanilla Design</h3>
-        </div>
-        <p>Get our Sketch library of common design components.</p>
-        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla Design UI Kit', 'eventValue' : undefined });" class="p-button" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download the Sketch UI Kit</a></p>
-        <small><i class="p-icon--warning"></i> The Sketch UI Kit is no longer maintained. Current version is compatible with Vanilla v2.25.</small>
       </div>
     </div>
   </div>
 </div>
 
-<div class="p-strip is-deep is-bordered">
-  <div class="u-fixed-width">
-    <h2>Latest news from our blog</h2>
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr>
+    </div>
   </div>
-  <div id="articles" class="row">
-    <p><i class="p-icon--spinner u-animation--spin"></i> Loading...</p>
+</div>
+
+<div id="quick-start" class="p-strip is-deep l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-12">
+        <h2>Quick start</h2>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-6 col-medium-3">
+        <p>The recommended method of including Vanilla Framework in your project is via <a href="https://www.npmjs.com/package/vanilla-framework">npm</a> or <a href="https://yarnpkg.com/package/vanilla-framework">yarn</a>. You can then simply include the framework in your SCSS files and compile.</p>
+        <p>For other methods, please see the <a href="/docs">advanced usage docs.</a></p>
+      </div>
+      <div class="col-6 col-medium-3">
+        <pre><code>yarn add sass vanilla-framework</code></pre>
+        <pre><code><span class="token keyword">@import</span> <span class="token string">"vanilla-framework"</span><span class="token punctuation">;</span><br><span class="token keyword">@include</span> vanilla<span class="token punctuation">;</span></code></pre>
+      </div>
+    </div>
   </div>
-  <div class="u-fixed-width"><a href="https://ubuntu.com/blog/topics/design" class="p-button">View more from our blog</a></div>
+</div>
+
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip is-deep l-full-width">
+  <div class="l-main">
+    <div class="row u-equal-height">
+      <div class="col-6 col-medium-3">
+        <h2>Guidelines</h2>
+        <p>If you are <a href="https://vanillaframework.io/contribute">contributing to Vanilla</a>, make sure to read and follow these guidelines.</p>
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            <a href="/accessibility" class="p-link">Accessibility</a>
+          </li>
+          <li class="p-list__item">
+            <a href="/browser-support" class="p-link">Browser support</a>
+          </li>
+        </ul>
+      </div>
+      <div class="col-6 col-medium-3 u-vertically-center u-align--center">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/af1e0f04-guidelines-illustration.svg",
+          alt="",
+          width="378",
+          height="200",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip is-deep l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-4 col-medium-2">
+        <h2>Downloads</h2>
+      </div>
+      <div class="p-card--highlighted col-4 col-medium-2">
+        <div class="p-heading-icon--small">
+          <div class="p-heading-icon__header">
+            <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/0276b842-github-icon.svg" alt="GitHub repo:" />
+            <h3 class="p-heading-icon__title">Vanilla Framework</h3>
+          </div>
+          <p>Use our CSS framework to start building&nbsp;your project.</p>
+          <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button" href="https://github.com/canonical/vanilla-framework/releases/latest">Download latest Vanilla v{{version}}</a></p>
+          <small>See the <a href="https://github.com/canonical/vanilla-framework/releases">release notes</a> for details on the latest&nbsp;updates.</small>
+        </div>
+      </div>
+      <div class="p-card--highlighted col-4 col-medium-2">
+        <div class="p-heading-icon--small">
+          <div class="p-heading-icon__header">
+            <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9a5b9c51-sketch-icon.svg" alt="Sketch library:" />
+            <h3 class="p-heading-icon__title">Vanilla Design</h3>
+          </div>
+          <p>Get our Sketch library of common design components.</p>
+          <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla Design UI Kit', 'eventValue' : undefined });" class="p-button" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download the Sketch UI Kit</a></p>
+          <small><i class="p-icon--warning"></i> The Sketch UI Kit is no longer maintained. Current version is compatible with Vanilla v2.25.</small>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip is-deep l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-4">
+        <h2>Latest news from our blog</h2>
+      </div>
+      <div class="col-8">
+        <div id="articles" class="row">
+          <p><i class="p-icon--spinner u-animation--spin"></i> Loading...</p>
+        </div>
+        <div class="u-fixed-width"><a href="https://ubuntu.com/blog/topics/design" class="p-button">View more from our blog</a></div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <!-- blog snippet template -->
 <template style="display:none" id="template">
-  <article class="col-3">
+  <article class="col-4 u-sv3">
     <h3><a class="article-link article-title"></a></h3>
     <time class="p-heading--6 article-time"></time>
   </article>
 </template>
 
-<div class="p-strip is-bordered">
-  <div class="u-fixed-width">
-    <div class="p-logo-section">
-      <p class="p-logo-section__title u-align-text--center">Who&rsquo;s using Vanilla</p>
-      <div class="p-logo-section__items">
-        <div class="p-logo-section__item">
-          <a href="https://ubuntu.com/">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/89680bdf-logo-ubuntu.svg",
-              alt="",
-              width="144",
-              height="144",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
-          </a>
-        </div>
-        <div class="p-logo-section__item">
-          <a href="https://jaas.ai/">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/7fe3f290-2019-logo-jaas.svg",
-              alt="",
-              width="145",
-              height="145",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
-          </a>
-        </div>
-        <div class="p-logo-section__item">
-          <a href="https://stmargarets.london/">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/b7c9c8ce-2019-st-margarets-logo.svg",
-              alt="",
-              width="145",
-              height="145",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
-          </a>
-        </div>
-        <div class="p-logo-section__item">
-          <a href="https://snapcraft.io/">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/e635d1ef-snapcraft_green-red_hex.png",
-              alt="",
-              width="170",
-              height="120",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
-          </a>
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr>
+    </div>
+  </div>
+</div>
+
+<div class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <div class="p-logo-section">
+        <p class="p-logo-section__title u-align-text--center">Who&rsquo;s using Vanilla</p>
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            <a href="https://ubuntu.com/">
+              {{ image (
+                url="https://assets.ubuntu.com/v1/89680bdf-logo-ubuntu.svg",
+                alt="",
+                width="144",
+                height="144",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}
+                ) | safe
+              }}
+            </a>
+          </div>
+          <div class="p-logo-section__item">
+            <a href="https://jaas.ai/">
+              {{ image (
+                url="https://assets.ubuntu.com/v1/7fe3f290-2019-logo-jaas.svg",
+                alt="",
+                width="145",
+                height="145",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}
+                ) | safe
+              }}
+            </a>
+          </div>
+          <div class="p-logo-section__item">
+            <a href="https://stmargarets.london/">
+              {{ image (
+                url="https://assets.ubuntu.com/v1/b7c9c8ce-2019-st-margarets-logo.svg",
+                alt="",
+                width="145",
+                height="145",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}
+                ) | safe
+              }}
+            </a>
+          </div>
+          <div class="p-logo-section__item">
+            <a href="https://snapcraft.io/">
+              {{ image (
+                url="https://assets.ubuntu.com/v1/e635d1ef-snapcraft_green-red_hex.png",
+                alt="",
+                width="170",
+                height="120",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}
+                ) | safe
+              }}
+            </a>
+          </div>
         </div>
       </div>
     </div>
   </div>
 </div>
 
-
-
-
-<div class="p-strip">
-  <div class="row">
-    <div class="col-3">
-      <h2>Contribute</h2>
-      <p><a class="github-button" href="https://github.com/canonical/vanilla-framework" data-size="large" data-show-count="true" aria-label="Follow @vanilla-framework on GitHub">Follow @vanilla-framework</a></p>
-      <p><a class="github-button" href="https://github.com/canonical/vanilla-framework/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork vanilla-framework/vanilla-framework on GitHub">Fork</a></p>
+<div class="l-full-width">
+  <div class="l-main">
+    <div class="u-fixed-width">
+      <hr>
     </div>
-    <div class="col-3">
-      <h2>Get involved</h2>
-      <ul class="p-list--divided">
-        <li class="p-list__item is-ticked" style="background-image: url('https://assets.ubuntu.com/v1/7eae50ca-icon-twitter.svg'); background-size: 1rem;">
-          <a href="https://twitter.com/vanillaframewrk" class="p-link--soft">Twitter&nbsp;&rsaquo;</a>
-        </li>
-        <li class="p-list__item is-ticked" style="background-image: url('https://assets.ubuntu.com/v1/f307a122-icon-github.svg'); background-size: 1rem;">
-          <a href="https://github.com/canonical/vanilla-framework" class="p-link--soft">GitHub&nbsp;&rsaquo;</a>
-        </li>
-      </ul>
-    </div>
-    <div class="col-6">
-      <h2>Subscribe to Vanilla updates</h2>
-      <form action="//canonical.us3.list-manage.com/subscribe/post?u=56dac47c206ba0f58ec25f314&amp;id=36f7d8394e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="p-form">
-        <div class="p-form__group">
-          <label for="mce-EMAIL">Email address</label>
-          <input type="email" value="" name="EMAIL" placeholder="vanilla@example.com" id="mce-EMAIL" aria-label="Email address" autocomplete="email" required />
-          <input class="u-off-screen" aria-hidden="true" type="hidden" name="b_56dac47c206ba0f58ec25f314_36f7d8394e" tabindex="-1" value="" />
-          <p class="p-form-help-text">Know about new releases, features, blog posts, calls&#8209;for&#8209;help&nbsp;and more.</p>
-        </div>
-        <button name="subscribe" type="submit" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Subscribe', 'eventLabel' : 'Subcribe to Vanilla updates', 'eventValue' : undefined });" class="p-button--positive">Subscribe</button>
-      </form>
+  </div>
+</div>
+
+<div class="p-strip l-full-width">
+  <div class="l-main">
+    <div class="row">
+      <div class="col-3">
+        <h2>Contribute</h2>
+        <p><a class="github-button" href="https://github.com/canonical/vanilla-framework" data-size="large" data-show-count="true" aria-label="Follow @vanilla-framework on GitHub">Follow @vanilla-framework</a></p>
+        <p><a class="github-button" href="https://github.com/canonical/vanilla-framework/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork vanilla-framework/vanilla-framework on GitHub">Fork</a></p>
+      </div>
+      <div class="col-3">
+        <h2>Get involved</h2>
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked" style="background-image: url('https://assets.ubuntu.com/v1/7eae50ca-icon-twitter.svg'); background-size: 1rem;">
+            <a href="https://twitter.com/vanillaframewrk" class="p-link--soft">Twitter&nbsp;&rsaquo;</a>
+          </li>
+          <li class="p-list__item is-ticked" style="background-image: url('https://assets.ubuntu.com/v1/f307a122-icon-github.svg'); background-size: 1rem;">
+            <a href="https://github.com/canonical/vanilla-framework" class="p-link--soft">GitHub&nbsp;&rsaquo;</a>
+          </li>
+        </ul>
+      </div>
+      <div class="col-6">
+        <h2>Subscribe to Vanilla updates</h2>
+        <form action="//canonical.us3.list-manage.com/subscribe/post?u=56dac47c206ba0f58ec25f314&amp;id=36f7d8394e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="p-form">
+          <div class="p-form__group">
+            <label for="mce-EMAIL">Email address</label>
+            <input type="email" value="" name="EMAIL" placeholder="vanilla@example.com" id="mce-EMAIL" aria-label="Email address" autocomplete="email" required />
+            <input class="u-off-screen" aria-hidden="true" type="hidden" name="b_56dac47c206ba0f58ec25f314_36f7d8394e" tabindex="-1" value="" />
+            <p class="p-form-help-text">Know about new releases, features, blog posts, calls&#8209;for&#8209;help&nbsp;and more.</p>
+          </div>
+          <button name="subscribe" type="submit" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Subscribe', 'eventLabel' : 'Subcribe to Vanilla updates', 'eventValue' : undefined });" class="p-button--positive">Subscribe</button>
+        </form>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- updates Vanilla site to use new full width layout
- small SCSS fixes for the layout

Fixes [WD-778](https://warthogs.atlassian.net/browse/WD-778)

## QA

- Open [demo](https://vanilla-framework-4650.demos.haus/)
- Make sure the site works as expected
  - check all the pages from top nav
  - check documentation section with side navigation
  - check search
  - verify pages on different screen sizes

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

<img width="1912" alt="image" src="https://user-images.githubusercontent.com/83575/217534886-df706f83-702d-4385-8407-2db8d4c78829.png">


[WD-778]: https://warthogs.atlassian.net/browse/WD-778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ