### PR TITLE
Revert What's new page to 3.12 release

### DIFF
--- a/templates/docs/whats-new.md
+++ b/templates/docs/whats-new.md
@@ -20,7 +20,7 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
-    <!-- 3.13.0 -->
+    <!-- 3.12.0 -->
     <tr>
       <th>
         <a href="/docs/patterns/logo-section#dense">
@@ -30,25 +30,9 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>
         <span class="p-status-label--information">Updated</span>
       </td>
-      <td>3.13.0</td>
+      <td>3.12.0</td>
       <td>We've introduced a new dense version of the logo section that spans a single column.</td>
     </tr>
-  </tbody>
-</table>
-
-## Previously in Vanilla v3
-
-<table aria-label="Previously in Vanilla v3">
-  <thead>
-    <tr>
-      <th style="width: 20%">Component</th>
-      <th style="width: 15%">Status</th>
-      <th style="width: 10%">Version</th>
-      <th style="width: 55%">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
-    <!-- 3.12.0 -->
     <tr>
       <th>
         <a href="/docs/patterns/lists">
@@ -86,6 +70,21 @@ When we add, make significant updates, or deprecate a component we update their 
       <td>3.12.0</td>
       <td>We are deprecating <code>p-text--x-small-capitalised</code>. New <code>p-text--small-caps</code> should be used instead. At the same time usage of <code>u-align-text--x-small-to-default</code> utility is deprecated with both of these class names as well, as they don't need it anymore.</td>
     </tr>
+  </tbody>
+</table>
+
+## Previously in Vanilla v3
+
+<table aria-label="Previously in Vanilla v3">
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
     <!-- 3.11.0 -->
     <tr>
       <th>


### PR DESCRIPTION
## Done

Fixed "what's new" page with reverted version 3.12.

## QA

- Open [demo](https://vanilla-framework-4673.demos.haus/docs/whats-new)
- Make sure last version is 3.12 and all 3.12 changes are correctly listed in top table.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.


## Screenshots

<img width="1328" alt="image" src="https://user-images.githubusercontent.com/83575/221856874-cbc231b2-203b-4a7c-89b4-d3ed8278be33.png">
