### PR TITLE
Remove unnecessary release notes

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1,9 +1,5 @@
 - version: 3.14.0
   features:
-    - component: Vertical spacing
-      url: /docs/utilities/vertical-spacing
-      status: New
-      notes: "We've added three utility classes: <code>.u-sv--shallow</code>, <code>.u-sv--regular</code> and <code>.u-sv--deep</code> for managing spacing between elements on the page."
     - component: Deep strip
       url: /docs/patterns/strip#deep-strip
       status: Updated


### PR DESCRIPTION
## Done

Revert some unnecessary old release notes (likely showed up because of some rebase).

## QA

- Open https://vanilla-framework-4738.demos.haus/docs/whats-new
- Make sure vertical spacing utils are not in release notes