### PR TITLE
Update top nav font weight

### DIFF
--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -76,7 +76,7 @@
   %vf-heading-4 {
     font-size: #{map-get($font-sizes, h4-mobile)}rem;
     font-style: normal;
-    font-weight: $font-weight-regular-text;
+    font-weight: $font-weight-thin;
     line-height: map-get($line-heights, h4-mobile);
     margin-bottom: map-get($sp-after, h4-mobile) - map-get($nudges, h4-mobile);
     margin-top: 0;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -66,7 +66,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     border-radius: 0;
 
     display: block;
-    font-weight: $font-weight-bold;
+    font-weight: $font-weight-regular-text;
     line-height: map-get($line-heights, default-text);
     margin: 0;
     overflow: hidden;

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -12,6 +12,7 @@ $base-font-sizes: (
   large: $font-size-largescreen,
 ) !default;
 $font-weight-display-heading: 100 !default;
+$font-weight-thin: 300 !default;
 $font-weight-regular-text: 400 !default;
 $font-weight-bold: 550 !default;
 


### PR DESCRIPTION
## Done

Update font weight of top navigation items.

Fixes #4634
 
## QA

- Open [demo](https://vanilla-framework-4658.demos.haus/)
- Check if top nav has correct font weight

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [X] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [X] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

