### PR TITLE
Fix font size of all caps text component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "vanilla-framework",
+  "version": "3.12.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"
@@ -20,7 +22,6 @@
     "module"
   ],
   "license": "LGPL-3.0",
-  "name": "vanilla-framework",
   "repository": {
     "type": "git",
     "url": "https://github.com/canonical/vanilla-framework"
@@ -47,7 +48,6 @@
     "percy": "percy exec -- node snapshots.js",
     "icon-svgs-to-mixins": "node scripts/convert-svgs-to-icon-mixins.js icons"
   },
-  "version": "3.11.1",
   "files": [
     "_index.scss",
     "/scss",

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -7,6 +7,7 @@
 /js/(?P<path>.*): /static/js/{path}
 /docs/component-status: /docs/whats-new
 /docs/upgrade-guide-v3: /docs/migration-guide-to-v3
+/docs/examples/patterns/x-small-capitalised: /docs/examples/patterns/text-small-caps
 
 # redirects based on class names
 /docs/patterns/code-snippet: /docs/base/code

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -214,6 +214,14 @@
     &.u-no-margin--bottom {
       @extend %u-no-margin--bottom--small;
     }
+
+    // deprecated: the use of .u-align-text--x-small-to-default on small caps text is deprecated
+    // previously small caps was implemented as x-small text variant requiring .u-align-text--x-small-to-default compensations
+    // but now it's implemented with default text size not requiring any compensations,
+    // so we need to reset the padding-top to the default value
+    &.u-align-text--x-small-to-default {
+      padding-top: map-get($nudges, p) + map-get($browser-rounding-compensations, p);
+    }
   }
 
   %table-header-label {

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -146,6 +146,8 @@
 
   %default-text {
     @extend %common-default-text-properties;
+    font-size: 1rem;
+    font-weight: $font-weight-regular-text;
 
     margin-bottom: map-get($sp-after, default-text) - map-get($nudges, p);
   }
@@ -204,7 +206,7 @@
   }
 
   %small-caps-text {
-    @extend %common-default-text-properties;
+    @extend %default-text;
     font-variant-caps: all-small-caps;
     letter-spacing: 0.05em;
     margin-bottom: map-get($sp-after, default-text) - map-get($nudges, p);
@@ -219,8 +221,7 @@
   }
 
   %muted-heading {
-    @extend %muted-text;
-    @extend %table-header-label;
+    @extend %small-caps-text;
 
     &.u-no-margin--bottom {
       @extend %u-no-margin--bottom--small;

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -210,6 +210,10 @@
     font-variant-caps: all-small-caps;
     letter-spacing: 0.05em;
     margin-bottom: map-get($sp-after, default-text) - map-get($nudges, p);
+
+    &.u-no-margin--bottom {
+      @extend %u-no-margin--bottom--small;
+    }
   }
 
   %table-header-label {
@@ -220,12 +224,9 @@
     text-transform: uppercase;
   }
 
+  // deprecated: %muted-text is deprecated, use %small-caps-text instead
   %muted-heading {
     @extend %small-caps-text;
-
-    &.u-no-margin--bottom {
-      @extend %u-no-margin--bottom--small;
-    }
   }
 
   %bold {

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -78,6 +78,8 @@
     @extend %x-small-text;
   }
 
+  .p-text--small-caps,
+  // deprecated: .p-text--x-small-capitalised is deprecated, use .p-text--small-caps instead
   .p-text--x-small-capitalised {
     @extend %small-caps-text;
   }

--- a/scss/_patterns_muted-heading.scss
+++ b/scss/_patterns_muted-heading.scss
@@ -1,5 +1,6 @@
+// deprecated: .p-muted-heading and vf-p-muted-heading is deprecated, use .p-text--small-caps instead
 @mixin vf-p-muted-heading {
   .p-muted-heading {
-    @extend %muted-heading;
+    @extend %small-caps-text;
   }
 }

--- a/templates/docs/base/typography.md
+++ b/templates/docs/base/typography.md
@@ -148,13 +148,17 @@ View example of the base blockquotes
 View example of the small text
 </a></div>
 
-## Extra small capitalised text
+## Small caps text
 
-Extra small capitalised text is used to style column headers in tables. This styling has proved useful in other contexts. To apply it, add the class `p-text--x-small-capitalised`.
+Small caps text is used to style column headers in tables. This styling has proved useful in other contexts. To apply it, add the class `p-text--small-caps`.
 
-<div class="embedded-example"><a href="/docs/examples/patterns/x-small-capitalised/" class="js-example">
-View example of the extra small capitalised text
+<div class="embedded-example"><a href="/docs/examples/patterns/text-small-caps/" class="js-example">
+View example of the small caps text
 </a></div>
+
+<span class="p-status-label--negative">Deprecated</span>
+
+Previously this style was implemented as `.p-text--x-small-capitalised` class name. This name is now deprecated and will be removed in next major version of Vanilla, please use `.p-text--small-caps` instead.
 
 ## Baseline alignment: small, extra small and paragraph text
 

--- a/templates/docs/base/typography.md
+++ b/templates/docs/base/typography.md
@@ -169,6 +169,10 @@ In some cases, for example when used on the same line, it can be useful to align
 View example of baseline alignment of paragraph, small, extra small text
 </a></div>
 
+<span class="p-status-label--negative">Deprecated</span>
+
+Small caps style used to be implemented as extra small text variant with `.p-text--x-small-capitalised` class name that required the `.u-align-text--x-small-to-default` utility to align the baseline. This is not the case any more, so usage of this utility with new `.p-text--small-caps` (and its deprecated equivalent `.p-text--x-small-capitaised`) is deprecated and can be removed.
+
 ## Strong text
 
 <div class="embedded-example"><a href="/docs/examples/base/strong/" class="js-example">

--- a/templates/docs/examples/patterns/text-small-caps.html
+++ b/templates/docs/examples/patterns/text-small-caps.html
@@ -1,0 +1,6 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Small caps text{% endblock %}
+
+{% block content %}
+<p class="p-text--small-caps">small caps text</p>
+{% endblock %}

--- a/templates/docs/examples/patterns/x-small-capitalised.html
+++ b/templates/docs/examples/patterns/x-small-capitalised.html
@@ -1,6 +1,0 @@
-{% extends "_layouts/examples.html" %}
-{% block title %}Extra small capitalised text{% endblock %}
-
-{% block content %}
-<p class="p-text--x-small-capitalised">extra small capitalised text</p>
-{% endblock %}

--- a/templates/docs/examples/utilities/align-by-baseline.html
+++ b/templates/docs/examples/utilities/align-by-baseline.html
@@ -10,6 +10,6 @@
     <div class="u-align-text--small-to-default p-text--small">small text</div>
   </div>
   <div class="col-8">
-    <p class="p-text--small-caps u-align-text--x-small-to-default">extra small capitalised text</p>
+    <p class="p-text--x-small u-align-text--x-small-to-default">extra small text</p>
   </div>
 {% endblock %}

--- a/templates/docs/examples/utilities/align-by-baseline.html
+++ b/templates/docs/examples/utilities/align-by-baseline.html
@@ -10,6 +10,6 @@
     <div class="u-align-text--small-to-default p-text--small">small text</div>
   </div>
   <div class="col-8">
-    <p class="p-text--x-small-capitalised u-align-text--x-small-to-default">extra small capitalised text</p>
+    <p class="p-text--small-caps u-align-text--x-small-to-default">extra small capitalised text</p>
   </div>
 {% endblock %}

--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -20,19 +20,30 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
-    <!-- 3.11.0 -->
+    <!-- 3.12.0 -->
     <tr>
       <th>
-        <a href="/docs/layouts/full-width/">
-          Full-width layout
+        <a href="/docs/base/typography#small-caps-text">
+          Small caps text
         </a>
       </th>
       <td>
-        <span class="p-status-label--positive">New</span>
+        <span class="p-status-label--information">Updated</span>
       </td>
-      <td>3.11.0</td>
-      <td>We are introducing new full-width site layout.
-      <p><i class="p-icon--warning"></i> This is an experimental feature, currenly meant for internal use on our design system site and docs.</p></td>
+      <td>3.12.0</td>
+      <td>We updated the style of small caps text and introduced new class name <code>p-text--small-caps</code> in place of previous <code>p-text--x-small-capitalised</code>.</td>
+    </tr>
+    <tr>
+      <th>
+        <a href="/docs/base/typography#small-caps-text">
+          Extra small capitalised text
+        </a>
+      </th>
+      <td>
+        <span class="p-status-label--negative">Deprecated</span>
+      </td>
+      <td>3.12.0</td>
+      <td>We are deprecating <code>p-text--x-small-capitalised</code>. New <code>p-text--small-caps</code> should be used instead. At the same time usage of <code>u-align-text--x-small-to-default</code> utility is deprecated with both of these class names as well, as they don't need it anymore.</td>
     </tr>
   </tbody>
 </table>
@@ -49,6 +60,20 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
+    <!-- 3.11.0 -->
+    <tr>
+      <th>
+        <a href="/docs/layouts/full-width/">
+          Full-width layout
+        </a>
+      </th>
+      <td>
+        <span class="p-status-label--positive">New</span>
+      </td>
+      <td>3.11.0</td>
+      <td>We are introducing new full-width site layout.
+      <p><i class="p-icon--warning"></i> This is an experimental feature, currenly meant for internal use on our design system site and docs.</p></td>
+    </tr>
     <!-- 3.10.0 -->
     <tr>
       <th>


### PR DESCRIPTION
## Done

- Make sure small caps text always has correct font size.
- Make sure muted heading uses new small caps style.
- Rename `p-text--x-small-capitalised` to `p-text--small-caps`.
- Deprecate old name (comments in the code and documentation).
- Fix the `u-align-text--x-small-to-default` usage on new style of small caps

Fixes #4662 #4664 

## QA

Demo: 

- Open [demo](https://vanilla-framework-4665.demos.haus/docs/examples/patterns/text-small-caps)
  - make sure it looks ok
  - change the element to header (like h2) and make sure the font size is not affected
  - add `u-align-text--x-small-to-default` and make sure the style is not affected
- Make sure muted heading uses same small caps style:
  - https://vanilla-framework-4665.demos.haus/docs/examples/patterns/headings/muted
- Review updated documentation:
  - https://vanilla-framework-4665.demos.haus/docs/base/typography#small-caps-text
  - https://vanilla-framework-4665.demos.haus/docs/whats-new
 
### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [X] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [X] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

<img width="1127" alt="image" src="https://user-images.githubusercontent.com/83575/220665471-5ec3c8ad-9607-4fb1-945a-e234ab2c601e.png">
