### PR TITLE
WD-777 Add full-width layout documentation

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -130,6 +130,7 @@
                 {{ side_nav_item("/docs/layouts/application", "Application") }}
                 {{ side_nav_item("/docs/layouts/documentation", "Documentation") }}
                 {{ side_nav_item("/docs/layouts/fluid-breakout", "Fluid breakout") }}
+                {{ side_nav_item("/docs/layouts/full-width", "Full-width") }}
                 {{ side_nav_item("/docs/layouts/sticky-footer", "Sticky footer") }}
               </ul>
 

--- a/templates/docs/examples/layouts/full-width/default.html
+++ b/templates/docs/examples/layouts/full-width/default.html
@@ -5,7 +5,6 @@
 <style>
   body {
     margin: 0;
-    position: relative;
   }
 </style>
 {% endblock %}

--- a/templates/docs/examples/layouts/full-width/structure.html
+++ b/templates/docs/examples/layouts/full-width/structure.html
@@ -1,0 +1,31 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Full width / Default{% endblock %}
+
+{% block style %}
+<style>
+.l-full-width .l-start,
+.l-full-width .l-main,
+.l-full-width .l-end {
+  background: rgba(199,22,43,.1);
+  border: 1px solid rgba(199,22,43,.5);
+}
+</style>
+{% endblock %}
+
+{% block content %}
+
+<div class="p-strip is-shallow l-full-width">
+  <div class="l-start">start</div>
+  <div class="l-main">main
+    <div class="row grid-demo">
+      <div class="col-6 col-medium-2">col</div>
+      <div class="col-3  col-medium-2">col</div>
+      <div class="col-3  col-medium-2">col</div>
+    </div>
+  </div>
+  <div class="l-end">end</div>
+</div>
+
+
+{% endblock %}
+

--- a/templates/docs/layouts/full-width.md
+++ b/templates/docs/layouts/full-width.md
@@ -1,0 +1,68 @@
+---
+wrapper_template: '_layouts/docs.html'
+context:
+  title: Full-width site layout | Layouts
+---
+
+# Full-width site layout
+
+<div class="p-notification--caution">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Experimental</h5>
+    <p class="p-notification__message">
+      The full-width layout is currently considered as experimental and used only internally by Vanilla and Design sites.<br>
+      We may introduce breaking changes to it without major release.
+    </p>
+  </div>
+</div>
+
+## Structure
+
+The `.l-full-width` serves as a wrapper for full-width layout, and allows for a start (left), main (central) and end (right) areas. Usually the `l-full-width` class name would be placed on a strip component `p-strip` or an individual element. Additionally a separate `l-full-width__sidebar` element can be added to serve as a container for side navigation placed on top of the start (left) area of the layout.
+
+On screens smaller than `$breakpoint--large` the sidebar is hidden off-screen and the whole width of the page is occupied by the main content area. On larger screens the sidebar is visible on the left side of the window.
+
+### Main area
+
+Main content area is placed inside the `l-main` child element of `l-full-width` wrapper. This is the main area for the content of the page, it should be built with standard grid rows and columns.
+
+### Start and end areas
+
+Start `l-start` and end `l-end` areas are placed on the left and right side of the window. While the main area is centered on the screen, the start and end areas will alight to the sides of the window regardless of its size.
+
+<div class="p-notification--caution">
+  <div class="p-notification__content">
+    <p class="p-notification__message">
+      Standard page content should not be placed inside start or main areas, they are mostly reserved for navigation.
+    </p>
+  </div>
+</div>
+
+In the top navigation in full-width layout the logo is placed in `l-start` area (so is always aligned with left side of the screen, on top of the sidebar) and any right-aligned navigation items (such as login) are placed in the `l-end` area.
+
+<div class="embedded-example"><a href="/docs/examples/layouts/full-width/structure" class="js-example">
+View example of the full-width layout structure
+</a></div>
+
+[View the full screen example of the full-width layout structure](/docs/examples/layouts/full-width/structure).
+
+### Sidebar
+
+On pages that use side navigation `.l-full-width__sidebar` element can be added that will position a container for side navigation component on top of the start area of the full-width layout (on the left side of the screen).
+
+An aside to the left, main area to the right:
+
+<div class="embedded-example"><a href="/docs/examples/layouts/full-width/default" class="js-example">
+View example of the full-width layout with a sidebar
+</a></div>
+
+[View the full screen example of the full-width layout with a sidebar](/docs/examples/layouts/full-width/default/).
+
+## Import
+
+To import just the fluid breakout layout component into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+@import 'layouts_full-width';
+@include vf-l-full-width;
+```

--- a/templates/docs/layouts/full-width.md
+++ b/templates/docs/layouts/full-width.md
@@ -18,22 +18,22 @@ context:
 
 ## Structure
 
-The `.l-full-width` serves as a wrapper for full-width layout, and allows for a start (left), main (central) and end (right) areas. Usually the `l-full-width` class name would be placed on a strip component `p-strip` or an individual element. Additionally a separate `l-full-width__sidebar` element can be added to serve as a container for side navigation placed on top of the start (left) area of the layout.
+The `.l-full-width` serves as a wrapper for full-width layout and allows for a start (left), main (central) and end (right) areas. Usually, the `l-full-width` class name would be placed on a strip component `p-strip` or an individual element. Additionally, a separate `l-full-width__sidebar` element can be added as a container for side navigation placed on top of the start (left) area of the layout.
 
-On screens smaller than `$breakpoint--large` the sidebar is hidden off-screen and the whole width of the page is occupied by the main content area. On larger screens the sidebar is visible on the left side of the window.
+On screens smaller than `$breakpoint--large` the sidebar is hidden off-screen and the whole width of the page is occupied by the main content area. On larger screens, the sidebar is visible on the left side of the window.
 
 ### Main area
 
-Main content area is placed inside the `l-main` child element of `l-full-width` wrapper. This is the main area for the content of the page, it should be built with standard grid rows and columns.
+The main content area is placed inside the `l-main` child element of `l-full-width` wrapper. This is the main area for the content of the page, it should be built with standard grid rows and columns.
 
 ### Start and end areas
 
-Start `l-start` and end `l-end` areas are placed on the left and right side of the window. While the main area is centered on the screen, the start and end areas will alight to the sides of the window regardless of its size.
+The start `l-start` and end `l-end` areas are placed on the left and right sides of the window. While the main area is centered on the screen, the start and end areas will align to the sides of the window regardless of its size.
 
 <div class="p-notification--caution">
   <div class="p-notification__content">
     <p class="p-notification__message">
-      Standard page content should not be placed inside start or main areas, they are mostly reserved for navigation.
+      Standard page content should not be placed inside the start or end areas, they are mostly reserved for navigation.
     </p>
   </div>
 </div>
@@ -48,7 +48,7 @@ View example of the full-width layout structure
 
 ### Sidebar
 
-On pages that use side navigation `.l-full-width__sidebar` element can be added that will position a container for side navigation component on top of the start area of the full-width layout (on the left side of the screen).
+On pages that use side navigation a `.l-full-width__sidebar` element can be added that will position a container for the side navigation component on top of the start area of the full-width layout (on the left side of the screen).
 
 An aside to the left, main area to the right:
 

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -23,7 +23,7 @@ When we add, make significant updates, or deprecate a component we update their 
     <!-- 3.11.0 -->
     <tr>
       <th>
-        <a href="/docs/examples/layouts/full-width/default">
+        <a href="/docs/layouts/full-width/">
           Full-width layout
         </a>
       </th>


### PR DESCRIPTION
## Done

Adds documentation page for new full-width layout

Fixes WD-777

## QA

- Open [demo](https://vanilla-framework-4655.demos.haus/docs/layouts/full-width)
- Review the documentation and examples

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


