### PR TITLE
Use chevron icon in article pagination

### DIFF
--- a/scss/_patterns_article-pagination.scss
+++ b/scss/_patterns_article-pagination.scss
@@ -7,7 +7,7 @@
 
     content: '';
     position: absolute;
-    top: 1.25rem;
+    top: calc($spv--large + $spv--x-small);
   }
 
   .p-article-pagination {
@@ -74,8 +74,8 @@
     &::before {
       @extend %chevron-icon;
 
-      transform: rotate(90deg);
       left: $sp-small;
+      transform: rotate(90deg);
     }
   }
 
@@ -96,8 +96,8 @@
     &::after {
       @extend %chevron-icon;
 
-      transform: rotate(-90deg);
       right: $sp-small;
+      transform: rotate(-90deg);
     }
   }
 }

--- a/scss/_patterns_article-pagination.scss
+++ b/scss/_patterns_article-pagination.scss
@@ -2,11 +2,12 @@
 
 @mixin vf-p-article-pagination {
   %chevron-icon {
-    color: $color-mid-dark;
-    content: '\203A';
-    font-size: 2em;
+    @extend %icon;
+    @include vf-icon-chevron($color-mid-dark);
+
+    content: '';
     position: absolute;
-    top: 1rem;
+    top: 1.25rem;
   }
 
   .p-article-pagination {
@@ -73,8 +74,8 @@
     &::before {
       @extend %chevron-icon;
 
+      transform: rotate(90deg);
       left: $sp-small;
-      transform: scaleX(-1);
     }
   }
 
@@ -95,6 +96,7 @@
     &::after {
       @extend %chevron-icon;
 
+      transform: rotate(-90deg);
       right: $sp-small;
     }
   }


### PR DESCRIPTION
## Done

- change article pagination chevrons to dedicated icon

Fixes #4604

## QA

- Open [demo](https://vanilla-framework-4669.demos.haus/docs/examples/patterns/article-pagination)
- Make sure it uses chevron icons instead of text.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

- before
<img width="880" alt="1" src="https://user-images.githubusercontent.com/46718614/221610504-58ff80d1-503b-4011-9ff3-ab171aaa59e3.png">
<img width="880" alt="4" src="https://user-images.githubusercontent.com/46718614/221610582-d5dee9b7-e212-4f81-aca3-3fd13a7ed33d.png">
- after
<img width="880" alt="2" src="https://user-images.githubusercontent.com/46718614/221610626-6c763b3a-3059-44a7-82dd-e5782f939643.png">
<img width="880" alt="3" src="https://user-images.githubusercontent.com/46718614/221610650-a2c23f55-81a8-4c15-8c0a-48a975c3a992.png">
