### PR TITLE
Fix stepped list in dark mode didn't show numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -30,6 +30,10 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
       position: absolute;
       text-align: center;
     }
+
+    p-strip--dark &::before {
+      background-color: $color-x-dark;
+    }
   }
 
   %nested-counter {

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -30,10 +30,6 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
       position: absolute;
       text-align: center;
     }
-
-    p-strip--dark &::before {
-      background-color: $color-x-dark;
-    }
   }
 
   %nested-counter {
@@ -336,6 +332,10 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
         line-height: calc($bullet-width - 2px);
         width: $bullet-width;
       }
+    }
+    .p-strip--dark &::before {
+      background-color: $color-x-dark;
+      border: 1px solid $color-x-light;
     }
   }
 

--- a/scss/standalone/patterns_lists.scss
+++ b/scss/standalone/patterns_lists.scss
@@ -1,4 +1,5 @@
 @import '../vanilla';
 @include vf-base;
 
+@include vf-p-strip;
 @include vf-p-lists;

--- a/templates/docs/examples/patterns/lists/lists-stepped-dark.html
+++ b/templates/docs/examples/patterns/lists/lists-stepped-dark.html
@@ -1,0 +1,69 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Lists / Stepped{% endblock %}
+
+{% block standalone_css %}patterns_lists{% endblock %}
+
+{% block content %}
+<div class="p-strip--dark">
+
+  <ol class="p-stepped-list">
+    <li class="p-stepped-list__item">
+      <h3 class="p-stepped-list__title">
+        Log in to JAAS
+      </h3>
+      <p class="p-stepped-list__content">Ensure you have an Ubuntu SSO account before contacting JAAS. Log in to JAAS now.</p>
+    </li>
+  
+    <li class="p-stepped-list__item">
+      <h3 class="p-stepped-list__title">
+        Configure a model
+      </h3>
+      <p class="p-stepped-list__content">Applications are contained within models and are installed via charms. Configure your model by pressing the "Start a new model" button.</p>
+    </li>
+  
+    <li class="p-stepped-list__item">
+      <h3 class="p-stepped-list__title">
+        Credentials and SSH keys
+      </h3>
+      <p class="p-stepped-list__content">After having selected a cloud, a form will appear for submitting your credentials to JAAS. The below resources are available if you need help with gathering credentials.</p>
+    </li>
+  
+    <li class="p-stepped-list__item">
+      <h3 class="p-stepped-list__title">
+        Design and&nbsp;<strong>build</strong>
+      </h3>
+      <p class="p-stepped-list__content">Together, we design your Kubernetes cluster based on your hardware, scale, roadmap, applications and monitoring system. We'll guide you through the hardware specification process to maximise the efficiency of your CAPEX, and we'll tailor the architecture of your cloud to meet your application, security, regulatory and integration requirements.</p>
+    </li>
+  </ol>
+  
+  <ol class="p-stepped-list">
+    <li class="p-stepped-list__item">
+      <h4 class="p-stepped-list__title">
+        Log in to JAAS
+      </h4>
+      <p class="p-stepped-list__content">Ensure you have an Ubuntu SSO account before contacting JAAS. Log in to JAAS now.</p>
+    </li>
+  
+    <li class="p-stepped-list__item">
+      <h4 class="p-stepped-list__title">
+        Configure a model
+      </h4>
+      <p class="p-stepped-list__content">Applications are contained within models and are installed via charms. Configure your model by pressing the "Start a new model" button.</p>
+    </li>
+  
+    <li class="p-stepped-list__item">
+      <h4 class="p-stepped-list__title">
+        Credentials and SSH keys
+      </h4>
+      <p class="p-stepped-list__content">After having selected a cloud, a form will appear for submitting your credentials to JAAS. The below resources are available if you need help with gathering credentials.</p>
+    </li>
+  
+    <li class="p-stepped-list__item">
+      <h4 class="p-stepped-list__title">
+        Design and&nbsp;<strong>build</strong>
+      </h4>
+      <p class="p-stepped-list__content">Together, we design your Kubernetes cluster based on your hardware, scale, roadmap, applications and monitoring system. We'll guide you through the hardware specification process to maximise the efficiency of your CAPEX, and we'll tailor the architecture of your cloud to meet your application, security, regulatory and integration requirements.</p>
+    </li>
+  </ol>
+</div>
+{% endblock %}

--- a/templates/docs/examples/patterns/lists/lists-stepped-dark.html
+++ b/templates/docs/examples/patterns/lists/lists-stepped-dark.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Lists / Stepped{% endblock %}
+{% block title %}Lists / Stepped / Dark{% endblock %}
 
 {% block standalone_css %}patterns_lists{% endblock %}
 


### PR DESCRIPTION
## Done

Fixed issue of numbers not being displayed correctly on stepped lists

Fixes #4656 

## QA

- Open [demo](https://vanilla-framework-4674.demos.haus/docs/examples/patterns/lists/lists-stepped-dark)
- The numbers in the title should be white over a dark background
- Review updated documentation:
  - No update in new classnames 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.


## Screenshots

![image](https://user-images.githubusercontent.com/30973042/222099412-65f0e375-e99d-4441-bf2a-28062a4377f5.png)
