### PR TITLE
Update deep strip paddings

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -4,6 +4,10 @@
       url: /docs/utilities/vertical-spacing
       status: New
       notes: "We've added three utility classes: <code>.u-sv--shallow</code>, <code>.u-sv--regular</code> and <code>.u-sv--deep</code> for managing spacing between elements on the page."
+    - component: Deep strip
+      url: /docs/patterns/strip#deep-strip
+      status: Updated
+      notes: "We've increased desktop and mobile paddings for the deep strip to <code>8rem</code> and <code>4rem</code> accordingly."
 - version: 3.13.0
   features:
     - component: Brochure site layout

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -77,7 +77,7 @@ $spv--large: $sp-unit * 2;
 $spv--x-large: $sp-unit * 3 !default;
 $spv--strip-shallow: $sp-unit * 3 !default;
 $spv--strip-regular: $sp-unit * 8 !default;
-$spv--strip-deep: $sp-unit * 12 !default; // will be changed to 16
+$spv--strip-deep: $sp-unit * 16 !default;
 
 $sph--x-small: $sp-unit * 0.5 !default; // to be used in place of an inline space between characters/words
 $sph--small: $sp-unit !default;


### PR DESCRIPTION
## Done

- Increased desktop and mobile paddings for the deep strip to `8rem` and `4rem` accordingly

Fixes [WD-2889](https://warthogs.atlassian.net/browse/WD-2889)

## QA

- Open [demo]()
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

- [Screenshot 1](https://capture.dropbox.com/cSjNTHRX5dnyWEzb)
