### PR TITLE
Add u-has-icon utility class [WD-2275]

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1,5 +1,9 @@
 - version: 3.12.0
   features:
+    - component: Text with icon utility class
+      url: /docs/utilities/has-icon
+      status: New
+      notes: We've introduced a new utility class that allows to place an icon next to some text with correct spacing.
     - component: Dense Logo Section
       url: /docs/patterns/logo-section#dense
       status: Updated

--- a/scss/_utilities_has-icon.scss
+++ b/scss/_utilities_has-icon.scss
@@ -1,6 +1,5 @@
 @mixin vf-u-has-icon {
-  // stylelint-disable-next-line selector-max-type
-  .u-has-icon i:first-child {
+  .u-has-icon [class*='p-icon--']:first-child {
     margin-right: $sph--small;
     margin-top: $spv--small;
   }

--- a/scss/_utilities_has-icon.scss
+++ b/scss/_utilities_has-icon.scss
@@ -1,0 +1,7 @@
+@mixin vf-u-has-icon {
+  // stylelint-disable-next-line selector-max-type
+  .u-has-icon i:first-child {
+    margin-right: $sph--small;
+    margin-top: $spv--small;
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -67,6 +67,7 @@
 @import 'utilities_equal-height';
 @import 'utilities_floats';
 @import 'utilities_font-metrics';
+@import 'utilities_has-icon';
 @import 'utilities_hide';
 @import 'utilities_image-position';
 @import 'utilities_layout';
@@ -150,6 +151,7 @@
   @include vf-u-embedded-media;
   @include vf-u-equal-height;
   @include vf-u-floats;
+  @include vf-u-has-icon;
   @include vf-u-image-position;
   @include vf-u-layout;
   @include vf-u-margin-collapse;

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -122,16 +122,16 @@
                 {{ side_nav_item("/docs/utilities/floats", "Floats") }}
                 {{ side_nav_item("/docs/utilities/font-metrics", "Font metrics") }}
                 {{ side_nav_item("/docs/utilities/functions", "Functions") }}
-                {{ side_nav_item("/docs/utilities/has-icon", "Has-icon", "New", "information") }}
                 {{ side_nav_item("/docs/utilities/hide", "Hide") }}
                 {{ side_nav_item("/docs/utilities/image-position", "Image position") }}
                 {{ side_nav_item("/docs/utilities/margin-collapse", "Margin collapse") }}
                 {{ side_nav_item("/docs/utilities/no-print", "No print") }}
                 {{ side_nav_item("/docs/utilities/off-screen", "Off-screen") }}
                 {{ side_nav_item("/docs/utilities/padding-collapse", "Padding collapse") }}
-                {{ side_nav_item("/docs/utilities/table-cell-padding-overlap", "Table cell padding overlap") }}
-                {{ side_nav_item("/docs/utilities/truncate", "Truncation") }}
                 {{ side_nav_item("/docs/utilities/show", "Show") }}
+                {{ side_nav_item("/docs/utilities/table-cell-padding-overlap", "Table cell padding overlap") }}
+                {{ side_nav_item("/docs/utilities/has-icon", "Text with icon") }}
+                {{ side_nav_item("/docs/utilities/truncate", "Truncation") }}
                 {{ side_nav_item("/docs/utilities/vertical-spacing", "Vertical spacing") }}
                 {{ side_nav_item("/docs/utilities/vertically-center", "Vertically center") }}
               </ul>

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -122,6 +122,7 @@
                 {{ side_nav_item("/docs/utilities/floats", "Floats") }}
                 {{ side_nav_item("/docs/utilities/font-metrics", "Font metrics") }}
                 {{ side_nav_item("/docs/utilities/functions", "Functions") }}
+                {{ side_nav_item("/docs/utilities/has-icon", "Has-icon", "New", "information") }}
                 {{ side_nav_item("/docs/utilities/hide", "Hide") }}
                 {{ side_nav_item("/docs/utilities/image-position", "Image position") }}
                 {{ side_nav_item("/docs/utilities/margin-collapse", "Margin collapse") }}

--- a/templates/docs/examples/utilities/text-with-icon.html
+++ b/templates/docs/examples/utilities/text-with-icon.html
@@ -1,0 +1,6 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Text / With icon{% endblock %}
+
+{% block content %}
+<span class="u-has-icon"><i class="p-icon--success"></i>Done</span>
+{% endblock %}

--- a/templates/docs/utilities/has-icon.md
+++ b/templates/docs/utilities/has-icon.md
@@ -1,0 +1,30 @@
+---
+wrapper_template: '_layouts/docs.html'
+context:
+  title: Has-icon | Utilities
+---
+
+# Has-icon
+
+<hr>
+
+To place an icon next to some text with correct spacing, use the class `u-has-icon` on the parent element.
+
+<div class="embedded-example"><a href="/docs/examples/utilities/text-with-icon" class="js-example">
+View example of the Has-icon utility
+</a></div>
+
+## Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework';
+@include vf-base;
+
+@include vf-u-has-icon;
+```
+
+For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/utilities/has-icon.md
+++ b/templates/docs/utilities/has-icon.md
@@ -1,17 +1,17 @@
 ---
 wrapper_template: '_layouts/docs.html'
 context:
-  title: Has-icon | Utilities
+  title: Text with icon | Utilities
 ---
 
-# Has-icon
+# Text with icon
 
 <hr>
 
 To place an icon next to some text with correct spacing, use the class `u-has-icon` on the parent element.
 
 <div class="embedded-example"><a href="/docs/examples/utilities/text-with-icon" class="js-example">
-View example of the Has-icon utility
+View example of the Text with icon utility
 </a></div>
 
 ## Import


### PR DESCRIPTION
## Done

Added `u-has-icon` utility class.

Fixes https://github.com/canonical/vanilla-framework/issues/3102

## QA

- Open [example](https://vanilla-framework-4677.demos.haus/docs/examples/utilities/text-with-icon)
- Check spacing between icon and text.
- Review new documentation:
  - [Has-icon](https://vanilla-framework-4677.demos.haus/docs/utilities/has-icon)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.