### PR TITLE
Fix padding in table-mobile-card

### DIFF
--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -29,15 +29,15 @@
           border-radius: $border-radius;
           display: block;
           margin-bottom: $spv--x-large;
-          padding: 0 $sph--large;
+          padding: 0 0;
         }
         td,
         tbody th {
           display: block;
           min-width: 100%;
           overflow: hidden;
-          padding-left: 0;
-          padding-right: 0;
+          padding-left: $sph--large;
+          padding-right: $sph--large;
           position: relative;
           text-overflow: ellipsis;
           white-space: nowrap;


### PR DESCRIPTION
## Done

Fixes #4646 

## QA

- Open [demo](https://vanillaframework.io/docs/examples/patterns/tables/table-mobile-card)
- See before/after screenshots
- Review updated documentation:
  - [does not apply]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

Before:
![before](https://user-images.githubusercontent.com/3260147/217930352-ed89793d-66c7-428b-b191-01583ea9787a.png)

After:
![after](https://user-images.githubusercontent.com/3260147/217930369-7f9569d8-33ae-4fcc-aaa9-6d9fa8ca12d3.png)
