### PR TITLE
Revert logo font size to match logo sizing

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -269,9 +269,10 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     }
 
     .p-navigation__logo-title {
-      @extend %vf-heading-4;
-      font-size: #{map-get($font-sizes, h4)}rem;
-      line-height: map-get($line-heights, x-small);
+      // font sizing adjusted to match logo
+      font-size: 1.3rem;
+      font-weight: 300;
+      line-height: $navigation-logo-size;
     }
 
     .p-navigation__link {


### PR DESCRIPTION
## Done

Reverts logo sizing, not to use new h4 size, but specific size adjusted to logo itself.

Fixes [WD-3214](https://warthogs.atlassian.net/browse/WD-3214)

## QA

- Open [demo](https://vanilla-framework-4756.demos.haus/)
- Check logo in top navigation. Make sure it uses font size the same as on Vanilla 3 (https://vanillaframework.io)




[WD-3214]: https://warthogs.atlassian.net/browse/WD-3214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ