### PR TITLE
Fix lists wrapping under the prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -129,7 +129,6 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
 }
 
 %vf-list-item-ordered {
-  counter-increment: list-item;
   &::marker {
     content: none;
     display: none;
@@ -206,8 +205,6 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
     color: $color-dark;
     content: '•';
     display: inline-block;
-    flex-shrink: 0;
-    grid-area: prefix;
     text-align: right;
   }
 }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -69,15 +69,30 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
     content: '';
     display: inline-block;
     height: $sph--large;
-    margin-right: $sph--large;
     position: relative;
     top: $sph--x-small;
-    width: $sph--large;
+  }
+}
+
+@mixin vf-list-item-has-prefix {
+  column-gap: $sph--large;
+  display: grid;
+  grid-template-areas:
+    'prefix inline-content'
+    'prefix  children';
+  grid-template-columns: $sph--large 1fr;
+
+  > .p-list--divided {
+    margin-left: 0;
+  }
+
+  > * {
+    grid-area: children;
   }
 }
 
 @mixin vf-list-item-divided {
-  box-shadow: inset 0px 1px 0px 0rem $color-mid-x-light;
+  box-shadow: inset 0px 1px 0px 0px $color-mid-x-light;
   margin: 0;
   padding-bottom: $sph--large;
   padding-top: $sph--small;
@@ -116,6 +131,7 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
 }
 
 %vf-list-item-ordered {
+  counter-increment: list-item;
   &::marker {
     content: none;
     display: none;
@@ -125,9 +141,7 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
     color: $color-dark;
     content: counters(list-item, '.') '. ';
     display: inline-block;
-    margin-right: $sph--large;
     text-align: right;
-    width: $sph--large;
   }
 }
 
@@ -159,7 +173,9 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
   // stylelint-disable selector-max-type -- we want to target ordered lists
   ol.p-list--divided {
     list-style: none;
+
     .p-list__item {
+      @include vf-list-item-has-prefix;
       @extend %vf-list-item-ordered;
     }
   }
@@ -169,6 +185,8 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
 // Displays item with a state icon
 @mixin vf-p-list-item-state {
   .is-ticked {
+    @include vf-list-item-has-prefix;
+
     &::before {
       @extend %vf-list-item-state-base;
       @include vf-icon-success;
@@ -176,6 +194,8 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
   }
 
   .is-crossed {
+    @include vf-list-item-has-prefix;
+
     &::before {
       @extend %vf-list-item-state-base;
       @include vf-icon-error;
@@ -188,14 +208,15 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
     color: $color-dark;
     content: '•';
     display: inline-block;
-    margin-right: $sph--large;
+    flex-shrink: 0;
+    grid-area: prefix;
     text-align: right;
-    width: $sph--large;
   }
 }
 
 // Displays item with a bullet
 .has-bullet {
+  @include vf-list-item-has-prefix;
   @extend %vf-list-item-bullet;
 }
 

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -69,25 +69,23 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
     content: '';
     display: inline-block;
     height: $sph--large;
-    position: relative;
-    top: $sph--x-small;
+    top: $spv--medium;
   }
 }
 
 @mixin vf-list-item-has-prefix {
-  column-gap: $sph--large;
-  display: grid;
-  grid-template-areas:
-    'prefix inline-content'
-    'prefix  children';
-  grid-template-columns: $sph--large 1fr;
+  padding-left: $sp-x-large;
+  position: relative;
 
-  > .p-list--divided {
+  > .p-list--divided,
+  > .p-list {
     margin-left: 0;
   }
 
-  > * {
-    grid-area: children;
+  &::before {
+    left: 0;
+    position: absolute;
+    width: $sp-medium;
   }
 }
 

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -477,7 +477,6 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
         columns: 2;
 
         .p-list__item {
-          display: inline-block;
           width: 100%;
         }
       }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -175,8 +175,8 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
     list-style: none;
 
     .p-list__item {
-      @include vf-list-item-has-prefix;
       @extend %vf-list-item-ordered;
+      @include vf-list-item-has-prefix;
     }
   }
   // stylelint-enable selector-max-type -- we want to target ordered lists
@@ -216,8 +216,8 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
 
 // Displays item with a bullet
 .has-bullet {
-  @include vf-list-item-has-prefix;
   @extend %vf-list-item-bullet;
+  @include vf-list-item-has-prefix;
 }
 
 // Displays a list inline with spacing

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -1,6 +1,5 @@
 @import 'settings';
-$list-status-icon-height: 0.875rem; // 14px value from svg as rem so it can be used in calculations
-$list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that positions the icon correctly
+$list-status-icon-height: $default-icon-size;
 
 @mixin vf-p-list-placeholders {
   %numbered-step-container {
@@ -69,7 +68,30 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
     content: '';
     display: inline-block;
     height: $sph--large;
-    top: $spv--medium;
+    top: $spv--small;
+  }
+
+  %vf-list-item-ordered {
+    &::marker {
+      content: none;
+      display: none;
+    }
+
+    &::before {
+      color: $color-dark;
+      content: counters(list-item, '.') '. ';
+      display: inline-block;
+      text-align: right;
+    }
+  }
+
+  %vf-list-item-bullet {
+    &::before {
+      color: $color-dark;
+      content: '•';
+      display: inline-block;
+      text-align: right;
+    }
   }
 }
 
@@ -108,14 +130,6 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
   }
 }
 
-@function svg-tick($color) {
-  @if type-of($color) != 'color' {
-    @warn '#{$color} is not a color.';
-    @return false;
-  }
-  @return url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Ccircle fill='" + vf-url-friendly-color($color) + "' cx='7' cy='7' r='7'/%3E%3Cpath fill='%23fff' d='M6.1 10.813L2.41 8.105l1.184-1.613L5.9 8.187l4.393-4.394 1.414 1.414z' /%3E%3C/svg%3E");
-}
-
 // List styling using list class
 @mixin vf-p-list {
   .p-list {
@@ -128,20 +142,6 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
   }
 }
 
-%vf-list-item-ordered {
-  &::marker {
-    content: none;
-    display: none;
-  }
-
-  &::before {
-    color: $color-dark;
-    content: counters(list-item, '.') '. ';
-    display: inline-block;
-    text-align: right;
-  }
-}
-
 // A list with separators between items
 @mixin vf-p-list-divided {
   .p-list--divided {
@@ -150,6 +150,11 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
     .p-list__item {
       @extend %vf-list-item;
       @include vf-list-item-divided;
+
+      &.is-ticked::before,
+      &.is-crossed::before {
+        top: $spv--medium;
+      }
     }
 
     &.is-split .p-list__item:last-of-type {
@@ -181,7 +186,7 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
 
 // Displays item with a state icon
 @mixin vf-p-list-item-state {
-  .is-ticked {
+  .p-list__item.is-ticked {
     @include vf-list-item-has-prefix;
 
     &::before {
@@ -190,7 +195,7 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
     }
   }
 
-  .is-crossed {
+  .p-list__item.is-crossed {
     @include vf-list-item-has-prefix;
 
     &::before {
@@ -198,21 +203,12 @@ $list-status-icon-nudge: 0.3rem; // 0.3rem seems to be a magic number that posit
       @include vf-icon-error;
     }
   }
-}
 
-%vf-list-item-bullet {
-  &::before {
-    color: $color-dark;
-    content: '•';
-    display: inline-block;
-    text-align: right;
+  // Displays item with a bullet
+  .p-list__item.has-bullet {
+    @extend %vf-list-item-bullet;
+    @include vf-list-item-has-prefix;
   }
-}
-
-// Displays item with a bullet
-.has-bullet {
-  @extend %vf-list-item-bullet;
-  @include vf-list-item-has-prefix;
 }
 
 // Displays a list inline with spacing

--- a/templates/docs/examples/patterns/lists/lists-dividers-all-wrapping.html
+++ b/templates/docs/examples/patterns/lists/lists-dividers-all-wrapping.html
@@ -1,0 +1,43 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Lists / All variations with horizontal divider and wrapping text{% endblock %}
+
+{% block standalone_css %}patterns_lists{% endblock %}
+
+{% block content %}
+<ul class="p-list--divided">
+  <li class="p-list__item has-bullet">
+    Balance compute load in the cloud
+    <ul class="p-list--divided">
+      <li class="p-list__item has-bullet">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam euismod risus a nisi pharetra iaculis. Maecenas dictum consectetur vehicula. Maecenas ullamcorper interdum ipsum, in rutrum felis consectetur quis. Quisque dictum lorem non pretium pretium. Aenean vitae sodales magna. Vivamus tincidunt, mauris vel accumsan pretium, sem dolor facilisis turpis, vitae imperdiet libero quam eget nibh. Nam vulputate ligula quis turpis facilisis, ac dapibus ipsum commodo. Aliquam dolor turpis, congue eu orci non, commodo placerat magna.</li>
+      <li class="p-list__item has-bullet">In sed tristique lectus. Nunc posuere ullamcorper nulla, id fringilla urna cursus et. Ut in augue sed risus iaculis aliquam. Sed ullamcorper turpis magna, ullamcorper egestas nunc auctor et. Ut rutrum nec enim et tincidunt. Ut quis est est. Donec aliquet mi sit amet lectus posuere consequat. Integer sit amet turpis vel nunc suscipit ultrices. Integer laoreet porttitor sagittis. Suspendisse ut erat ut eros luctus ultricies. Donec varius posuere maximus. Duis venenatis tortor sit amet lacus placerat, eget blandit ex imperdiet. Curabitur maximus aliquam nulla, id auctor ligula accumsan eu. Nulla facilisi. Integer dignissim diam ligula.</li>
+      <li class="p-list__item has-bullet">Nulla sit amet diam ac elit interdum eleifend. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Fusce tempus imperdiet nisi, eget mollis leo faucibus a. Curabitur vitae sem lectus. Nulla facilisi. Fusce ullamcorper ultricies lectus a blandit. Nullam sed nisi libero. Praesent at lectus bibendum, iaculis neque nec, volutpat velit.</li>
+    </ul>
+  </li>
+  <li class="p-list__item is-ticked">
+    Balance compute load in the cloud
+    <ul class="p-list--divided">
+      <li class="p-list__item is-ticked">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam euismod risus a nisi pharetra iaculis. Maecenas dictum consectetur vehicula. Maecenas ullamcorper interdum ipsum, in rutrum felis consectetur quis. Quisque dictum lorem non pretium pretium. Aenean vitae sodales magna. Vivamus tincidunt, mauris vel accumsan pretium, sem dolor facilisis turpis, vitae imperdiet libero quam eget nibh. Nam vulputate ligula quis turpis facilisis, ac dapibus ipsum commodo. Aliquam dolor turpis, congue eu orci non, commodo placerat magna.</li>
+      <li class="p-list__item is-ticked">In sed tristique lectus. Nunc posuere ullamcorper nulla, id fringilla urna cursus et. Ut in augue sed risus iaculis aliquam. Sed ullamcorper turpis magna, ullamcorper egestas nunc auctor et. Ut rutrum nec enim et tincidunt. Ut quis est est. Donec aliquet mi sit amet lectus posuere consequat. Integer sit amet turpis vel nunc suscipit ultrices. Integer laoreet porttitor sagittis. Suspendisse ut erat ut eros luctus ultricies. Donec varius posuere maximus. Duis venenatis tortor sit amet lacus placerat, eget blandit ex imperdiet. Curabitur maximus aliquam nulla, id auctor ligula accumsan eu. Nulla facilisi. Integer dignissim diam ligula.</li>
+      <li class="p-list__item is-ticked">Nulla sit amet diam ac elit interdum eleifend. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Fusce tempus imperdiet nisi, eget mollis leo faucibus a. Curabitur vitae sem lectus. Nulla facilisi. Fusce ullamcorper ultricies lectus a blandit. Nullam sed nisi libero. Praesent at lectus bibendum, iaculis neque nec, volutpat velit.</li>
+    </ul>
+  </li>
+  <li class="p-list__item">
+    Balance compute load in the cloud
+    <ul class="p-list--divided">
+      <li class="p-list__item">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam euismod risus a nisi pharetra iaculis. Maecenas dictum consectetur vehicula. Maecenas ullamcorper interdum ipsum, in rutrum felis consectetur quis. Quisque dictum lorem non pretium pretium. Aenean vitae sodales magna. Vivamus tincidunt, mauris vel accumsan pretium, sem dolor facilisis turpis, vitae imperdiet libero quam eget nibh. Nam vulputate ligula quis turpis facilisis, ac dapibus ipsum commodo. Aliquam dolor turpis, congue eu orci non, commodo placerat magna.</li>
+      <li class="p-list__item">In sed tristique lectus. Nunc posuere ullamcorper nulla, id fringilla urna cursus et. Ut in augue sed risus iaculis aliquam. Sed ullamcorper turpis magna, ullamcorper egestas nunc auctor et. Ut rutrum nec enim et tincidunt. Ut quis est est. Donec aliquet mi sit amet lectus posuere consequat. Integer sit amet turpis vel nunc suscipit ultrices. Integer laoreet porttitor sagittis. Suspendisse ut erat ut eros luctus ultricies. Donec varius posuere maximus. Duis venenatis tortor sit amet lacus placerat, eget blandit ex imperdiet. Curabitur maximus aliquam nulla, id auctor ligula accumsan eu. Nulla facilisi. Integer dignissim diam ligula.</li>
+      <li class="p-list__item">Nulla sit amet diam ac elit interdum eleifend. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Fusce tempus imperdiet nisi, eget mollis leo faucibus a. Curabitur vitae sem lectus. Nulla facilisi. Fusce ullamcorper ultricies lectus a blandit. Nullam sed nisi libero. Praesent at lectus bibendum, iaculis neque nec, volutpat velit.</li>
+    </ul>
+  </li>
+</ul>
+<ol class="p-list--divided p-list--nested-counter">
+  <li class="p-list__item">
+    Balance compute load in the cloud
+    <ol class="p-list--divided">
+      <li class="p-list__item">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam euismod risus a nisi pharetra iaculis. Maecenas dictum consectetur vehicula. Maecenas ullamcorper interdum ipsum, in rutrum felis consectetur quis. Quisque dictum lorem non pretium pretium. Aenean vitae sodales magna. Vivamus tincidunt, mauris vel accumsan pretium, sem dolor facilisis turpis, vitae imperdiet libero quam eget nibh. Nam vulputate ligula quis turpis facilisis, ac dapibus ipsum commodo. Aliquam dolor turpis, congue eu orci non, commodo placerat magna.</li>
+      <li class="p-list__item">In sed tristique lectus. Nunc posuere ullamcorper nulla, id fringilla urna cursus et. Ut in augue sed risus iaculis aliquam. Sed ullamcorper turpis magna, ullamcorper egestas nunc auctor et. Ut rutrum nec enim et tincidunt. Ut quis est est. Donec aliquet mi sit amet lectus posuere consequat. Integer sit amet turpis vel nunc suscipit ultrices. Integer laoreet porttitor sagittis. Suspendisse ut erat ut eros luctus ultricies. Donec varius posuere maximus. Duis venenatis tortor sit amet lacus placerat, eget blandit ex imperdiet. Curabitur maximus aliquam nulla, id auctor ligula accumsan eu. Nulla facilisi. Integer dignissim diam ligula.</li>
+      <li class="p-list__item">Nulla sit amet diam ac elit interdum eleifend. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Fusce tempus imperdiet nisi, eget mollis leo faucibus a. Curabitur vitae sem lectus. Nulla facilisi. Fusce ullamcorper ultricies lectus a blandit. Nullam sed nisi libero. Praesent at lectus bibendum, iaculis neque nec, volutpat velit.</li>
+    </ol>
+  </li>
+</ol>
+{% endblock %}

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -12,7 +12,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Stylesheet size',
       benchmark: 150000,
-      threshold: 320000,
+      threshold: 350000,
       result: results['total-stylesheet-size'],
     },
     {


### PR DESCRIPTION
## Done

Fix long list elements wrapping under the prefix (bullet, tick, etc.)

Fixes https://github.com/canonical/vanilla-framework/issues/4696

## QA

- Open https://vanilla-framework-4702.demos.haus/docs/examples/patterns/lists/lists-dividers-all-wrapping
- check that all is well

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![image](https://user-images.githubusercontent.com/11927929/225377865-eb117672-e1d6-4840-86b3-433effbcbe30.png)

