### PR TITLE
Set white background for search and filter dropdown [WD-2279]

### DIFF
--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -72,7 +72,7 @@
     .p-search-and-filter__panel {
       @include vf-transition(opacity, fast);
 
-      background-color: $colors--light-theme--background-inputs;
+      background-color: $color-x-light;
       border-radius: $border-radius;
       box-shadow: $box-shadow;
       opacity: 1;


### PR DESCRIPTION
## Done

Set white background for search and filter dropdown.
Fixes https://github.com/canonical/vanilla-framework/issues/4654

## QA

- Open [demo](https://vanilla-framework-4671.demos.haus/)
- Go to '[search and filter documentation](https://vanilla-framework-4671.demos.haus/docs/patterns/search-and-filter)'
- Click on the search and filter input
- Dropdown opens
- Dropdown background is now white

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.