### PR TITLE
New active and hover states on light theme [WD-2470]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -100,8 +100,8 @@ $colors--light-theme--text-inactive: rgba($color-x-dark, $inactive-text-opacity-
 $colors--light-theme--background-default: #fff !default;
 $colors--light-theme--background-alt: #f7f7f7 !default;
 $colors--light-theme--background-inputs: adjust-color($color-x-dark, $lightness: 100% * (1 - $input-background-opacity-amount)) !default;
-$colors--light-theme--background-active: adjust-color($color-x-dark, $lightness: 100% * (1 - $active-background-opacity-amount)) !default;
-$colors--light-theme--background-hover: adjust-color($color-x-dark, $lightness: 100% * (1 - $hover-background-opacity-amount)) !default;
+$colors--light-theme--background-active: hsl(220, 55%, 94%) !default;
+$colors--light-theme--background-hover: hsl(220, 87%, 97%) !default;
 $colors--light-theme--background-overlay: transparentize($color-dark, 0.15) !default;
 
 $colors--light-theme--border-default: rgba($color-x-dark, 0.15) !default;


### PR DESCRIPTION
## Done

Incorporated new active/hover states for the light theme.

Fixes https://github.com/canonical/vanilla-framework/issues/4593

## QA

- Open a page with active/hover states, e.g. [/docs/patterns/tabs](https://vanilla-framework-4687.demos.haus/docs/patterns/tabs)
- Check that the active/hover states match the expected color values

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).