### PR TITLE
Accordion Side Navigation for Docs 

### DIFF
--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -11,7 +11,7 @@
 
     <aside class="l-full-width__sidebar">
 
-      <nav class="p-side-navigation is-sticky is-drawer-hidden" id="side-navigation-drawer" aria-label="Side">
+      <nav class="p-side-navigation--accordion is-sticky is-drawer-hidden" id="side-navigation-drawer" aria-label="Side">
 
         <div class="u-hide--large p-strip--light is-shallow">
           <div class="u-fixed-width">
@@ -53,14 +53,19 @@
                   </li>
               {%- endmacro %}
               
-              {% for item in sideNavigation %}
               <ul class="p-side-navigation__list">
-                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">{{ item.heading | replace("{version}", version) }}</span></li>
-                {% for subheading in item.subheadings %}
-                {{ side_nav_item(subheading.url, subheading.title) }}
+                {% for item in sideNavigation %}
+                <li class="p-side-navigation__item">
+                  <button class="p-side-navigation__accordion-button" aria-expanded="false">{{ item.heading | replace("{version}", version) }}</button>
+                  <ul class="p-side-navigation__list">
+
+                    {% for subheading in item.subheadings %}
+                    {{ side_nav_item(subheading.url, subheading.title) }}
+                    {% endfor %}
+                  </ul>
+                </li>
                 {% endfor %}
               </ul>
-              {% endfor %}
 
             </div>
           </div>

--- a/templates/static/js/scripts.js
+++ b/templates/static/js/scripts.js
@@ -215,6 +215,51 @@
       parent.appendChild(list);
     }
   }
+  
+  //
+  var currentPage = document.querySelector('.p-side-navigation__link[aria-current="page"]');
+  var parentList = currentPage.parentNode.parentNode;
+  parentList.setAttribute("aria-expanded",true);
+  parentList.previousElementSibling.setAttribute("aria-expanded",true);
+
+  function setupSideNavigationExpandToggle(toggle) {
+    const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+    if (!isExpanded) {
+      toggle.setAttribute('aria-expanded', isExpanded);
+    }
+    const item = toggle.closest('.p-side-navigation__item');
+    const link = item.querySelector('.p-side-navigation__link');
+    const nestedList = item.querySelector('.p-side-navigation__list');
+    if (!link?.hasAttribute('aria-expanded')) {
+      link.setAttribute('aria-expanded', isExpanded);
+    }
+    if (!nestedList?.hasAttribute('aria-expanded')) {
+      nestedList.setAttribute('aria-expanded', isExpanded);
+    }
+  }
+  
+  function handleExpandToggle(event) {
+    const item = event.currentTarget.closest('.p-side-navigation__item');
+    const button = item.querySelector('.p-side-navigation__expand, .p-side-navigation__accordion-button');
+    const link = item.querySelector('.p-side-navigation__link');
+    const nestedList = item.querySelector('.p-side-navigation__list');
+  
+    [button, link, nestedList].forEach((el) => {
+      el.setAttribute('aria-expanded', el.getAttribute('aria-expanded') === 'true' ? 'false' : 'true');
+    });
+  }
+  
+  function setupSideNavigationExpands() {
+    var expandToggles = document.querySelectorAll('.p-side-navigation__expand, .p-side-navigation__accordion-button');
+    expandToggles.forEach((toggle) => {
+      setupSideNavigationExpandToggle(toggle);
+      toggle.addEventListener('click', (e) => {
+        handleExpandToggle(e);
+      });
+    });
+  }
+  
+  setupSideNavigationExpands();
 })();
 
 // scroll active side navigation item into view (without scrolling whole page)


### PR DESCRIPTION
## Done

Converts side navigation into accordion

Fixes [[WD-2278]](https://warthogs.atlassian.net/browse/WD-2278)

## QA

- Open [demo](https://vanilla-framework-4692.demos.haus/docs)
- Side navigation should have accordion
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![image](https://user-images.githubusercontent.com/30973042/224032241-5928278f-6ed8-45a1-b191-63295def0384.png)


[WD-2278]: https://warthogs.atlassian.net/browse/WD-2278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ