### PR TITLE
Fix nesting row in fixed width container

### DIFF
--- a/scss/_utilities_layout.scss
+++ b/scss/_utilities_layout.scss
@@ -3,7 +3,8 @@
     @extend %fixed-width-container;
 
     & &,
-    .row & {
+    .row &,
+    & .row {
       @include vf-b-row-reset;
     }
   }

--- a/templates/docs/examples/utilities/fixed-width-container-nesting.html
+++ b/templates/docs/examples/utilities/fixed-width-container-nesting.html
@@ -1,0 +1,26 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Fixed width container / Nesting{% endblock %}
+
+{% block content %}
+<div class="u-fixed-width">
+  <div class="u-fixed-width">
+    Nested <code>u-fixed-width</code> containers should not add additional padding.
+  </div>
+</div>
+
+<div class="u-fixed-width">
+  <div class="row">
+    <div class="col-12">
+      <code>row</code>  nested in <code>u-fixed-width</code> container should not add additional padding.
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-12">
+      <div class="u-fixed-width">
+        <code>u-fixed-width</code> container nested in <code>row</code> should not add additional padding.
+      </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Done

Fixes #4641

Fixes padding on rows nested inside fixed width container, adds an example to help catch up any regressions around that in future.

## QA

- Open [demo](/docs/examples/utilities/fixed-width-container-nesting)
- Make sure nested rows and fixed width containers don't have additional padding

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

