### PR TITLE
Remove separator for the first item in the list (except if nested)

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -4,6 +4,10 @@
       url: /docs/utilities/vertical-spacing
       status: New
       notes: "We've added three utility classes: <code>.u-sv--shallow</code>, <code>.u-sv--regular</code> and <code>.u-sv--deep</code> for managing spacing between elements on the page."
+    - component: Divided lists
+      url: /docs/patterns/lists#bulleted-with-horizontal-divider
+      status: Updated
+      notes: "We removed the line above the first list item in the bulleted list with horizontal divider."
 - version: 3.13.0
   features:
     - component: Brochure site layout

--- a/releases.yml
+++ b/releases.yml
@@ -7,7 +7,7 @@
     - component: Divided lists
       url: /docs/patterns/lists#bulleted-with-horizontal-divider
       status: Updated
-      notes: "We removed the line above the first list item in the bulleted list with horizontal divider."
+      notes: 'We removed the line above the first list item in the bulleted list with horizontal divider.'
 - version: 3.13.0
   features:
     - component: Brochure site layout

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -121,7 +121,6 @@ $list-status-icon-height: $default-icon-size;
     box-shadow: none;
   }
 
-  .p-list--divided > .p-list__item:first-child,
   .p-list--divided > .p-list__item:first-child {
     box-shadow: inset 0px 1px 0px 0px $color-mid-x-light;
   }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -116,6 +116,15 @@ $list-status-icon-height: $default-icon-size;
   margin: 0;
   padding-bottom: $sph--large;
   padding-top: $sph--small;
+
+  &:first-child {
+    box-shadow: none;
+  }
+
+  .p-list--divided > .p-list__item:first-child,
+  .p-list--divided > .p-list__item:first-child {
+    box-shadow: inset 0px 1px 0px 0px $color-mid-x-light;
+  }
 }
 
 // Mixin for inline list items


### PR DESCRIPTION
## Done

Remove separator from the first list item

Fixes WD-3017

## QA

- Open [demo](https://vanilla-framework-4723.demos.haus/docs/patterns/lists)
- check that it displays correctly

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![image](https://user-images.githubusercontent.com/11927929/229503189-bc7a8764-efc1-4cde-a94f-c7192c3efcba.png)

