### PR TITLE
Fix icon override on the main page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -318,10 +318,10 @@
         <h2>Get involved</h2>
         <ul class="p-list--divided">
           <li class="p-list__item">
-            <a href="https://twitter.com/vanillaframewrk" class="p-link--soft u-has-icon"><i class="p-icon--twitter"></i>Twitter&nbsp;&rsaquo;</a>
+            <a href="https://twitter.com/vanillaframewrk" class="p-link--soft">Twitter&nbsp;&rsaquo;</a>
           </li>
           <li class="p-list__item">
-            <a href="https://github.com/canonical/vanilla-framework" class="p-link--soft u-has-icon"><i class="p-icon--github"></i>GitHub&nbsp;&rsaquo;</a>
+            <a href="https://github.com/canonical/vanilla-framework" class="p-link--soft">GitHub&nbsp;&rsaquo;</a>
           </li>
         </ul>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -317,11 +317,11 @@
       <div class="col-3">
         <h2>Get involved</h2>
         <ul class="p-list--divided">
-          <li class="p-list__item is-ticked" style="background-image: url('https://assets.ubuntu.com/v1/7eae50ca-icon-twitter.svg'); background-size: 1rem;">
-            <a href="https://twitter.com/vanillaframewrk" class="p-link--soft">Twitter&nbsp;&rsaquo;</a>
+          <li class="p-list__item">
+            <a href="https://twitter.com/vanillaframewrk" class="p-link--soft u-has-icon"><i class="p-icon--twitter"></i>Twitter&nbsp;&rsaquo;</a>
           </li>
-          <li class="p-list__item is-ticked" style="background-image: url('https://assets.ubuntu.com/v1/f307a122-icon-github.svg'); background-size: 1rem;">
-            <a href="https://github.com/canonical/vanilla-framework" class="p-link--soft">GitHub&nbsp;&rsaquo;</a>
+          <li class="p-list__item">
+            <a href="https://github.com/canonical/vanilla-framework" class="p-link--soft u-has-icon"><i class="p-icon--github"></i>GitHub&nbsp;&rsaquo;</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Done

Fix the social links section at the bottom of the index page where inline styles were causing a bug.

## QA

- Open [demo](insert-demo-url)
- Check that the twitter and github logos look ok at the bottom

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

I tried to used the default icon size of `1.5rem` which makes the icons bigger than they used to 
![image](https://user-images.githubusercontent.com/11927929/224037411-4b7c6dc3-24e5-4e28-9b41-45e79b8b7193.png)


We could also set it to `1rem` as it was before
![image](https://user-images.githubusercontent.com/11927929/224038063-4d1142c7-f91e-4ef8-8d45-2e12975ccd75.png)


In both cases the alignment is a bit different. I don't know if it's something we want to fix inline or in the `has-icon` utility.