### PR TITLE
Fixes incorrect aria-label on tabs examples

### DIFF
--- a/templates/docs/examples/patterns/segmented-control/default.html
+++ b/templates/docs/examples/patterns/segmented-control/default.html
@@ -9,9 +9,9 @@
   <div class="p-segmented-control__list" role="tablist" aria-label="Juju technology">
     <button
       class="p-segmented-control__button"
-      role="tab" 
-      aria-selected="true" 
-      aria-controls="olm-tab" 
+      role="tab"
+      aria-selected="true"
+      aria-controls="olm-tab"
       id="olm"
     >OLM</button>
     <button
@@ -19,7 +19,7 @@
       role="tab"
       aria-selected="false"
       aria-controls="operator-tab"
-      id="operator" 
+      id="operator"
       tabindex="-1"
     >SDK</button>
     <button
@@ -41,7 +41,7 @@
   <p>A set of tools to help you write Charmed Operators and to package them as Charms.</p>
 </div>
 
-<div tabindex="0" role="tabpanel" id="charmhub-tab" aria-labelledby="complex" hidden="hidden">
+<div tabindex="0" role="tabpanel" id="charmhub-tab" aria-labelledby="charmhub" hidden="hidden">
   <p>A repository for charms - from Observability to Data to Identity and more.</p>
 </div>
 

--- a/templates/docs/examples/patterns/segmented-control/dense.html
+++ b/templates/docs/examples/patterns/segmented-control/dense.html
@@ -9,9 +9,9 @@
   <div class="p-segmented-control__list" role="tablist" aria-label="Juju technology">
     <button
       class="p-segmented-control__button"
-      role="tab" 
-      aria-selected="true" 
-      aria-controls="olm-tab-dense" 
+      role="tab"
+      aria-selected="true"
+      aria-controls="olm-tab-dense"
       id="olm"
     >
       OLM
@@ -21,7 +21,7 @@
       role="tab"
       aria-selected="false"
       aria-controls="operator-tab-dense"
-      id="operator" 
+      id="operator"
       tabindex="-1"
     >SDK</button>
     <button
@@ -43,7 +43,7 @@
   <p>A set of tools to help you write Charmed Operators and to package them as Charms.</p>
 </div>
 
-<div tabindex="0" role="tabpanel" id="charmhub-tab-dense" aria-labelledby="complex" hidden="hidden">
+<div tabindex="0" role="tabpanel" id="charmhub-tab-dense" aria-labelledby="charmhub" hidden="hidden">
   <p>A repository for charms - from Observability to Data to Identity and more.</p>
 </div>
 

--- a/templates/docs/examples/patterns/segmented-control/icons.html
+++ b/templates/docs/examples/patterns/segmented-control/icons.html
@@ -9,9 +9,9 @@
   <div class="p-segmented-control__list" role="tablist" aria-label="Juju technology">
     <button
       class="p-segmented-control__button"
-      role="tab" 
-      aria-selected="true" 
-      aria-controls="olm-tab" 
+      role="tab"
+      aria-selected="true"
+      aria-controls="olm-tab"
       id="olm"
     >
       <i class="p-icon--information"></i><span>OLM</span>
@@ -21,7 +21,7 @@
       role="tab"
       aria-selected="false"
       aria-controls="operator-tab"
-      id="operator" 
+      id="operator"
       tabindex="-1"
     >
       <i class="p-icon--information"></i><span>SDK</span>
@@ -47,7 +47,7 @@
   <p>A set of tools to help you write Charmed Operators and to package them as Charms.</p>
 </div>
 
-<div tabindex="0" role="tabpanel" id="charmhub-tab" aria-labelledby="complex" hidden="hidden">
+<div tabindex="0" role="tabpanel" id="charmhub-tab" aria-labelledby="charmhub" hidden="hidden">
   <p>A repository for charms - from Observability to Data to Identity and more.</p>
 </div>
 

--- a/templates/docs/examples/patterns/tab-buttons/default.html
+++ b/templates/docs/examples/patterns/tab-buttons/default.html
@@ -9,9 +9,9 @@
   <div class="p-tab-buttons__list" role="tablist" aria-label="Juju technology">
     <button
       class="p-tab-buttons__button"
-      role="tab" 
-      aria-selected="true" 
-      aria-controls="olm-tab" 
+      role="tab"
+      aria-selected="true"
+      aria-controls="olm-tab"
       id="olm"
     >OLM</button>
     <button
@@ -19,7 +19,7 @@
       role="tab"
       aria-selected="false"
       aria-controls="operator-tab"
-      id="operator" 
+      id="operator"
       tabindex="-1"
     >SDK</button>
     <button
@@ -41,7 +41,7 @@
   <p>A set of tools to help you write Charmed Operators and to package them as Charms.</p>
 </div>
 
-<div tabindex="0" role="tabpanel" id="charmhub-tab" aria-labelledby="complex" hidden="hidden">
+<div tabindex="0" role="tabpanel" id="charmhub-tab" aria-labelledby="charmhub" hidden="hidden">
   <p>A repository for charms - from Observability to Data to Identity and more.</p>
 </div>
 

--- a/templates/docs/examples/patterns/tab-buttons/dense.html
+++ b/templates/docs/examples/patterns/tab-buttons/dense.html
@@ -9,9 +9,9 @@
   <div class="p-tab-buttons__list" role="tablist" aria-label="Juju technology">
     <button
       class="p-tab-buttons__button"
-      role="tab" 
-      aria-selected="true" 
-      aria-controls="olm-tab-dense" 
+      role="tab"
+      aria-selected="true"
+      aria-controls="olm-tab-dense"
       id="olm"
     >
       OLM
@@ -21,7 +21,7 @@
       role="tab"
       aria-selected="false"
       aria-controls="operator-tab-dense"
-      id="operator" 
+      id="operator"
       tabindex="-1"
     >SDK</button>
     <button
@@ -43,7 +43,7 @@
   <p>A set of tools to help you write Charmed Operators and to package them as Charms.</p>
 </div>
 
-<div tabindex="0" role="tabpanel" id="charmhub-tab-dense" aria-labelledby="complex" hidden="hidden">
+<div tabindex="0" role="tabpanel" id="charmhub-tab-dense" aria-labelledby="charmhub" hidden="hidden">
   <p>A repository for charms - from Observability to Data to Identity and more.</p>
 </div>
 

--- a/templates/docs/examples/patterns/tab-buttons/icons.html
+++ b/templates/docs/examples/patterns/tab-buttons/icons.html
@@ -9,9 +9,9 @@
   <div class="p-tab-buttons__list" role="tablist" aria-label="Juju technology">
     <button
       class="p-tab-buttons__button"
-      role="tab" 
-      aria-selected="true" 
-      aria-controls="olm-tab" 
+      role="tab"
+      aria-selected="true"
+      aria-controls="olm-tab"
       id="olm"
     >
       <i class="p-icon--information"></i><span>OLM</span>
@@ -21,7 +21,7 @@
       role="tab"
       aria-selected="false"
       aria-controls="operator-tab"
-      id="operator" 
+      id="operator"
       tabindex="-1"
     >
       <i class="p-icon--information"></i><span>SDK</span>
@@ -47,7 +47,7 @@
   <p>A set of tools to help you write Charmed Operators and to package them as Charms.</p>
 </div>
 
-<div tabindex="0" role="tabpanel" id="charmhub-tab" aria-labelledby="complex" hidden="hidden">
+<div tabindex="0" role="tabpanel" id="charmhub-tab" aria-labelledby="charmhub" hidden="hidden">
   <p>A repository for charms - from Observability to Data to Identity and more.</p>
 </div>
 

--- a/templates/docs/examples/patterns/tabs/content.html
+++ b/templates/docs/examples/patterns/tabs/content.html
@@ -8,26 +8,26 @@
 <div class="p-tabs">
   <div class="p-tabs__list" role="tablist" aria-label="Juju technology">
     <div class="p-tabs__item">
-      <button 
+      <button
         class="p-tabs__link"
-        role="tab" 
-        aria-selected="true" 
-        aria-controls="olm-tab" 
+        role="tab"
+        aria-selected="true"
+        aria-controls="olm-tab"
         id="olm"
       >Charmed Operator Lifecycle Manager</button>
     </div>
     <div class="p-tabs__item">
-      <button 
+      <button
         class="p-tabs__link"
         role="tab"
         aria-selected="false"
         aria-controls="operator-tab"
-        id="operator" 
+        id="operator"
         tabindex="-1"
       >Charmed Operator SDK</button>
     </div>
     <div class="p-tabs__item">
-      <button 
+      <button
         class="p-tabs__link"
         role="tab"
         aria-selected="false"
@@ -46,7 +46,7 @@
     <p>A set of tools to help you write Charmed Operators and to package them as Charms.</p>
   </div>
 
-  <div tabindex="0" role="tabpanel" id="charmhub-tab" aria-labelledby="complex" hidden="hidden">
+  <div tabindex="0" role="tabpanel" id="charmhub-tab" aria-labelledby="charmhub" hidden="hidden">
     <p>A repository for charms - from Observability to Data to Identity and more.</p>
   </div>
 </div>


### PR DESCRIPTION
## Done

Fixes incorrect aria-label on tabs examples

## QA

- Go to /docs/patterns/tabs
- See that the aria-label for the charmhub panel is "charmhub" and not "complex"
