### PR TITLE
Add missing secret for upload-assets snap

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -62,3 +62,5 @@ jobs:
         run: sudo snap install upload-assets
       - name: Upload to assets server
         run: upload-assets --url-path vanilla-framework-version-$(cat css/VANILLA_VERSION).min.css css/build.css
+        env:
+          UPLOAD_ASSETS_API_TOKEN: ${{secrets.UPLOAD_ASSETS_API_TOKEN}}


### PR DESCRIPTION
## Done

Fix missing secret in asset upload step of release process…

## QA

- Review code
- compare with how it looked initially: https://github.com/canonical/vanilla-framework/blob/29d0e0914ad2a616cd053d4a254f0ed756c336fd/.github/workflows/publish-on-release.yml
-  keep fingers crossed until next release…


