### PR TITLE
Fixed hex code for color-mid-light + a couple of typos

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -127,7 +127,7 @@
 
               <ul class="p-side-navigation__list">
                 <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Layouts</span></li>
-                {{ side_nav_item("/docs/layouts/application", "Application", "Updated", "information") }}
+                {{ side_nav_item("/docs/layouts/application", "Application") }}
                 {{ side_nav_item("/docs/layouts/documentation", "Documentation") }}
                 {{ side_nav_item("/docs/layouts/fluid-breakout", "Fluid breakout") }}
                 {{ side_nav_item("/docs/layouts/full-width", "Full-width") }}
@@ -139,7 +139,7 @@
                 {{ side_nav_item("/docs/settings/animation-settings", "Animations") }}
                 {{ side_nav_item("/docs/settings/assets-settings", "Assets") }}
                 {{ side_nav_item("/docs/settings/breakpoint-settings", "Breakpoints") }}
-                {{ side_nav_item("/docs/settings/color-settings", "Color", "Updated", "information") }}
+                {{ side_nav_item("/docs/settings/color-settings", "Color") }}
                 {{ side_nav_item("/docs/settings/font-settings", "Font") }}
                 {{ side_nav_item("/docs/settings/layout-settings", "Layout") }}
                 {{ side_nav_item("/docs/settings/placeholder-settings", "Placeholders") }}

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -127,7 +127,7 @@
 
               <ul class="p-side-navigation__list">
                 <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Layouts</span></li>
-                {{ side_nav_item("/docs/layouts/application", "Application") }}
+                {{ side_nav_item("/docs/layouts/application", "Application", "Updated", "information") }}
                 {{ side_nav_item("/docs/layouts/documentation", "Documentation") }}
                 {{ side_nav_item("/docs/layouts/fluid-breakout", "Fluid breakout") }}
                 {{ side_nav_item("/docs/layouts/full-width", "Full-width") }}
@@ -139,7 +139,7 @@
                 {{ side_nav_item("/docs/settings/animation-settings", "Animations") }}
                 {{ side_nav_item("/docs/settings/assets-settings", "Assets") }}
                 {{ side_nav_item("/docs/settings/breakpoint-settings", "Breakpoints") }}
-                {{ side_nav_item("/docs/settings/color-settings", "Color") }}
+                {{ side_nav_item("/docs/settings/color-settings", "Color", "Updated", "information") }}
                 {{ side_nav_item("/docs/settings/font-settings", "Font") }}
                 {{ side_nav_item("/docs/settings/layout-settings", "Layout") }}
                 {{ side_nav_item("/docs/settings/placeholder-settings", "Placeholders") }}

--- a/templates/docs/layouts/application.md
+++ b/templates/docs/layouts/application.md
@@ -90,7 +90,7 @@ The panel component (`p-panel`) is an integral part of the application layout. I
 
 ### Panel header
 
-The panel header (`p-panel__header`) may contain the panel title (`p-panel__title`) or logo (`p-pabel__logo`) on the left and any action buttons (`p-pabel__controls`) to the right. Panel header can be optionally made sticky while scrolling by adding `is-sticky` modifier class to the `p-panel__header` element.
+The panel header (`p-panel__header`) may contain the panel title (`p-panel__title`) or logo (`p-panel__logo`) on the left and any action buttons (`p-panel__controls`) to the right. Panel header can be optionally made sticky while scrolling by adding `is-sticky` modifier class to the `p-panel__header` element.
 
 ## Panels example
 

--- a/templates/docs/settings/color-settings.md
+++ b/templates/docs/settings/color-settings.md
@@ -31,9 +31,9 @@ These guidelines are the framework upon which we have built our system for how c
       </p>
     </div>
     <div class="col-2 p-card u-no-padding">
-      <div class="p-strip is-shallow is-bordered" style="background-color: #cdcdcd"></div>
+      <div class="p-strip is-shallow is-bordered" style="background-color: #d9d9d9"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
-        $color-mid-light<br><span class="p-muted-heading">#cdcdcd</span>
+        $color-mid-light<br><span class="p-muted-heading">#d9d9d9</span>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

Fixes a couple of typos in docs pages.

- Two typos in Application Layout docs page (pabel -> panel)
- Wrong hex code for `color-mid-light` in Color docs page.

## QA

- Open [demo](https://vanilla-framework-4670.demos.haus/)
- Review updated documentation:
  - [/docs/layouts/application](https://vanilla-framework-4670.demos.haus/docs/layouts/application)
  - [/docs/settings/color-settings](https://vanilla-framework-4670.demos.haus/docs/settings/color-settings)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Documentation side navigation should be updated with the relevant labels.