### PR TITLE
Add missing page to side navigation

### DIFF
--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -128,6 +128,8 @@
       url: /docs/utilities/padding-collapse
     - title: Table cell padding overlap
       url: /docs/utilities/table-cell-padding-overlap
+    - title: Text with icon
+      url: /docs/utilities/has-icon
     - title: Truncation
       url: /docs/utilities/truncate
     - title: Show


### PR DESCRIPTION
## Done

This must have got lost in conflicts when navigation was refactored.

## QA

- Open [demo](https://vanilla-framework-4700.demos.haus/docs)
- Make sure link to "Text with icon" util is in the navigation, marked as "new"


<img width="1003" alt="image" src="https://user-images.githubusercontent.com/83575/224998379-748f654c-6ae6-4ad6-8704-1f667c4f0e85.png">


