### PR TITLE
Skip installing Chromium for production on jenkins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM node:18 AS yarn-dependencies
 WORKDIR /srv
 ADD package.json package.json
 ADD yarn.lock yarn.lock
-RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 yarn install
 
 
 # Build stage: Build vanilla-framework itself


### PR DESCRIPTION
## Done

After moving dependencies and installing them all when building docker image, our jenkins builds started to fail.
This should fix that.

## QA

- Open [demo](https://vanilla-framework-4732.demos.haus/)
- Make sure all CI checks pass
- Make sure demo runs
