### PR TITLE
Removed highlight of side nav items on search results page [WD-2276]

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -151,13 +151,17 @@ def global_template_context():
     version_parts = VANILLA_VERSION.split(".")
     version_minor = f"{version_parts[0]}.{version_parts[1]}"
 
-    docs_slug = (
-        flask.request.path.replace("/docs/", "")
-        .replace("/design/", "")
-        .replace("/accessibility", "")
-    )
+    # Add an exception for the /docs/search path
+    if flask.request.path == "/docs/search":
+        docs_slug = ""
+    else:
+        docs_slug = (
+            flask.request.path.replace("/docs/", "")
+            .replace("/design/", "")
+            .replace("/accessibility", "")
+        )
 
-    docs_slug = "" if docs_slug == "/docs" else docs_slug
+        docs_slug = "" if docs_slug == "/docs" else docs_slug
 
     # Read navigation.yaml
     with open("component_tabs.yaml") as component_tabs_file:


### PR DESCRIPTION
## Done

Removed highlight of side nav items on the search results page.

Fixes https://github.com/canonical/vanilla-framework/issues/4486

## QA

- Open [an example search page](https://vanilla-framework-4682.demos.haus/docs/search?q=tooltip).
- Check that no item is selected in  side nav.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/templates/docs/whats-new.md).
- [x] Documentation side navigation should be updated with the relevant labels.