### PR TITLE
Update mobile nav to match new design

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -70,19 +70,32 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     line-height: map-get($line-heights, default-text);
     margin: 0;
     overflow: hidden;
+    padding-left: calc(#{map-get($grid-margin-widths, small)} + #{$sph--x-large}); // allow navigation align with tag logo text on small screens
     position: relative;
     text-align: left;
     text-overflow: ellipsis;
     white-space: nowrap;
     width: 100%;
 
+    @media (min-width: $threshold-4-6-col) {
+      padding-left: calc(#{map-get($grid-margin-widths, default)} + #{$sph--x-large});
+    }
+
+    @media (min-width: $breakpoint-navigation-threshold) {
+      padding-left: $sph--large;
+    }
+
     &::before {
       content: '';
       height: 1px;
-      left: 0;
+      left: calc(#{map-get($grid-margin-widths, small)} + #{$sph--x-large}); // allow navigation separator align with tag logo text on small screens
       position: absolute;
       right: 0;
       top: 0;
+
+      @media (min-width: $threshold-4-6-col) {
+        left: calc(#{map-get($grid-margin-widths, default)} + #{$sph--x-large});
+      }
 
       @media (min-width: $breakpoint-navigation-threshold) {
         content: none;
@@ -190,6 +203,16 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     justify-content: space-between;
     padding-right: 0;
 
+    .p-navigation__link {
+      // reser padding for navigation links in the navigation banner
+      @extend %navigation-link-responsive-padding-horizontal;
+      @extend %navigation-link-responsive-padding-vertical;
+
+      &::before {
+        content: none;
+      }
+    }
+
     @media (min-width: $threshold-4-6-col) {
       padding-left: map-get($grid-margin-widths, default);
       padding-right: 0;
@@ -274,6 +297,29 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     list-style: none;
     margin: -1px 0 0 0;
     padding: 0;
+    position: relative;
+
+    // add separator between navigation items
+    &::before {
+      content: '';
+      height: 1px;
+      left: calc(#{map-get($grid-margin-widths, small)} + #{$sph--x-large});
+      position: absolute;
+      right: 0;
+      top: 0;
+
+      @media (min-width: $threshold-4-6-col) {
+        left: calc(#{map-get($grid-margin-widths, default)} + #{$sph--x-large});
+      }
+
+      @media (min-width: $breakpoint-navigation-threshold) {
+        content: none;
+      }
+    }
+
+    &:first-child::before {
+      content: none;
+    }
 
     @media (min-width: $breakpoint-navigation-threshold) {
       display: flex;
@@ -300,6 +346,11 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     display: flex;
     flex-wrap: wrap;
     margin-top: 0; // prevents bottom border of nav from moving 1px
+
+    // remove separtion for navigation items in the navigation banner
+    &::before {
+      content: none;
+    }
 
     @media (min-width: $breakpoint-navigation-threshold) {
       display: none;
@@ -544,6 +595,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
       right: map-get($grid-margin-widths, small);
       text-indent: calc(100% + 10rem);
       top: calc($spv--large + map-get($nudges, x-small));
+      transform: rotate(-90deg);
       width: map-get($icon-sizes, default);
 
       @media (min-width: $threshold-4-6-col) {
@@ -552,12 +604,17 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
 
       @media (min-width: $breakpoint-navigation-threshold) {
         right: calc($sph--small + 1px); // 1px for the border on selects. this aligns it with any selects underneath
+        transform: rotate(0deg);
       }
     }
 
     &.is-active {
       &::after {
-        transform: rotate(180deg);
+        transform: rotate(0deg);
+
+        @media (min-width: $breakpoint-navigation-threshold) {
+          transform: rotate(180deg);
+        }
       }
 
       .p-navigation__dropdown,
@@ -570,18 +627,46 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
       // add padding to accommodate icon
       padding-right: 2 * $sph--small + map-get($icon-sizes, default);
     }
+
+    &:first-child .p-navigation__link::before {
+      content: none;
+    }
   }
 
   .p-navigation__dropdown-item {
     @extend %navigation-link-responsive-padding-horizontal;
+    @extend %navigation-link-responsive-padding-vertical;
 
     display: block;
-    padding-bottom: $spv--small;
-    padding-top: $spv--small;
+    padding-left: calc(#{map-get($grid-margin-widths, small)} + #{$sph--x-large}); // make dropdown items align with the tag logo text
+    position: relative;
     white-space: nowrap;
+
+    // add separator line for dropdown items
+    &::before {
+      content: '';
+      height: 1px;
+      left: calc(#{map-get($grid-margin-widths, small)} + #{$sph--x-large});
+      position: absolute;
+      right: 0;
+      top: 0;
+
+      @media (min-width: $threshold-4-6-col) {
+        left: calc(#{map-get($grid-margin-widths, default)} + #{$sph--x-large});
+      }
+
+      @media (min-width: $breakpoint-navigation-threshold) {
+        content: none;
+      }
+    }
+
+    @media (min-width: $threshold-4-6-col) {
+      padding-left: calc(#{map-get($grid-margin-widths, default)} + #{$sph--x-large});
+    }
 
     @media (min-width: $breakpoint-navigation-threshold) {
       padding-bottom: $spv--medium;
+      padding-left: $sph--large;
       padding-top: $spv--medium;
     }
 
@@ -685,7 +770,10 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     }
   }
 
-  .p-navigation__nav .p-navigation__link::before {
+  // add color to separator line for navigation items, navigation links and dropdown items
+  .p-navigation__nav .p-navigation__link::before,
+  .p-navigation__nav .p-navigation__items::before,
+  .p-navigation__nav .p-navigation__items .p-navigation__dropdown-item::before {
     background: $color-navigation-separator;
   }
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -57,6 +57,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     $properties: #{background-color, color, opacity};
     @extend %navigation-link-responsive-padding-horizontal;
     @extend %navigation-link-responsive-padding-vertical;
+    @extend %vf-navigation-separator;
     @include vf-transition($properties, snap);
     @include vf-focus;
 
@@ -85,10 +86,23 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
       padding-left: $sph--large;
     }
 
+    &:visited,
+    &:focus,
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  %vf-reset-horizontal-padding {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  %vf-navigation-separator {
     &::before {
       content: '';
       height: 1px;
-      left: calc(#{map-get($grid-margin-widths, small)} + #{$sph--x-large}); // allow navigation separator align with tag logo text on small screens
+      left: calc(#{map-get($grid-margin-widths, small)} + #{$sph--x-large});
       position: absolute;
       right: 0;
       top: 0;
@@ -101,17 +115,6 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
         content: none;
       }
     }
-
-    &:visited,
-    &:focus,
-    &:hover {
-      text-decoration: none;
-    }
-  }
-
-  %vf-reset-horizontal-padding {
-    padding-left: 0;
-    padding-right: 0;
   }
 
   .p-navigation {
@@ -293,29 +296,13 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
 
   // navigation items
   .p-navigation__items {
+    @extend %vf-navigation-separator;
+
     display: none; // hidden by default on mobile (expands is a dropdown)
     list-style: none;
     margin: -1px 0 0 0;
     padding: 0;
     position: relative;
-
-    // add separator between navigation items
-    &::before {
-      content: '';
-      height: 1px;
-      left: calc(#{map-get($grid-margin-widths, small)} + #{$sph--x-large});
-      position: absolute;
-      right: 0;
-      top: 0;
-
-      @media (min-width: $threshold-4-6-col) {
-        left: calc(#{map-get($grid-margin-widths, default)} + #{$sph--x-large});
-      }
-
-      @media (min-width: $breakpoint-navigation-threshold) {
-        content: none;
-      }
-    }
 
     &:first-child::before {
       content: none;
@@ -636,29 +623,12 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
   .p-navigation__dropdown-item {
     @extend %navigation-link-responsive-padding-horizontal;
     @extend %navigation-link-responsive-padding-vertical;
+    @extend %vf-navigation-separator;
 
     display: block;
     padding-left: calc(#{map-get($grid-margin-widths, small)} + #{$sph--x-large}); // make dropdown items align with the tag logo text
     position: relative;
     white-space: nowrap;
-
-    // add separator line for dropdown items
-    &::before {
-      content: '';
-      height: 1px;
-      left: calc(#{map-get($grid-margin-widths, small)} + #{$sph--x-large});
-      position: absolute;
-      right: 0;
-      top: 0;
-
-      @media (min-width: $threshold-4-6-col) {
-        left: calc(#{map-get($grid-margin-widths, default)} + #{$sph--x-large});
-      }
-
-      @media (min-width: $breakpoint-navigation-threshold) {
-        content: none;
-      }
-    }
 
     @media (min-width: $threshold-4-6-col) {
       padding-left: calc(#{map-get($grid-margin-widths, default)} + #{$sph--x-large});

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -207,10 +207,11 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     padding-right: 0;
 
     .p-navigation__link {
-      // reser padding for navigation links in the navigation banner
+      // reset padding for navigation links in the navigation banner
       @extend %navigation-link-responsive-padding-horizontal;
       @extend %navigation-link-responsive-padding-vertical;
 
+      // remove navigation separator for navigation links in the navigation banner
       &::before {
         content: none;
       }
@@ -304,6 +305,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     padding: 0;
     position: relative;
 
+    // remove navigation separator for the first navigation items list
     &:first-child::before {
       content: none;
     }

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -12,7 +12,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Stylesheet size',
       benchmark: 150000,
-      threshold: 320000,
+      threshold: 350000,
       result: results['total-stylesheet-size'],
     },
     {


### PR DESCRIPTION
## Done

- Update the style of the navigation on smaller screens to match the new designs on figma.

## QA

- Open the [examples page](https://vanilla-framework-4706.demos.haus/docs/examples/)
- Select any of the `navigation` variants/examples under the components column.
- Compare with the [figma designs](https://www.figma.com/file/BSP7FqnRMcMvO7kCozJKUa/Ubuntu.com-navigation-update-Iteration-9?node-id=1323%3A3714&t=bHZJdx7PhdV9tjc1-0)

## Issues

- [WD-2615](https://warthogs.atlassian.net/browse/WD-2615)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


[WD-2615]: https://warthogs.atlassian.net/browse/WD-2615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ