### PR TITLE
Fix alignment of heading icon

### DIFF
--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -29,7 +29,6 @@
   .p-heading-icon--small {
     .p-heading-icon__img {
       height: map-get($icon-sizes, heading-icon--small);
-      margin-top: 0;
       margin-top: map-get($nudges, h3);
       width: map-get($icon-sizes, heading-icon--small);
     }

--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -19,31 +19,19 @@
 
   .p-heading-icon__img {
     flex-shrink: 0;
-    height: map-get($icon-sizes, heading-icon--small);
+    height: map-get($icon-sizes, heading-icon);
     margin-bottom: 0;
     margin-right: $sph--large;
-    margin-top: calc(map-get($nudges, h3-mobile) / 2); // just a quick fix, should be calculated based on line height and icon size
-    width: map-get($icon-sizes, heading-icon--small);
-
-    @media (min-width: $breakpoint-heading-threshold) {
-      height: map-get($icon-sizes, heading-icon);
-      margin-top: calc(map-get($nudges, h3) / 2); // just a quick fix, should be calculated based on line height and icon size
-      width: map-get($icon-sizes, heading-icon);
-    }
+    margin-top: calc(map-get($nudges, h3) / 2); // just a quick fix, should be calculated based on line height and icon size
+    width: map-get($icon-sizes, heading-icon);
   }
 
   .p-heading-icon--small {
     .p-heading-icon__img {
-      height: map-get($icon-sizes, heading-icon--x-small);
-      margin-top: map-get($nudges, h3-mobile);
-      width: map-get($icon-sizes, heading-icon--x-small);
-
-      @media (min-width: $breakpoint-heading-threshold) {
-        height: map-get($icon-sizes, heading-icon--small);
-        margin-top: 0;
-        margin-top: map-get($nudges, h3);
-        width: map-get($icon-sizes, heading-icon--small);
-      }
+      height: map-get($icon-sizes, heading-icon--small);
+      margin-top: 0;
+      margin-top: map-get($nudges, h3);
+      width: map-get($icon-sizes, heading-icon--small);
     }
   }
 }

--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -22,12 +22,12 @@
     height: map-get($icon-sizes, heading-icon--small);
     margin-bottom: 0;
     margin-right: $sph--large;
-    margin-top: map-get($nudges, h3-mobile);
+    margin-top: calc(map-get($nudges, h3-mobile) / 2); // just a quick fix, should be calculated based on line height and icon size
     width: map-get($icon-sizes, heading-icon--small);
 
     @media (min-width: $breakpoint-heading-threshold) {
       height: map-get($icon-sizes, heading-icon);
-      margin-top: map-get($nudges, h3);
+      margin-top: calc(map-get($nudges, h3) / 2); // just a quick fix, should be calculated based on line height and icon size
       width: map-get($icon-sizes, heading-icon);
     }
   }
@@ -35,12 +35,13 @@
   .p-heading-icon--small {
     .p-heading-icon__img {
       height: map-get($icon-sizes, heading-icon--x-small);
-      margin-top: $sp-x-small;
+      margin-top: map-get($nudges, h3-mobile);
       width: map-get($icon-sizes, heading-icon--x-small);
 
       @media (min-width: $breakpoint-heading-threshold) {
         height: map-get($icon-sizes, heading-icon--small);
         margin-top: 0;
+        margin-top: map-get($nudges, h3);
         width: map-get($icon-sizes, heading-icon--small);
       }
     }


### PR DESCRIPTION
## Done

Fixes heading icon alignment

Fixes WD-3211

## QA

- Open [demo](https://vanilla-framework-4736.demos.haus/docs/patterns/heading-icon)
- Make sure icons in heading icon are aligned as expected

## Screenshots

<img width="699" alt="image" src="https://user-images.githubusercontent.com/83575/232521477-252241f5-1d71-4c54-af3e-7a51b8aea630.png">
