### PR TITLE
abstract side navigation to YAML file

### DIFF
--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -1,0 +1,178 @@
+- heading: Welcome
+  subheadings:
+    - title: Get started
+      url: /docs
+    - title: Building with Vanilla
+      url: /docs/building-vanilla
+    - title: Customising Vanilla
+      url: /docs/customising-vanilla
+    - title: What's new in %version
+      url: /docs/whats-new
+    - title: Migrating to v3.0
+      url: /docs/migration-guide-to-v3
+- heading: Base elements
+  subheadings:
+    - title: Code
+      url: /docs/base/code
+    - title: Forms
+      url: /docs/base/forms
+    - title: Reset
+      url: /docs/base/reset
+    - title: Separators
+      url: /docs/base/separators
+    - title: Tables
+      url: /docs/base/tables
+    - title: Typography
+      url: /docs/base/typography
+- heading: Components
+  subheadings:
+    - title: Accordion
+      url: /docs/patterns/accordion
+    - title: Badge
+      url: /docs/patterns/badge
+    - title: Breadcrumbs
+      url: /docs/patterns/breadcrumbs
+    - title: Buttons
+      url: /docs/patterns/buttons
+    - title: Cards
+      url: /docs/patterns/card
+    - title: Chips
+      url: /docs/patterns/chip
+    - title: Contextual menu
+      url: /docs/patterns/contextual-menu
+    - title: Divider
+      url: /docs/patterns/divider
+    - title: Empty state
+      url: /docs/patterns/empty-state
+    - title: Grid
+      url: /docs/patterns/grid
+    - title: Heading icon
+      url: /docs/patterns/heading-icon
+    - title: Icons
+      url: /docs/patterns/icons
+    - title: Images
+      url: /docs/patterns/images
+    - title: Links
+      url: /docs/patterns/links
+    - title: List tree
+      url: /docs/patterns/list-tree
+    - title: Lists
+      url: /docs/patterns/lists
+    - title: Logo section
+      url: /docs/patterns/logo-section
+    - title: Updated information Matrix
+      url: /docs/patterns/matrix
+    - title: Media object
+      url: /docs/patterns/media-object
+    - title: Modal
+      url: /docs/patterns/modal
+    - title: Muted heading
+      url: /docs/patterns/muted-heading
+    - title: Navigation
+      url: /docs/patterns/navigation
+    - title: Notifications
+      url: /docs/patterns/notification
+    - title: Pagination
+      url: /docs/patterns/pagination
+    - title: Quotes
+      url: /docs/patterns/pull-quote
+    - title: Search and filter
+      url: /docs/patterns/search-and-filter
+    - title: Search box
+      url: /docs/patterns/search-box
+    - title: Segmented control
+      url: /docs/patterns/segmented-control
+    - title: Slider
+      url: /docs/patterns/slider
+    - title: Status labels
+      url: /docs/patterns/status-labels
+    - title: Strip
+      url: /docs/patterns/strip
+    - title: Switch
+      url: /docs/patterns/switch
+    - title: Table of contents
+      url: /docs/patterns/table-of-contents
+    - title: Tabs
+      url: /docs/patterns/tabs
+    - title: Tooltips
+      url: /docs/patterns/tooltips
+- heading: Utilities
+  subheadings:
+    - title: Align
+      url: /docs/utilities/align
+    - title: Baseline grid
+      url: /docs/utilities/baseline-grid
+    - title: Clearfix
+      url: /docs/utilities/clearfix
+    - title: Embedded media
+      url: /docs/utilities/embedded-media
+    - title: Equal height
+      url: /docs/utilities/equal-height
+    - title: Floats
+      url: /docs/utilities/floats
+    - title: Font metrics
+      url: /docs/utilities/font-metrics
+    - title: Functions
+      url: /docs/utilities/functions
+    - title: Hide
+      url: /docs/utilities/hide
+    - title: Image position
+      url: /docs/utilities/image-position
+    - title: Margin collapse
+      url: /docs/utilities/margin-collapse
+    - title: No print
+      url: /docs/utilities/no-print
+    - title: Off-screen
+      url: /docs/utilities/off-screen
+    - title: Padding collapse
+      url: /docs/utilities/padding-collapse
+    - title: Table cell padding overlap
+      url: /docs/utilities/table-cell-padding-overlap
+    - title: Truncation
+      url: /docs/utilities/truncate
+    - title: Show
+      url: /docs/utilities/show
+    - title: Vertical spacing
+      url: /docs/utilities/vertical-spacing
+    - title: Vertically center
+      url: /docs/utilities/vertically-center
+- heading: Layouts
+  subheadings:
+    - title: Application
+      url: /docs/layouts/application
+    - title: Documentation
+      url: /docs/layouts/documentation
+    - title: Fluid breakout
+      url: /docs/layouts/fluid-breakout
+    - title: Full-width
+      url: /docs/layouts/full-width
+    - title: Sticky footer
+      url: /docs/layouts/sticky-footer
+- heading: Settings
+  subheadings:
+    - title: Animations
+      url: /docs/settings/animation-settings
+    - title: Assets
+      url: /docs/settings/assets-settings
+    - title: Breakpoints
+      url: /docs/settings/breakpoint-settings
+    - title: Color
+      url: /docs/settings/color-settings
+    - title: Font
+      url: /docs/settings/font-settings
+    - title: Layout
+      url: /docs/settings/layout-settings
+    - title: Placeholders
+      url: /docs/settings/placeholder-settings
+    - title: Spacing
+      url: /docs/settings/spacing-settings
+    - title: Table layout
+      url: /docs/settings/table-layout
+- heading: Resources
+  subheadings:
+    - title: Component examples
+      url: /docs/examples
+    - title: Release notes for %version
+      url: https://github.com/canonical/vanilla-framework/releases/latest
+    - title: Download Sketch UI Kit
+      url: https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -32,7 +32,7 @@
               {% macro side_nav_item(url, title, label, type) -%}
                   <li class="p-side-navigation__item">
                     <a class="p-side-navigation__link" href="{{ url }}" {% if (slug and slug in url) or (url == path) %}aria-current="page"{% endif %}>
-                      {{ title }}
+                      {{ title | safe | replace("%version", version) }}
                       {% if label %}
                         <span class="p-side-navigation__status">
                           <span class="p-status-label--{{ type|lower }}">
@@ -43,139 +43,23 @@
                     </a>
                   </li>
               {%- endmacro %}
-
+              
+              {% for title in sideNavigation %}
               <ul class="p-side-navigation__list">
-                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Welcome</span></li>
-                {{ side_nav_item("/docs", "Get started") }}
-                {{ side_nav_item("/docs/building-vanilla", "Building with Vanilla") }}
-                {{ side_nav_item("/docs/customising-vanilla", "Customising Vanilla") }}
-                {{ side_nav_item("/docs/whats-new", "What’s new in " ~ version) }}
-                {{ side_nav_item("/docs/migration-guide-to-v3", "Migrating to v3.0") }}
+                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">{{ title.heading | safe | replace("%version", version) }}</span></li>
+                {% for subheading in title.subheadings %}
+                {{ side_nav_item(subheading.url, subheading.title) }}
+                {% endfor %}
               </ul>
+              {% endfor %}
 
-              <ul class="p-side-navigation__list">
-                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Base elements</span></li>
-                {{ side_nav_item("/docs/base/code", "Code") }}
-                {{ side_nav_item("/docs/base/forms", "Forms") }}
-                {{ side_nav_item("/docs/base/reset", "Reset") }}
-                {{ side_nav_item("/docs/base/separators", "Separators") }}
-                {{ side_nav_item("/docs/base/tables", "Tables") }}
-                {{ side_nav_item("/docs/base/typography", "Typography") }}
-              </ul>
 
-              <ul class="p-side-navigation__list">
-                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Components</span></li>
-                {{ side_nav_item("/docs/patterns/accordion", "Accordion") }}
-                {{ side_nav_item("/docs/patterns/badge", "Badge") }}
-                {{ side_nav_item("/docs/patterns/breadcrumbs", "Breadcrumbs") }}
-                {{ side_nav_item("/docs/patterns/buttons", "Buttons") }}
-                {{ side_nav_item("/docs/patterns/card", "Cards") }}
-                {{ side_nav_item("/docs/patterns/chip", "Chips") }}
-                {{ side_nav_item("/docs/patterns/contextual-menu", "Contextual menu") }}
-                {{ side_nav_item("/docs/patterns/divider", "Divider") }}
-                {{ side_nav_item("/docs/patterns/empty-state", "Empty state") }}
-                {{ side_nav_item("/docs/patterns/grid", "Grid") }}
-                {{ side_nav_item("/docs/patterns/heading-icon", "Heading icon") }}
-                {{ side_nav_item("/docs/patterns/icons", "Icons") }}
-                {{ side_nav_item("/docs/patterns/images", "Images") }}
-                {{ side_nav_item("/docs/patterns/links", "Links") }}
-                {{ side_nav_item("/docs/patterns/list-tree", "List tree") }}
-                {{ side_nav_item("/docs/patterns/lists", "Lists") }}
-                {{ side_nav_item("/docs/patterns/logo-section", "Logo section", "Updated", "information") }}
-                {{ side_nav_item("/docs/patterns/matrix", "Matrix") }}
-                {{ side_nav_item("/docs/patterns/media-object", "Media object") }}
-                {{ side_nav_item("/docs/patterns/modal", "Modal") }}
-                {{ side_nav_item("/docs/patterns/muted-heading", "Muted heading") }}
-                {{ side_nav_item("/docs/patterns/navigation", "Navigation") }}
-                {{ side_nav_item("/docs/patterns/notification", "Notifications") }}
-                {{ side_nav_item("/docs/patterns/pagination", "Pagination") }}
-                {{ side_nav_item("/docs/patterns/pull-quote", "Quotes") }}
-                {{ side_nav_item("/docs/patterns/search-and-filter", "Search and filter") }}
-                {{ side_nav_item("/docs/patterns/search-box", "Search box") }}
-                {{ side_nav_item("/docs/patterns/segmented-control", "Segmented control") }}
-                {{ side_nav_item("/docs/patterns/slider", "Slider") }}
-                {{ side_nav_item("/docs/patterns/status-labels", "Status labels") }}
-                {{ side_nav_item("/docs/patterns/strip", "Strip") }}
-                {{ side_nav_item("/docs/patterns/switch", "Switch") }}
-                {{ side_nav_item("/docs/patterns/table-of-contents", "Table of contents") }}
-                {{ side_nav_item("/docs/patterns/tabs", "Tabs") }}
-                {{ side_nav_item("/docs/patterns/tooltips", "Tooltips") }}
-              </ul>
-
-              <ul class="p-side-navigation__list">
-                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Utilities</span></li>
-                {{ side_nav_item("/docs/utilities/align", "Align") }}
-                {{ side_nav_item("/docs/utilities/baseline-grid", "Baseline grid") }}
-                {{ side_nav_item("/docs/utilities/clearfix", "Clearfix") }}
-                {{ side_nav_item("/docs/utilities/embedded-media", "Embedded media") }}
-                {{ side_nav_item("/docs/utilities/equal-height", "Equal height") }}
-                {{ side_nav_item("/docs/utilities/floats", "Floats") }}
-                {{ side_nav_item("/docs/utilities/font-metrics", "Font metrics") }}
-                {{ side_nav_item("/docs/utilities/functions", "Functions") }}
-                {{ side_nav_item("/docs/utilities/hide", "Hide") }}
-                {{ side_nav_item("/docs/utilities/image-position", "Image position") }}
-                {{ side_nav_item("/docs/utilities/margin-collapse", "Margin collapse") }}
-                {{ side_nav_item("/docs/utilities/no-print", "No print") }}
-                {{ side_nav_item("/docs/utilities/off-screen", "Off-screen") }}
-                {{ side_nav_item("/docs/utilities/padding-collapse", "Padding collapse") }}
-                {{ side_nav_item("/docs/utilities/table-cell-padding-overlap", "Table cell padding overlap") }}
-                {{ side_nav_item("/docs/utilities/truncate", "Truncation") }}
-                {{ side_nav_item("/docs/utilities/show", "Show") }}
-                {{ side_nav_item("/docs/utilities/vertical-spacing", "Vertical spacing") }}
-                {{ side_nav_item("/docs/utilities/vertically-center", "Vertically center") }}
-              </ul>
-
-              <ul class="p-side-navigation__list">
-                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Layouts</span></li>
-                {{ side_nav_item("/docs/layouts/application", "Application") }}
-                {{ side_nav_item("/docs/layouts/documentation", "Documentation") }}
-                {{ side_nav_item("/docs/layouts/fluid-breakout", "Fluid breakout") }}
-                {{ side_nav_item("/docs/layouts/full-width", "Full-width") }}
-                {{ side_nav_item("/docs/layouts/sticky-footer", "Sticky footer") }}
-              </ul>
-
-              <ul class="p-side-navigation__list">
-                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Settings</span></li>
-                {{ side_nav_item("/docs/settings/animation-settings", "Animations") }}
-                {{ side_nav_item("/docs/settings/assets-settings", "Assets") }}
-                {{ side_nav_item("/docs/settings/breakpoint-settings", "Breakpoints") }}
-                {{ side_nav_item("/docs/settings/color-settings", "Color") }}
-                {{ side_nav_item("/docs/settings/font-settings", "Font") }}
-                {{ side_nav_item("/docs/settings/layout-settings", "Layout") }}
-                {{ side_nav_item("/docs/settings/placeholder-settings", "Placeholders") }}
-                {{ side_nav_item("/docs/settings/spacing-settings", "Spacing") }}
-                {{ side_nav_item("/docs/settings/table-layout", "Table layout") }}
-              </ul>
-
-              <ul class="p-side-navigation__list">
-                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Resources</span></li>
-                {{ side_nav_item("/docs/examples", "Component examples") }}
-                {{ side_nav_item("https://github.com/canonical/vanilla-framework/releases/latest", "Release notes for " ~ version) }}
-                {{ side_nav_item("https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch", "Download Sketch UI Kit") }}
-              </ul>
+              
             </div>
           </div>
       </div>
-
-      <!-- <nav class="p-side-navigation is-sticky is-drawer-hidden" id="side-navigation-drawer" aria-label="Side">
-        <a href="#side-navigation-drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="side-navigation-drawer">
-          Toggle side navigation
-        </a>
-
-        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="side-navigation-drawer"></div>
-
-        <div class="p-side-navigation__drawer">
-          <div class="p-side-navigation__drawer-header">
-            <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="side-navigation-drawer">
-              Toggle side navigation
-            </a>
-          </div>
-
-
-
-        </div>
-      </nav> -->
     </aside>
+    
     <div class="p-strip is-shallow l-full-width">
       <div class="l-main">
         <div class="row">

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -165,29 +165,42 @@ def global_template_context():
             component_tabs_file.read(), Loader=yaml.FullLoader
         )
 
+    # Read side-navigation.yaml
+    with open("side-navigation.yaml") as side_navigation_file:
+        side_navigation = yaml.load(
+            side_navigation_file.read(),
+            Loader=yaml.FullLoader,
+        )
+
     return {
         "version": VANILLA_VERSION,
         "versionMinor": version_minor,
         "path": flask.request.path,
         "page_tabs": component_tabs.get(docs_slug),
         "slug": docs_slug,
+        "sideNavigation": side_navigation,
     }
+
 
 @app.template_filter()
 def markdown(text):
     return markupsafe.Markup(mistune.markdown(text))
 
+
 def class_reference(component=None):
-    component = component or urllib.parse.urlsplit(flask.request.path).path.split('/')[-1]
+    component = (
+        component
+        or urllib.parse.urlsplit(flask.request.path).path.split("/")[-1]
+    )
     data = CLASS_REFERENCES["class-references"][component]
-    return markupsafe.Markup(flask.render_template("_layouts/_class-reference.html", data=data))
+    return markupsafe.Markup(
+        flask.render_template("_layouts/_class-reference.html", data=data)
+    )
+
 
 @app.context_processor
 def utility_processor():
-    return {
-        "class_reference": class_reference,
-        "image": image_template
-    }
+    return {"class_reference": class_reference, "image": image_template}
 
 
 template_finder_view = TemplateFinder.as_view("template_finder")


### PR DESCRIPTION
## Done

Side navigation is now rendered from a YAML file instead

Fixes [list issues/bugs if needed]

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [ ] Documentation side navigation should be updated with the relevant labels.


## Screenshots

[if relevant, include a screenshot or screen capture]
