### PR TITLE
Add unified spacing utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 3.14.0
+  features:
+    - component: Vertical spacing
+      url: /docs/utilities/vertical-spacing
+      status: New
+      notes: "We've added three utility classes: <code>.u-sv--shallow</code>, <code>.u-sv--regular</code> and <code>.u-sv--deep</code> for managing spacing between elements on the page."
 - version: 3.13.0
   features:
     - component: Brochure site layout

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -75,8 +75,9 @@ $spv--small: $sp-unit !default;
 $spv--medium: $sp-unit * 1.5 !default;
 $spv--large: $sp-unit * 2;
 $spv--x-large: $sp-unit * 3 !default;
+$spv--strip-shallow: $sp-unit * 3 !default;
 $spv--strip-regular: $sp-unit * 8 !default;
-$spv--strip-deep: $sp-unit * 12 !default;
+$spv--strip-deep: $sp-unit * 12 !default; // will be changed to 16
 
 $sph--x-small: $sp-unit * 0.5 !default; // to be used in place of an inline space between characters/words
 $sph--small: $sp-unit !default;

--- a/scss/_utilities_vertical-spacing.scss
+++ b/scss/_utilities_vertical-spacing.scss
@@ -1,3 +1,11 @@
+@mixin vf-section-spacing-vertical($spacing) {
+  margin-bottom: calc($spacing / 2 - 1px) !important;
+
+  @media (min-width: $breakpoint-large) {
+    margin-bottom: calc($spacing - 1px) !important;
+  }
+}
+
 @mixin vf-u-vertical-spacing($start: -3, $end: 3) {
   %u-vertical-spacer {
     content: '';
@@ -16,5 +24,17 @@
         }
       }
     }
+  }
+
+  .u-sv--shallow {
+    @include vf-section-spacing-vertical($spv--strip-shallow);
+  }
+
+  .u-sv--regular {
+    @include vf-section-spacing-vertical($spv--strip-regular);
+  }
+
+  .u-sv--deep {
+    @include vf-section-spacing-vertical($spv--strip-deep);
   }
 }

--- a/templates/docs/examples/utilities/vertical-spacing-unit.html
+++ b/templates/docs/examples/utilities/vertical-spacing-unit.html
@@ -1,0 +1,34 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Vertical spacing by unit{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-2 col-medium-2">
+        <p class="u-sv-3"><code>&lt;p&gt;</code> with .u-sv-3</p>
+        <p>text below</p>
+    </div>
+    <div class="col-2 col-medium-2">
+        <p class="u-sv-2"><code>&lt;p&gt;</code> with .u-sv-2</p>
+        <p>text below</p>
+    </div>
+    <div class="col-2 col-medium-2">
+        <p class="u-sv-1"><code>&lt;p&gt;</code> with .u-sv-1</p>
+        <p>text below</p>
+    </div>
+</div>
+<hr />
+<div class="row">
+    <div class="col-2 col-medium-2">
+        <p class="u-sv1"><code>&lt;p&gt;</code> with .u-sv1</p>
+        <p>text below</p>
+    </div>
+    <div class="col-2 col-medium-2">
+        <p class="u-sv2"><code>&lt;p&gt;</code> with .u-sv2</p>
+        <p>text below</p>
+    </div>
+    <div class="col-2 col-medium-2">
+        <p class="u-sv3"><code>&lt;p&gt;</code> with .u-sv3</p>
+        <p>text below</p>
+    </div>
+</div>
+{% endblock %}

--- a/templates/docs/examples/utilities/vertical-spacing.html
+++ b/templates/docs/examples/utilities/vertical-spacing.html
@@ -4,30 +4,15 @@
 {% block content %}
 <div class="row">
     <div class="col-2 col-medium-2">
-        <p class="u-sv-3"><code>&lt;p&gt;</code> with .u-sv-3</p>
+        <p class="u-sv--shallow"><code>&lt;p&gt;</code> with .u-sv--shallow</p>
         <p>text below</p>
     </div>
     <div class="col-2 col-medium-2">
-        <p class="u-sv-2"><code>&lt;p&gt;</code> with .u-sv-2</p>
+        <p class="u-sv--regular"><code>&lt;p&gt;</code> with .u-sv--regular</p>
         <p>text below</p>
     </div>
     <div class="col-2 col-medium-2">
-        <p class="u-sv-1"><code>&lt;p&gt;</code> with .u-sv-1</p>
-        <p>text below</p>
-    </div>
-</div>
-<hr />
-<div class="row">
-    <div class="col-2 col-medium-2">
-        <p class="u-sv1"><code>&lt;p&gt;</code> with .u-sv1</p>
-        <p>text below</p>
-    </div>
-    <div class="col-2 col-medium-2">
-        <p class="u-sv2"><code>&lt;p&gt;</code> with .u-sv2</p>
-        <p>text below</p>
-    </div>
-    <div class="col-2 col-medium-2">
-        <p class="u-sv3"><code>&lt;p&gt;</code> with .u-sv3</p>
+        <p class="u-sv--deep"><code>&lt;p&gt;</code> with .u-sv--deep</p>
         <p>text below</p>
     </div>
 </div>

--- a/templates/docs/utilities/vertical-spacing.md
+++ b/templates/docs/utilities/vertical-spacing.md
@@ -8,6 +8,28 @@ context:
 
 <hr>
 
+When desired vertical spacing between sections of the content can't be achieved using the default margins and paddings that are built into components, you can the bottom spacing of an element is using the following spacing utilities: `.u-sv--shallow`, `.u-sv--regular` and `.u-sv--deep`.
+
+| Class            | Formula <sup>\*</sup> | Default Value |
+| ---------------- | --------------------- | ------------- |
+| `.u-sv--shallow` | `$sp-unit * 3`        | `1.5rem`      |
+| `.u-sv--regular` | `$sp-unit * 8`        | `4rem`        |
+| `.u-sv--deep`    | `$sp-unit * 12`       | `6rem`        |
+
+<sup>\*</sup> The values are provided for large screens. They go twice smaller on medium and small screens.
+
+<div class="embedded-example"><a href="/docs/examples/utilities/vertical-spacing/" class="js-example">
+View example of the vertical spacing utility
+</a></div>
+
+Use `shallow` gap for spacing under siblings within a section.
+
+Use `regular` gap for spacing under each section, spacing under big headings.
+
+Use `deep` gap for spacing reserved for special cases, like making a large heading / CTA stand out, or at the end of the main content of a page, just before the dark footer.
+
+## More granular spacing adjustments
+
 The `.u-sv` set of utility classes adjusts the space after an element in positive or negative multiples of the baseline grid unit. A baseline grid unit is equivalent to `.5rem`.
 
 For example, to pull the next element `1rem` closer, apply `.u-sv-2`. To push it `.5rem` away from the current element, apply `u-sv1`.
@@ -46,7 +68,7 @@ These classes should be used sparingly, and exist to give designers greater flex
 | `.u-sv2`  | Increases space by 2 baseline grid units |
 | `.u-sv3`  | Increases space by 3 baseline grid units |
 
-<div class="embedded-example"><a href="/docs/examples/utilities/vertical-spacing/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/utilities/vertical-spacing-unit/" class="js-example">
 View example of the vertical spacing utility
 </a></div>
 


### PR DESCRIPTION
## Done

- Added common spacing classes to be used between elements.

Fixes [WD-2884](https://warthogs.atlassian.net/browse/WD-2884)

## QA

- Open [demo](https://vanilla-framework-4714.demos.haus/docs/examples/utilities/vertical-spacing-common)
- Check the new example page
- Review [updated documentation](https://vanilla-framework-4714.demos.haus/docs/utilities/vertical-spacing)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


[WD-2884]: https://warthogs.atlassian.net/browse/WD-2884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ