### PR TITLE
Fix split list items overflowing in the other column

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -468,6 +468,7 @@ $list-status-icon-height: $default-icon-size;
         columns: 2;
 
         .p-list__item {
+          display: inline-block;
           width: 100%;
         }
       }

--- a/templates/docs/examples/patterns/lists/lists-split.html
+++ b/templates/docs/examples/patterns/lists/lists-split.html
@@ -7,7 +7,7 @@
 <ul class="p-list--divided is-split">
   <li class="p-list__item is-ticked">Jointly shape the OpenStack architecture</li>
   <li class="p-list__item is-ticked">We help you plan your cloud hardware requirements</li>
-  <li class="p-list__item is-ticked">We build OpenStack in your data center</li>
+  <li class="p-list__item is-ticked">We build OpenStack in your data center. With OpenStack, you can easily manage your cloud infrastructure with our intuitive web-based dashboard. Our platform offers flexible scaling and automatic upgrades, ensuring your cloud stays up-to-date and responsive to your needs.</li>
   <li class="p-list__item is-ticked">We operate the cloud to an SLA</li>
   <li class="p-list__item is-ticked">Transparent audit, logging, monitoring and management</li>
   <li class="p-list__item is-ticked">When your team is ready, we hand over the keys</li>


### PR DESCRIPTION
## Done

Fix long split list items overflowing in the second column.
Added an example of long list item to catch the regression

Fixes https://github.com/canonical/vanilla-framework/issues/4719

## QA

- Open [demo](https://vanilla-framework-4722.demos.haus/docs/examples/patterns/lists/lists-split)
- check that it displays correctly

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![image](https://user-images.githubusercontent.com/11927929/229499706-9712440c-b118-4373-9014-a7a274532783.png)

