### PR TITLE
Fix the calculation of hr margin

### DIFF
--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -6,7 +6,7 @@
   hr {
     @extend %hr;
 
-    margin-bottom: calc($spv--small - $input-border-thickness);
+    margin-bottom: calc($spv--small - 1px);
 
     &.u-no-margin--bottom {
       // compensate for hr thickness, to make sure it doesn't drift from baseline grid


### PR DESCRIPTION
## Done

Fix wrongly calculated bottom margin of hr.

Fixes #4659 

## QA

- Open [demo](https://vanilla-framework-4660.demos.haus/docs/examples/base/hr)
- Make sure bottom margin is correctly offset by 1px (width of the hr)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.

