### PR TITLE
Overhaul theming

### DIFF
--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -17,8 +17,22 @@
     @include vf-transition(#{background-color, border-color}, snap, in);
     @include vf-focus;
 
+    --button-background-color: #{$colors--light-theme--background-default};
+    --button-text-color: #{$colors--light-theme--text-default};
+    --button-disabled-background-color: #{$color-transparent};
+    --button-disabled-border-color: #{$colors--light-theme--border-high-contrast};
+    --button-border-color: #{$colors--light-theme--border-high-contrast};
+    --button-hover-background-color: #{$colors--light-theme--background-hover};
+    --button-hover-border-color: #{$colors--light-theme--border-high-contrast};
+    --button-active-background-color: #{$colors--light-theme--background-active};
+    --button-active-border-color: #{$colors--light-theme--border-high-contrast};
+
+    background-color: var(--button-background-color);
+    border-color: var(--button-border-color);
+
     border-style: solid;
     border-width: $input-border-thickness;
+    color: var(--button-text-color);
     cursor: pointer;
     display: inline-block;
     font-size: 1rem;
@@ -29,6 +43,36 @@
     padding: $input-vertical-padding $sph--large;
     text-align: center;
     text-decoration: none;
+
+    &:visited {
+      color: var(--button-text-color);
+    }
+
+    &:hover {
+      background-color: var(--button-hover-background-color);
+      border-color: var(--button-hover-border-color);
+    }
+
+    &:active,
+    &[aria-pressed='true'],
+    &[aria-selected='true'],
+    &[aria-expanded='true'] {
+      background-color: var(--button-active-background-color);
+      border-color: var(--button-active-border-color);
+      transition-duration: 0s;
+    }
+
+    &:disabled,
+    &.is-disabled {
+      &:active,
+      &[aria-pressed='true'],
+      &[aria-selected='true'],
+      &[aria-expanded='true'],
+      &:hover {
+        background-color: var(--button-disabled-background-color);
+        border-color: var(--button-disabled-border-color);
+      }
+    }
 
     &:active,
     &:focus,

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -64,6 +64,9 @@
 
     &:disabled,
     &.is-disabled {
+      cursor: not-allowed;
+      opacity: $disabled-element-opacity;
+
       &:active,
       &[aria-pressed='true'],
       &[aria-selected='true'],
@@ -78,12 +81,6 @@
     &:focus,
     &:hover {
       text-decoration: none;
-    }
-
-    &:disabled,
-    &.is-disabled {
-      cursor: not-allowed;
-      opacity: $disabled-element-opacity;
     }
 
     &:last-child {

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -25,9 +25,30 @@
 // Horizontal rule
 @mixin vf-b-hr {
   // stylelint-disable selector-max-type -- base styles can use type selectors
+  %light-version {
+    --color-hr-line: #{$colors--light-theme--border-default};
+  }
+  %dark-version {
+    --color-hr-line: #{$colors--dark-theme--border-default};
+  }
+
   hr {
     @extend %hr;
 
+    @if ($theme-default-hr == 'dark') {
+      @extend %dark-version;
+    } @else {
+      @extend %light-version;
+    }
+
+    &.is-light {
+      @extend %light-version;
+    }
+
+    &.is-dark {
+      @extend %dark-version;
+    }
+    background-color: var(--color-hr-line);
     margin-bottom: calc($spv--small - 1px);
 
     &.u-no-margin--bottom {
@@ -43,39 +64,4 @@
       @extend %fixed-width-hr;
     }
   }
-
-  // Theming
-  @if ($theme-default-hr == 'dark') {
-    hr {
-      @include vf-hr-dark-theme;
-    }
-
-    hr.is-light {
-      @include vf-hr-light-theme;
-    }
-  } @else {
-    hr {
-      @include vf-hr-light-theme;
-    }
-
-    hr.is-dark {
-      @include vf-hr-dark-theme;
-    }
-  }
-  // stylelint-enable selector-max-type
-}
-
-@mixin vf-hr-theme(
-  // color of the horizontal rule line
-  $color-hr-line
-) {
-  background: $color-hr-line;
-}
-
-@mixin vf-hr-light-theme {
-  @include vf-hr-theme($colors--light-theme--border-default);
-}
-
-@mixin vf-hr-dark-theme {
-  @include vf-hr-theme($colors--dark-theme--border-default);
 }

--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -1,7 +1,8 @@
+/* stylelint-disable property-no-vendor-prefix */
 @mixin vf-icon-chevron($color: $color-mid-dark) {
   background-color: $color;
-  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath d='M8.187 11.748l6.187-6.187-1.06-1.061-5.127 5.127L3.061 4.5 2 5.561z'/%3E%3C/svg%3E");
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath d='M8.187 11.748l6.187-6.187-1.06-1.061-5.127 5.127L3.061 4.5 2 5.561z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath d='M8.187 11.748l6.187-6.187-1.06-1.061-5.127 5.127L3.061 4.5 2 5.561z'/%3E%3C/svg%3E");
 }
 
 @mixin vf-icon-anchor($color) {
@@ -26,8 +27,8 @@
 
 @mixin vf-icon-close($color) {
   background-color: $color;
-  mask-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='nonzero' d='M13.041 1.898l1.06 1.06L9.062 8l5.04 5.042-1.06 1.06L8 9.062 2.96 14.1l-1.06-1.06L6.938 8 1.9 2.96l1.06-1.06 5.04 5.04z'/%3E%3C/svg%3E");
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='nonzero' d='M13.041 1.898l1.06 1.06L9.062 8l5.04 5.042-1.06 1.06L8 9.062 2.96 14.1l-1.06-1.06L6.938 8 1.9 2.96l1.06-1.06 5.04 5.04z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='nonzero' d='M13.041 1.898l1.06 1.06L9.062 8l5.04 5.042-1.06 1.06L8 9.062 2.96 14.1l-1.06-1.06L6.938 8 1.9 2.96l1.06-1.06 5.04 5.04z'/%3E%3C/svg%3E");
 }
 
 @mixin vf-icon-help($color) {
@@ -72,8 +73,8 @@
 
 @mixin vf-icon-search($color) {
   background-color: $color;
-  mask-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.964 1a5.964 5.964 0 014.709 9.623l4.303 4.305-1.06 1.06-4.306-4.305A5.964 5.964 0 116.963 1zm0 1.5a4.464 4.464 0 100 8.927 4.464 4.464 0 000-8.927z' fill-rule='nonzero'/%3E%3C/svg%3E");
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.964 1a5.964 5.964 0 014.709 9.623l4.303 4.305-1.06 1.06-4.306-4.305A5.964 5.964 0 116.963 1zm0 1.5a4.464 4.464 0 100 8.927 4.464 4.464 0 000-8.927z' fill-rule='nonzero'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.964 1a5.964 5.964 0 014.709 9.623l4.303 4.305-1.06 1.06-4.306-4.305A5.964 5.964 0 116.963 1zm0 1.5a4.464 4.464 0 100 8.927 4.464 4.464 0 000-8.927z' fill-rule='nonzero'/%3E%3C/svg%3E");
 }
 
 @mixin vf-icon-success($bg-color: $color-positive, $fg-color: $color-x-light) {
@@ -503,3 +504,4 @@
 @mixin vf-icon-stop($color) {
   background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cg id='stop'%3E%3Crect width='16' height='16' /%3E%3Cpath id='Rectangle 13 (Stroke)' fill-rule='evenodd' clip-rule='evenodd' d='M12 3.5H4C3.72386 3.5 3.5 3.72386 3.5 4V12C3.5 12.2761 3.72386 12.5 4 12.5H12C12.2761 12.5 12.5 12.2761 12.5 12V4C12.5 3.72386 12.2761 3.5 12 3.5ZM4 2C2.89543 2 2 2.89543 2 4V12C2 13.1046 2.89543 14 4 14H12C13.1046 14 14 13.1046 14 12V4C14 2.89543 13.1046 2 12 2H4Z' fill='#{vf-url-friendly-color($color)}'/%3E%3C/g%3E%3C/svg%3E%0A");
 }
+/* stylelint-enable property-no-vendor-prefix */

--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -25,7 +25,9 @@
 }
 
 @mixin vf-icon-close($color) {
-  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero' d='M13.041 1.898l1.06 1.06L9.062 8l5.04 5.042-1.06 1.06L8 9.062 2.96 14.1l-1.06-1.06L6.938 8 1.9 2.96l1.06-1.06 5.04 5.04z'/%3E%3C/svg%3E");
+  background-color: $color;
+  mask-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='nonzero' d='M13.041 1.898l1.06 1.06L9.062 8l5.04 5.042-1.06 1.06L8 9.062 2.96 14.1l-1.06-1.06L6.938 8 1.9 2.96l1.06-1.06 5.04 5.04z'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='nonzero' d='M13.041 1.898l1.06 1.06L9.062 8l5.04 5.042-1.06 1.06L8 9.062 2.96 14.1l-1.06-1.06L6.938 8 1.9 2.96l1.06-1.06 5.04 5.04z'/%3E%3C/svg%3E");
 }
 
 @mixin vf-icon-help($color) {

--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -1,7 +1,7 @@
 @mixin vf-icon-chevron($color: $color-mid-dark) {
   background-color: $color;
-  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='#{vf-url-friendly-color($color)}' d='M8.187 11.748l6.187-6.187-1.06-1.061-5.127 5.127L3.061 4.5 2 5.561z'/%3E%3C/svg%3E");
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='#{vf-url-friendly-color($color)}' d='M8.187 11.748l6.187-6.187-1.06-1.061-5.127 5.127L3.061 4.5 2 5.561z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath d='M8.187 11.748l6.187-6.187-1.06-1.061-5.127 5.127L3.061 4.5 2 5.561z'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath d='M8.187 11.748l6.187-6.187-1.06-1.061-5.127 5.127L3.061 4.5 2 5.561z'/%3E%3C/svg%3E");
 }
 
 @mixin vf-icon-anchor($color) {
@@ -69,7 +69,9 @@
 }
 
 @mixin vf-icon-search($color) {
-  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.964 1a5.964 5.964 0 014.709 9.623l4.303 4.305-1.06 1.06-4.306-4.305A5.964 5.964 0 116.963 1zm0 1.5a4.464 4.464 0 100 8.927 4.464 4.464 0 000-8.927z' fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero'/%3E%3C/svg%3E");
+  background-color: $color;
+  mask-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.964 1a5.964 5.964 0 014.709 9.623l4.303 4.305-1.06 1.06-4.306-4.305A5.964 5.964 0 116.963 1zm0 1.5a4.464 4.464 0 100 8.927 4.464 4.464 0 000-8.927z' fill-rule='nonzero'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.964 1a5.964 5.964 0 014.709 9.623l4.303 4.305-1.06 1.06-4.306-4.305A5.964 5.964 0 116.963 1zm0 1.5a4.464 4.464 0 100 8.927 4.464 4.464 0 000-8.927z' fill-rule='nonzero'/%3E%3C/svg%3E");
 }
 
 @mixin vf-icon-success($bg-color: $color-positive, $fg-color: $color-x-light) {

--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -1,5 +1,7 @@
 @mixin vf-icon-chevron($color: $color-mid-dark) {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='#{vf-url-friendly-color($color)}' d='M8.187 11.748l6.187-6.187-1.06-1.061-5.127 5.127L3.061 4.5 2 5.561z'/%3E%3C/svg%3E");
+  background-color: $color;
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='#{vf-url-friendly-color($color)}' d='M8.187 11.748l6.187-6.187-1.06-1.061-5.127 5.127L3.061 4.5 2 5.561z'/%3E%3C/svg%3E");
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='#{vf-url-friendly-color($color)}' d='M8.187 11.748l6.187-6.187-1.06-1.061-5.127 5.127L3.061 4.5 2 5.561z'/%3E%3C/svg%3E");
 }
 
 @mixin vf-icon-anchor($color) {

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -16,22 +16,28 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 }
 
 @mixin vf-button-plain {
-  %p-button-light {
-    @include vf-button-pattern();
+  %light-version {
+    --button-background-color: #{$colors--light-theme--background-default};
+    --button-text-color: #{$colors--light-theme--text-default};
+    --button-disabled-background-color: #{$color-transparent};
+    --button-disabled-border-color: #{$colors--light-theme--border-high-contrast};
+    --button-border-color: #{$colors--light-theme--border-high-contrast};
+    --button-hover-background-color: #{$colors--light-theme--background-hover};
+    --button-hover-border-color: #{$colors--light-theme--border-high-contrast};
+    --button-active-background-color: #{$colors--light-theme--background-active};
+    --button-active-border-color: #{$colors--light-theme--border-high-contrast};
   }
 
-  %p-button-dark {
-    @include vf-button-pattern(
-      $button-background-color: $colors--dark-theme--background-default,
-      $button-text-color: $colors--dark-theme--text-default,
-      $button-disabled-background-color: $color-transparent,
-      $button-disabled-border-color: $colors--dark-theme--border-high-contrast,
-      $button-border-color: $colors--dark-theme--border-high-contrast,
-      $button-hover-background-color: $colors--dark-theme--background-hover,
-      $button-hover-border-color: $colors--dark-theme--border-high-contrast,
-      $button-active-background-color: $colors--dark-theme--background-active,
-      $button-active-border-color: $colors--dark-theme--border-high-contrast
-    );
+  %dark-version {
+    --button-background-color: #{$colors--dark-theme--background-default};
+    --button-text-color: #{$colors--dark-theme--text-default};
+    --button-disabled-background-color: #{$color-transparent};
+    --button-disabled-border-color: #{$colors--dark-theme--border-high-contrast};
+    --button-border-color: #{$colors--dark-theme--border-high-contrast};
+    --button-hover-background-color: #{$colors--dark-theme--background-hover};
+    --button-hover-border-color: #{$colors--dark-theme--border-high-contrast};
+    --button-active-background-color: #{$colors--dark-theme--background-active};
+    --button-active-border-color: #{$colors--dark-theme--border-high-contrast};
   }
 
   .p-button {
@@ -39,66 +45,49 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 
     // Theming
     @if ($theme-default-p-button == 'dark') {
-      @extend %p-button-dark;
-
-      &.is-light {
-        @extend %p-button-light;
-      }
+      @extend %dark-version;
     } @else {
-      @extend %p-button-light;
+      @extend %light-version;
+    }
 
-      &.is-dark {
-        @extend %p-button-dark;
-      }
+    &.is-light {
+      @extend %light-version;
+    }
+
+    &.is-dark {
+      @extend %dark-version;
     }
   }
 }
 
+@mixin vf-button-color-variables($base-color) {
+  --button-hover-background-color: #{adjust-color($base-color, $lightness: -$hover-background-opacity-percentage)};
+  --button-background-color: #{$base-color};
+  --button-active-background-color: #{adjust-color($base-color, $lightness: -$active-background-opacity-percentage)};
+  --button-disabled-background-color: #{$base-color};
+  --button-border-color: #{$base-color};
+  --button-hover-border-color: #{adjust-color($base-color, $lightness: -$hover-background-opacity-percentage)};
+  --button-active-border-color: #{adjust-color($base-color, $lightness: -$active-background-opacity-percentage)};
+  --button-disabled-border-color: #{$base-color};
+  --button-text-color: #{vf-contrast-text-color($base-color)};
+}
+
 @mixin vf-button-brand {
-  %p-button--brand-light {
-    @include vf-button-pattern(
-      $button-background-color: $color-brand,
-      $button-hover-background-color: adjust-color($color-brand, $lightness: -$hover-background-opacity-percentage),
-      $button-active-background-color: adjust-color($color-brand, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-background-color: $color-brand,
-      $button-border-color: $color-brand,
-      $button-hover-border-color: adjust-color($color-brand, $lightness: -$hover-background-opacity-percentage),
-      $button-active-border-color: adjust-color($color-brand, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-border-color: $color-brand,
-      $button-text-color: vf-contrast-text-color($color-brand)
-    );
-  }
-
-  %p-button--brand-dark {
-    @include vf-button-pattern(
-      $button-background-color: $color-brand-dark,
-      $button-hover-background-color: adjust-color($color-brand-dark, $lightness: -$hover-background-opacity-percentage),
-      $button-active-background-color: adjust-color($color-brand-dark, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-background-color: $color-brand-dark,
-      $button-border-color: $color-brand-dark,
-      $button-hover-border-color: adjust-color($color-brand-dark, $lightness: -$hover-background-opacity-percentage),
-      $button-active-border-color: adjust-color($color-brand-dark, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-border-color: $color-brand-dark,
-      $button-text-color: vf-contrast-text-color($color-brand-dark)
-    );
-  }
-
   .p-button--brand {
     @extend %vf-button-base;
 
     // Theming
     @if ($theme-default-p-button == 'dark') {
-      @extend %p-button--brand-dark;
-
-      &.is-light {
-        @extend %p-button--brand-light;
-      }
+      @include vf-button-color-variables($color-brand-dark);
     } @else {
-      @extend %p-button--brand-light;
+      @include vf-button-color-variables($color-brand);
+    }
 
-      &.is-dark {
-        @extend %p-button--brand-dark;
-      }
+    &.is-light {
+      @include vf-button-color-variables($color-brand);
+    }
+    &.is-dark {
+      @include vf-button-color-variables($color-brand-dark);
     }
 
     @extend %vf-button-white-success-icon;
@@ -106,138 +95,70 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 }
 
 @mixin vf-button-positive {
-  %p-button--positive-light {
-    @include vf-button-pattern(
-      $button-background-color: $color-positive,
-      $button-hover-background-color: adjust-color($color-positive, $lightness: -$hover-background-opacity-percentage),
-      $button-active-background-color: adjust-color($color-positive, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-background-color: $color-positive,
-      $button-border-color: $color-positive,
-      $button-hover-border-color: adjust-color($color-positive, $lightness: -$hover-background-opacity-percentage),
-      $button-active-border-color: adjust-color($color-positive, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-border-color: $color-positive,
-      $button-text-color: vf-contrast-text-color($color-positive)
-    );
-
-    @include vf-focus($color-focus-positive);
-  }
-
-  %p-button--positive-dark {
-    @include vf-button-pattern(
-      $button-background-color: $color-positive-dark,
-      $button-hover-background-color: adjust-color($color-positive-dark, $lightness: -$hover-background-opacity-percentage),
-      $button-active-background-color: adjust-color($color-positive-dark, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-background-color: $color-positive-dark,
-      $button-border-color: $color-positive-dark,
-      $button-hover-border-color: adjust-color($color-positive-dark, $lightness: -$hover-background-opacity-percentage),
-      $button-active-border-color: adjust-color($color-positive-dark, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-border-color: $color-positive-dark,
-      $button-text-color: vf-contrast-text-color($color-positive-dark)
-    );
-
-    @include vf-focus($color-focus-positive);
-  }
-
   .p-button--positive {
     @extend %vf-button-base;
 
     // Theming
     @if ($theme-default-p-button == 'dark') {
-      @extend %p-button--positive-dark;
-
-      &.is-light {
-        @extend %p-button--positive-light;
-      }
+      @include vf-button-color-variables($color-positive-dark);
     } @else {
-      @extend %p-button--positive-light;
-
-      &.is-dark {
-        @extend %p-button--positive-dark;
-      }
+      @include vf-button-color-variables($color-positive);
     }
 
+    &.is-light {
+      @include vf-button-color-variables($color-positive);
+    }
+    &.is-dark {
+      @include vf-button-color-variables($color-positive-dark);
+    }
+
+    @include vf-focus($color-focus-positive);
     @extend %vf-button-white-success-icon;
   }
 }
 
 @mixin vf-button-negative {
-  %p-button--negative-light {
-    @include vf-button-pattern(
-      $button-background-color: $color-negative,
-      $button-hover-background-color: adjust-color($color-negative, $lightness: -$hover-background-opacity-percentage),
-      $button-active-background-color: adjust-color($color-negative, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-background-color: $color-negative,
-      $button-border-color: $color-negative,
-      $button-hover-border-color: adjust-color($color-negative, $lightness: -$hover-background-opacity-percentage),
-      $button-active-border-color: adjust-color($color-negative, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-border-color: $color-negative,
-      $button-text-color: vf-contrast-text-color($color-negative)
-    );
-
-    @include vf-focus($color-focus-negative);
-  }
-
-  %p-button--negative-dark {
-    @include vf-button-pattern(
-      $button-background-color: $color-negative-dark,
-      $button-hover-background-color: adjust-color($color-negative-dark, $lightness: -$hover-background-opacity-percentage),
-      $button-active-background-color: adjust-color($color-negative-dark, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-background-color: $color-negative-dark,
-      $button-border-color: $color-negative-dark,
-      $button-hover-border-color: adjust-color($color-negative-dark, $lightness: -$hover-background-opacity-percentage),
-      $button-active-border-color: adjust-color($color-negative-dark, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-border-color: $color-negative-dark,
-      $button-text-color: vf-contrast-text-color($color-negative-dark)
-    );
-
-    @include vf-focus($color-focus-negative);
-  }
-
   .p-button--negative {
     @extend %vf-button-base;
 
     // Theming
     @if ($theme-default-p-button == 'dark') {
-      @extend %p-button--negative-dark;
-
-      &.is-light {
-        @extend %p-button--negative-light;
-      }
+      @include vf-button-color-variables($color-negative-dark);
     } @else {
-      @extend %p-button--negative-light;
-
-      &.is-dark {
-        @extend %p-button--negative-dark;
-      }
+      @include vf-button-color-variables($color-negative);
     }
 
+    &.is-light {
+      @include vf-button-color-variables($color-negative);
+    }
+    &.is-dark {
+      @include vf-button-color-variables($color-negative-dark);
+    }
+
+    @include vf-focus($color-focus-negative);
     @extend %vf-button-white-success-icon;
   }
 }
 
 @mixin vf-button-base {
-  %p-button--base-light {
-    @include vf-button-pattern(
-      $button-background-color: $color-transparent,
-      $button-border-color: $color-transparent,
-      $button-hover-border-color: $color-transparent,
-      $button-active-border-color: $color-transparent,
-      $button-disabled-border-color: $color-transparent
-    );
+  %base-light-version {
+    --button-background-color: #{$color-transparent};
+    --button-border-color: #{$color-transparent};
+    --button-hover-border-color: #{$color-transparent};
+    --button-disabled-border-color: #{$color-transparent};
+    --button-active-border-color: #{$color-transparent};
   }
 
-  %p-button--base-dark {
-    @include vf-button-pattern(
-      $button-background-color: $color-transparent,
-      $button-text-color: $colors--dark-theme--text-default,
-      $button-disabled-background-color: $color-transparent,
-      $button-hover-background-color: $colors--dark-theme--background-hover,
-      $button-active-background-color: $colors--dark-theme--background-active,
-      $button-border-color: $color-transparent,
-      $button-hover-border-color: $color-transparent,
-      $button-active-border-color: $color-transparent,
-      $button-disabled-border-color: $color-transparent
-    );
+  %base-dark-version {
+    --button-background-color: #{$color-transparent};
+    --button-text-color: #{$colors--dark-theme--text-default};
+    --button-disabled-background-color: #{$color-transparent};
+    --button-disabled-border-color: #{$color-transparent};
+    --button-border-color: #{$color-transparent};
+    --button-hover-background-color: #{$colors--dark-theme--background-hover};
+    --button-hover-border-color: #{$color-transparent};
+    --button-active-background-color: #{$colors--dark-theme--background-active};
+    --button-active-border-color: #{$color-transparent};
   }
 
   .p-button--base {
@@ -245,17 +166,17 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 
     // Theming
     @if ($theme-default-p-button == 'dark') {
-      @extend %p-button--base-dark;
-
-      &.is-light {
-        @extend %p-button--base-light;
-      }
+      @extend %base-dark-version;
     } @else {
-      @extend %p-button--base-light;
+      @extend %base-light-version;
+    }
 
-      &.is-dark {
-        @extend %p-button--base-dark;
-      }
+    &.is-light {
+      @extend %base-light-version;
+    }
+
+    &.is-dark {
+      @extend %base-dark-version;
     }
   }
 }

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -112,8 +112,8 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
       @include vf-button-color-variables($color-positive-dark);
     }
 
-    @include vf-focus($color-focus-positive);
     @extend %vf-button-white-success-icon;
+    @include vf-focus($color-focus-positive);
   }
 }
 
@@ -135,8 +135,8 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
       @include vf-button-color-variables($color-negative-dark);
     }
 
-    @include vf-focus($color-focus-negative);
     @extend %vf-button-white-success-icon;
+    @include vf-focus($color-focus-negative);
   }
 }
 

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -1,6 +1,40 @@
 @use 'sass:math';
 @import 'settings';
 
+@mixin vf-chip-colors($chip-type, $class-name) {
+  %dark-version#{$chip-type} {
+    --color-chip-value: #{$colors--dark-theme--text-default};
+    --color-chip-lead: #{$colors--dark-theme--text-default};
+    --color-chip-background: #{map-get($colors-dark-theme--tinted-backgrounds, #{$chip-type}, 'default')};
+    --color-chip-background-hover: #{map-get($colors-dark-theme--tinted-backgrounds, #{$chip-type}, 'hover')};
+    --color-chip-background-active: #{map-get($colors-dark-theme--tinted-backgrounds, #{$chip-type}, 'active')};
+    --color-chip-border: #{map-get($colors-dark-theme--tinted-borders, #{$chip-type})};
+  }
+  %light-version#{$chip-type} {
+    --color-chip-value: #{$colors--light-theme--text-default};
+    --color-chip-lead: #{$colors--light-theme--text-default};
+    --color-chip-background: #{map-get($colors-light-theme--tinted-backgrounds, #{$chip-type}, 'default')};
+    --color-chip-background-hover: #{map-get($colors-light-theme--tinted-backgrounds, #{$chip-type}, 'hover')};
+    --color-chip-background-active: #{map-get($colors-light-theme--tinted-backgrounds, #{$chip-type}, 'active')};
+    --color-chip-border: #{map-get($colors-light-theme--tinted-borders, #{$chip-type})};
+  }
+  #{$class-name} {
+    @if ($theme-default-p-chip == 'dark') {
+      @extend %dark-version#{$chip-type};
+    } @else {
+      @extend %light-version#{$chip-type};
+    }
+
+    &.is-light {
+      @extend %light-version#{$chip-type};
+    }
+
+    &.is-dark {
+      @extend %dark-version#{$chip-type};
+    }
+  }
+}
+
 @mixin vf-p-chip {
   %vf-chip {
     @extend %small-text;
@@ -8,6 +42,9 @@
     @include vf-focus;
 
     align-items: baseline;
+
+    background-color: var(--color-chip-background);
+    border: $input-border-thickness solid var(--color-chip-border);
     border-radius: 1rem;
     display: inline-flex;
     margin: 0 $sph--small $input-margin-bottom 0;
@@ -17,6 +54,15 @@
     user-select: none;
     vertical-align: calc($input-border-thickness - map-get($nudges, p));
     white-space: nowrap;
+
+    .p-chip__value {
+      color: var(--color-chip-value);
+    }
+
+    .p-chip__lead,
+    .p-chip__lead + .p-chip__value::before {
+      color: var(--color-chip-lead);
+    }
 
     .p-chip__lead,
     .p-chip__value {
@@ -69,166 +115,63 @@
     }
   }
 
-  .p-chip,
-  .p-chip--positive,
-  .p-chip--caution,
-  .p-chip--negative,
-  .p-chip--information {
+  span.p-chip,
+  span.p-chip--positive,
+  span.p-chip--caution,
+  span.p-chip--negative,
+  span.p-chip--information {
     @extend %vf-chip;
+    .p-chip__dismiss {
+      @include vf-button-pattern(
+        $button-background-color: transparent,
+        $button-border-color: transparent,
+        $button-text-color: transparent,
+        $button-hover-background-color: var(--color-chip-background-hover),
+        $button-hover-border-color: transparent,
+        $button-active-background-color: var(--color-chip-background-active),
+        $button-active-border-color: transparent
+      );
+
+      position: relative;
+
+      &::before {
+        content: '';
+        display: block;
+        height: 1rem;
+        left: 1px;
+        -webkit-mask-size: 0.7rem;
+        mask-size: 0.7rem;
+        position: absolute;
+        top: 1px;
+        width: 1rem;
+        @include vf-icon-close(var(--color-chip-lead));
+      }
+    }
   }
 
-  // Theming
-  @if ($theme-default-p-chip == 'dark') {
-    .p-chip {
-      @include vf-chip-dark-theme;
+  button.p-chip,
+  button.p-chip--positive,
+  button.p-chip--caution,
+  button.p-chip--negative,
+  button.p-chip--information {
+    @extend %vf-chip;
+    &:hover {
+      background-color: var(--color-chip-background-hover);
+      border-color: var(--color-chip-border);
     }
-    .p-chip.is-light {
-      @include vf-chip-light-theme;
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip {
-      @include vf-chip-dark-theme($is-interactive: true);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip.is-light {
-      @include vf-chip-light-theme($is-interactive: true);
-    }
-
-    .p-chip--positive {
-      @include vf-chip-dark-theme(positive);
-    }
-    .p-chip--positive.is-light {
-      @include vf-chip-light-theme(positive);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip--positive {
-      @include vf-chip-dark-theme($chip-type: positive, $is-interactive: true);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip--positive.is-light {
-      @include vf-chip-light-theme($chip-type: positive, $is-interactive: true);
-    }
-
-    .p-chip--caution {
-      @include vf-chip-dark-theme(caution);
-    }
-    .p-chip--caution.is-light {
-      @include vf-chip-light-theme(caution);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip--caution {
-      @include vf-chip-dark-theme($chip-type: caution, $is-interactive: true);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip--caution.is-light {
-      @include vf-chip-light-theme($chip-type: caution, $is-interactive: true);
-    }
-
-    .p-chip--negative {
-      @include vf-chip-dark-theme(negative);
-    }
-    .p-chip--negative.is-light {
-      @include vf-chip-light-theme(negative);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip--negative {
-      @include vf-chip-dark-theme($chip-type: negative, $is-interactive: true);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip--negative.is-light {
-      @include vf-chip-light-theme($chip-type: negative, $is-interactive: true);
-    }
-
-    .p-chip--information {
-      @include vf-chip-dark-theme(information);
-    }
-    .p-chip--information.is-light {
-      @include vf-chip-light-theme(information);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip--information {
-      @include vf-chip-dark-theme($chip-type: information, $is-interactive: true);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip--information.is-light {
-      @include vf-chip-light-theme($chip-type: information, $is-interactive: true);
-    }
-  } @else {
-    .p-chip {
-      @include vf-chip-light-theme;
-    }
-    .p-chip.is-dark {
-      @include vf-chip-dark-theme;
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip {
-      @include vf-chip-light-theme($is-interactive: true);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip.is-dark {
-      @include vf-chip-dark-theme($is-interactive: true);
-    }
-
-    .p-chip--positive {
-      @include vf-chip-light-theme(positive);
-    }
-    .p-chip--positive.is-dark {
-      @include vf-chip-dark-theme(positive);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip--positive {
-      @include vf-chip-light-theme($chip-type: positive, $is-interactive: true);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip--positive.is-dark {
-      @include vf-chip-dark-theme($chip-type: positive, $is-interactive: true);
-    }
-
-    .p-chip--caution {
-      @include vf-chip-light-theme(caution);
-    }
-    .p-chip--caution.is-dark {
-      @include vf-chip-dark-theme(caution);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip--caution {
-      @include vf-chip-light-theme($chip-type: caution, $is-interactive: true);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip--caution.is-dark {
-      @include vf-chip-dark-theme($chip-type: caution, $is-interactive: true);
-    }
-
-    .p-chip--negative {
-      @include vf-chip-light-theme(negative);
-    }
-    .p-chip--negative.is-dark {
-      @include vf-chip-dark-theme(negative);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip--negative {
-      @include vf-chip-light-theme($chip-type: negative, $is-interactive: true);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip--negative.is-dark {
-      @include vf-chip-dark-theme($chip-type: negative, $is-interactive: true);
-    }
-
-    .p-chip--information {
-      @include vf-chip-light-theme(information);
-    }
-    .p-chip--information.is-dark {
-      @include vf-chip-dark-theme(information);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip--information {
-      @include vf-chip-light-theme($chip-type: information, $is-interactive: true);
-    }
-    // stylelint-disable-next-line selector-max-type
-    button.p-chip--information.is-dark {
-      @include vf-chip-dark-theme($chip-type: information, $is-interactive: true);
+    &[aria-pressed='true'],
+    &.is-selected,
+    &:active {
+      background-color: var(--color-chip-background-active);
+      border-color: var(--color-chip-border);
     }
   }
+
+  @include vf-chip-colors('neutral', '.p-chip');
+  @include vf-chip-colors('positive', '.p-chip--positive');
+  @include vf-chip-colors('caution', '.p-chip--caution');
+  @include vf-chip-colors('negative', '.p-chip--negative');
+  @include vf-chip-colors('information', '.p-chip--information');
 }
 
 @mixin vf-chip-theme($chip-type: neutral, $is-interactive: false, $colors-chip-tinted-backgrounds, $colors-chip-tinted-borders, $color-chip-value, $color-chip-lead) {
@@ -277,26 +220,4 @@
       );
     }
   }
-}
-
-@mixin vf-chip-light-theme($chip-type: neutral, $is-interactive: false) {
-  @include vf-chip-theme(
-    $chip-type: $chip-type,
-    $is-interactive: $is-interactive,
-    $colors-chip-tinted-backgrounds: $colors-light-theme--tinted-backgrounds,
-    $colors-chip-tinted-borders: $colors-light-theme--tinted-borders,
-    $color-chip-value: $colors--light-theme--text-default,
-    $color-chip-lead: $colors--light-theme--text-default
-  );
-}
-
-@mixin vf-chip-dark-theme($chip-type: neutral, $is-interactive: false) {
-  @include vf-chip-theme(
-    $chip-type: $chip-type,
-    $is-interactive: $is-interactive,
-    $colors-chip-tinted-backgrounds: $colors-dark-theme--tinted-backgrounds,
-    $colors-chip-tinted-borders: $colors-dark-theme--tinted-borders,
-    $color-chip-value: $colors--dark-theme--text-default,
-    $color-chip-lead: $colors--dark-theme--text-default
-  );
 }

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -56,7 +56,9 @@
     white-space: nowrap;
 
     .p-chip__value {
+      @extend %small-text;
       color: var(--color-chip-value);
+      font-weight: $font-weight-bold;
     }
 
     .p-chip__lead,
@@ -86,11 +88,6 @@
       content: ': ';
     }
 
-    .p-chip__value {
-      @extend %small-text;
-      font-weight: $font-weight-bold;
-    }
-
     .p-chip__dismiss {
       @extend %icon;
       // also includes button and close icon styles in the theming section
@@ -114,6 +111,8 @@
       vertical-align: baseline;
     }
   }
+
+  /* stylelint-disable property-no-vendor-prefix, selector-max-type */
 
   span.p-chip,
   span.p-chip--positive,
@@ -166,6 +165,8 @@
       border-color: var(--color-chip-border);
     }
   }
+
+  /* stylelint-enable property-no-vendor-prefix, selector-max-type */
 
   @include vf-chip-colors('neutral', '.p-chip');
   @include vf-chip-colors('positive', '.p-chip--positive');

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -113,16 +113,13 @@
     width: 100%;
 
     &:hover {
+      background-color: var(--color-contextual-menu-hover-background);
       border-radius: $border-radius;
       text-decoration: none;
     }
 
     &:visited {
       color: var(--color-contextual-menu-text);
-    }
-
-    &:hover {
-      background-color: var(--color-contextual-menu-hover-background);
     }
 
     &:active {

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -1,10 +1,40 @@
 @import 'settings';
 
 @mixin vf-p-contextual-menu {
+  %light-version {
+    --color-contextual-menu-background: #{$colors--light-theme--background-default};
+    --color-contextual-menu-hover-background: #{$colors--light-theme--background-hover};
+    --color-contextual-menu-active-background: #{$colors--light-theme--background-active};
+    --color-contextual-menu-border: #{$colors--light-theme--border-default};
+    --color-contextual-menu-text: #{$colors--light-theme--text-default};
+  }
+
+  %dark-version {
+    --color-contextual-menu-background: #{$colors--dark-theme--background-default};
+    --color-contextual-menu-hover-background: #{$colors--dark-theme--background-hover};
+    --color-contextual-menu-active-background: #{$colors--dark-theme--background-active};
+    --color-contextual-menu-border: #{$colors--dark-theme--border-default};
+    --color-contextual-menu-text: #{$colors--dark-theme--text-default};
+  }
+
   %p-contextual-menu {
     display: inline-block;
     margin: 0;
     position: relative;
+
+    @if ($theme-default-p-contextual-menu == 'dark') {
+      @extend %dark-version;
+    } @else {
+      @extend %light-version;
+    }
+
+    &.is-light {
+      @extend %light-version;
+    }
+
+    &.is-dark {
+      @extend %dark-version;
+    }
   }
 
   .p-contextual-menu {
@@ -16,6 +46,7 @@
     @extend %vf-has-box-shadow;
     @extend %vf-has-round-corners;
 
+    background: var(--color-contextual-menu-background);
     display: none;
     margin: 0;
     max-width: 21rem;
@@ -58,6 +89,7 @@
     display: block;
 
     + .p-contextual-menu__group {
+      border-top-color: var(--color-contextual-menu-border);
       border-top-style: solid;
       border-top-width: $input-border-thickness;
       margin: -$input-border-thickness 0 0 0;
@@ -67,8 +99,10 @@
   .p-contextual-menu__link {
     @include vf-focus;
 
+    background-color: transparent;
     border: 0;
     clear: both;
+    color: var(--color-contextual-menu-text);
     display: block;
     margin: 0;
     overflow: hidden;
@@ -81,6 +115,19 @@
     &:hover {
       border-radius: $border-radius;
       text-decoration: none;
+    }
+
+    &:visited {
+      color: var(--color-contextual-menu-text);
+    }
+
+    &:hover {
+      background-color: var(--color-contextual-menu-hover-background);
+    }
+
+    &:active {
+      background-color: var(--color-contextual-menu-active-background);
+      cursor: default;
     }
   }
 
@@ -96,79 +143,4 @@
       transform: rotate(180deg);
     }
   }
-
-  // Theming
-  @if ($theme-default-p-contextual-menu == 'dark') {
-    @include vf-contextual-menu-dark-theme;
-
-    [class*='p-contextual-menu'].is-light {
-      @include vf-contextual-menu-light-theme;
-    }
-  } @else {
-    @include vf-contextual-menu-light-theme;
-
-    [class*='p-contextual-menu'].is-dark {
-      @include vf-contextual-menu-dark-theme;
-    }
-  }
-}
-
-@mixin vf-contextual-menu-theme(
-  // color of the contextual menu background
-  $color-contextual-menu-background,
-  // color of the contextual menu border between groups
-  $color-contextual-menu-border,
-  // color of the contextual menu item link text
-  $color-contextual-menu-text,
-  // color of the contextual menu item link active background
-  $color-contextual-menu-active-background,
-  // color of the contextual menu item link hover background
-  $color-contextual-menu-hover-background
-) {
-  .p-contextual-menu__dropdown {
-    background: $color-contextual-menu-background;
-  }
-
-  .p-contextual-menu__group + .p-contextual-menu__group {
-    border-top-color: $color-contextual-menu-border;
-  }
-
-  .p-contextual-menu__link {
-    &,
-    &:active,
-    &:hover,
-    &:visited {
-      background-color: transparent;
-      color: $color-contextual-menu-text;
-    }
-
-    &:hover {
-      background-color: $color-contextual-menu-hover-background;
-    }
-
-    &:active {
-      background-color: $color-contextual-menu-active-background;
-      cursor: default;
-    }
-  }
-}
-
-@mixin vf-contextual-menu-light-theme {
-  @include vf-contextual-menu-theme(
-    $color-contextual-menu-background: $colors--light-theme--background-default,
-    $color-contextual-menu-hover-background: $colors--light-theme--background-hover,
-    $color-contextual-menu-active-background: $colors--light-theme--background-active,
-    $color-contextual-menu-border: $colors--light-theme--border-default,
-    $color-contextual-menu-text: $colors--light-theme--text-default
-  );
-}
-
-@mixin vf-contextual-menu-dark-theme {
-  @include vf-contextual-menu-theme(
-    $color-contextual-menu-background: $colors--dark-theme--background-default,
-    $color-contextual-menu-hover-background: $colors--dark-theme--background-hover,
-    $color-contextual-menu-active-background: $colors--dark-theme--background-active,
-    $color-contextual-menu-border: $colors--dark-theme--border-default,
-    $color-contextual-menu-text: $colors--dark-theme--text-default
-  );
 }

--- a/scss/_patterns_divider.scss
+++ b/scss/_patterns_divider.scss
@@ -5,6 +5,7 @@
   padding-top: $spv--large;
 
   &:not(:first-child)::before {
+    background-color: var(--color-divider-line);
     bottom: auto;
     content: '';
     height: 1px;
@@ -21,6 +22,7 @@
   padding-top: 0;
 
   &:not(:first-child)::before {
+    background-color: var(--color-divider-line);
     bottom: 0;
     content: '';
     height: auto;
@@ -33,13 +35,36 @@
 }
 
 @mixin vf-p-divider {
+  %light-version {
+    --color-divider-text: #{$colors--light-theme--text-default};
+    --color-divider-line: #{$colors--light-theme--border-default};
+  }
+  %dark-version {
+    --color-divider-text: #{$colors--dark-theme--text-default};
+    --color-divider-line: #{$colors--dark-theme--border-default};
+  }
+
   .p-divider {
     @extend %vf-row;
+    @if ($theme-default-p-divider == 'dark') {
+      @extend %dark-version;
+    } @else {
+      @extend %light-version;
+    }
+
+    &.is-light {
+      @extend %light-version;
+    }
+
+    &.is-dark {
+      @extend %dark-version;
+    }
 
     margin-bottom: $spv--x-large;
   }
 
   .p-divider__block {
+    color: var(--color-divider-text);
     position: relative;
 
     @include horizontal-dividers();
@@ -57,39 +82,4 @@
       @include vertical-dividers();
     }
   }
-
-  // Theming
-  @if ($theme-default-p-divider == 'dark') {
-    .p-divider__block {
-      @include vf-divider-dark-theme;
-    }
-
-    .p-divider.is-light .p-divider__block {
-      @include vf-divider-light-theme;
-    }
-  } @else {
-    .p-divider__block {
-      @include vf-divider-light-theme;
-    }
-
-    .p-divider.is-dark .p-divider__block {
-      @include vf-divider-dark-theme;
-    }
-  }
-}
-
-@mixin vf-divider-theme($color-divider-text, $color-divider-line) {
-  color: $color-divider-text;
-
-  &:not(:first-child)::before {
-    background-color: $color-divider-line;
-  }
-}
-
-@mixin vf-divider-light-theme {
-  @include vf-divider-theme($colors--light-theme--text-default, $colors--light-theme--border-default);
-}
-
-@mixin vf-divider-dark-theme {
-  @include vf-divider-theme($colors--dark-theme--text-default, $colors--dark-theme--border-default);
 }

--- a/scss/_patterns_form-tick-elements.scss
+++ b/scss/_patterns_form-tick-elements.scss
@@ -1,6 +1,20 @@
 @import 'settings';
 
 @mixin vf-p-form-tick-elements {
+  %light-version {
+    --color-tick-text: #{$colors--light-theme--text-default};
+    --color-tick-background: #{$colors--light-theme--background-default};
+    --color-tick-border: #{$colors--light-theme--border-high-contrast};
+    --color-radio-dot: #{$colors--light-theme--background-default};
+  }
+
+  %dark-version {
+    --color-tick-text: #{$colors--dark-theme--text-default};
+    --color-tick-background: #{$colors--dark-theme--background-default};
+    --color-tick-border: #{$colors--dark-theme--border-high-contrast};
+    --color-radio-dot: #{$colors--dark-theme--text-default};
+  }
+
   %vf-hidden-tick-input {
     float: none;
     height: $form-tick-box-size;
@@ -54,6 +68,7 @@
     }
 
     &::after {
+      border-color: var(--color-tick-background);
       opacity: 1;
     }
   }
@@ -66,7 +81,12 @@
 
   %vf-pseudo-checkbox {
     // container
+
+    color: var(--color-tick-text);
+
     &::before {
+      background: var(--color-tick-background);
+      border: $input-border-thickness solid var(--color-tick-border);
       border-radius: 0;
     }
 
@@ -93,11 +113,17 @@
   }
 
   %vf-pseudo-radio {
+    color: var(--color-tick-text);
+
     &::before {
+      background: var(--color-tick-background);
+      border: $input-border-thickness solid var(--color-tick-border);
+      border-radius: 0;
       border-radius: 50%;
     }
 
     &::after {
+      background-color: var(--color-tick-background);
       border-radius: 50%;
       height: $form-radio-inner-circle-diameter;
       left: #{($form-tick-box-size - $form-radio-inner-circle-diameter) * 0.5};
@@ -132,6 +158,20 @@
   .p-radio,
   .p-radio--heading,
   .p-radio--inline {
+    @if ($theme-default-forms == 'dark') {
+      @extend %dark-version;
+    } @else {
+      @extend %light-version;
+    }
+
+    &.is-light {
+      @extend %light-version;
+    }
+
+    &.is-dark {
+      @extend %dark-version;
+    }
+
     $asterisk-width: 1ch;
 
     position: relative;
@@ -206,128 +246,4 @@
   .p-radio + .p-checkbox {
     margin-top: -$sp-unit;
   }
-
-  // Theming
-  @if ($theme-default-forms == 'dark') {
-    .p-checkbox__label {
-      @include vf-checkbox-dark-theme;
-    }
-
-    .p-radio__label {
-      @include vf-radio-dark-theme;
-    }
-
-    .p-checkbox.is-light .p-checkbox__label {
-      @include vf-checkbox-light-theme;
-    }
-
-    .p-radio.is-light .p-radio__label {
-      @include vf-radio-light-theme;
-    }
-  } @else {
-    .p-checkbox__label {
-      @include vf-checkbox-light-theme;
-    }
-
-    .p-radio__label {
-      @include vf-radio-light-theme;
-    }
-
-    .p-checkbox.is-dark .p-checkbox__label {
-      @include vf-checkbox-dark-theme;
-    }
-
-    .p-radio.is-dark .p-radio__label {
-      @include vf-radio-dark-theme;
-    }
-  }
-}
-
-// theme for common properties on radios and checkboxes
-@mixin vf-tick-elements-theme(
-  // color of the tick element label text
-  $color-tick-text,
-  // color of the tick element background
-  $color-tick-background,
-  // color of the tick element border
-  $color-tick-border: $colors--light-theme--border-high-contrast
-) {
-  color: $color-tick-text;
-
-  &::before {
-    background: $color-tick-background;
-    border: $input-border-thickness solid $color-tick-border;
-  }
-}
-
-// theme for checkbox (including common properties)
-@mixin vf-checkbox-theme(
-  // color of the tick element label text
-  $color-tick-text,
-  // color of the tick element background
-  $color-tick-background,
-  // color of the tick element border
-  $color-tick-border,
-  // color of the checkbox tick
-  $color-checkbox-tick
-) {
-  @include vf-tick-elements-theme($color-tick-text, $color-tick-background, $color-tick-border);
-
-  &::after {
-    color: $color-checkbox-tick;
-  }
-}
-
-@mixin vf-checkbox-light-theme {
-  @include vf-checkbox-theme(
-    $color-tick-text: $colors--light-theme--text-default,
-    $color-tick-background: $colors--light-theme--background-default,
-    $color-tick-border: $colors--light-theme--border-high-contrast,
-    $color-checkbox-tick: $colors--light-theme--background-default
-  );
-}
-
-@mixin vf-checkbox-dark-theme {
-  @include vf-checkbox-theme(
-    $color-tick-text: $colors--dark-theme--text-default,
-    $color-tick-background: $colors--dark-theme--background-default,
-    $color-tick-border: $colors--dark-theme--border-high-contrast,
-    $color-checkbox-tick: $colors--dark-theme--text-default
-  );
-}
-
-// theme for radio (including common properties)
-@mixin vf-radio-theme(
-  // color of the tick element label text
-  $color-tick-text,
-  // color of the tick element background
-  $color-tick-background,
-  // color of the tick element border
-  $color-tick-border,
-  // color of the radio dot
-  $color-radio-dot
-) {
-  @include vf-tick-elements-theme($color-tick-text, $color-tick-background, $color-tick-border);
-
-  &::after {
-    background-color: $color-radio-dot;
-  }
-}
-
-@mixin vf-radio-light-theme {
-  @include vf-radio-theme(
-    $color-tick-text: $colors--light-theme--text-default,
-    $color-tick-background: $colors--light-theme--background-default,
-    $color-tick-border: $colors--light-theme--border-high-contrast,
-    $color-radio-dot: $colors--light-theme--background-default
-  );
-}
-
-@mixin vf-radio-dark-theme {
-  @include vf-radio-theme(
-    $color-tick-text: $colors--dark-theme--text-default,
-    $color-tick-background: $colors--dark-theme--background-default,
-    $color-tick-border: $colors--dark-theme--border-high-contrast,
-    $color-radio-dot: $colors--dark-theme--text-default
-  );
 }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -2,6 +2,13 @@
 $list-status-icon-height: $default-icon-size;
 
 @mixin vf-p-list-placeholders {
+  %light-version {
+    --colors-list-text: #{$colors--light-theme--text-default};
+  }
+  %dark-version {
+    --colors-list-text: #{$colors--dark-theme--text-default};
+  }
+
   %numbered-step-container {
     counter-reset: li;
     display: flex;
@@ -234,6 +241,21 @@ $list-status-icon-height: $default-icon-size;
 // Displays a list inline with items separated by dots
 @mixin vf-p-inline-list-middot {
   .p-inline-list--middot {
+    @if ($theme-default-p-inline-list--middot == 'dark') {
+      @extend %dark-version;
+    } @else {
+      @extend %light-version;
+    }
+
+    &.is-light {
+      @extend %light-version;
+    }
+
+    &.is-dark {
+      @extend %dark-version;
+    }
+
+    color: var(--colors-list-text);
     margin-left: 0;
     padding-left: 0;
 
@@ -257,37 +279,6 @@ $list-status-icon-height: $default-icon-size;
       }
     }
   }
-
-  // Theming
-  @if ($theme-default-p-inline-list--middot == 'dark') {
-    .p-inline-list--middot {
-      @include vf-p-inline-list-middot-dark-theme;
-    }
-
-    .p-inline-list--middot.is-light {
-      @include vf-p-inline-list-middot-light-theme;
-    }
-  } @else {
-    .p-inline-list--middot {
-      @include vf-p-inline-list-middot-light-theme;
-    }
-
-    .p-inline-list--middot.is-dark {
-      @include vf-p-inline-list-middot-dark-theme;
-    }
-  }
-}
-
-@mixin vf-p-inline-list-middot-theme($color-list-text) {
-  color: $color-list-text;
-}
-
-@mixin vf-p-inline-list-middot-light-theme {
-  @include vf-p-inline-list-middot-theme($colors--light-theme--text-default);
-}
-
-@mixin vf-p-inline-list-middot-dark-theme {
-  @include vf-p-inline-list-middot-theme($colors--dark-theme--text-default);
 }
 
 @mixin vf-p-inline-list-stretch {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -97,18 +97,33 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     white-space: nowrap;
     width: 100%;
 
+    &,
+    &:hover,
+    &:visited,
+    &:focus {
+      color: var(--color-navigation-text);
+    }
+
+    &:visited {
+      color: var(--color-navigation-text);
+    }
+
+    &:hover {
+      background-color: var(--color-navigation-background--hover);
+      text-decoration: none;
+    }
+
+    &[aria-pressed='true'],
+    &:active {
+      background-color: var(--color-navigation-background--active);
+    }
+
     @media (min-width: $threshold-4-6-col) {
       padding-left: calc(#{map-get($grid-margin-widths, default)} + #{$sph--x-large});
     }
 
     @media (min-width: $breakpoint-navigation-threshold) {
       padding-left: $sph--large;
-    }
-
-    &:visited,
-    &:focus,
-    &:hover {
-      text-decoration: none;
     }
   }
 
@@ -119,6 +134,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
 
   %vf-navigation-separator {
     &::before {
+      background: var(--color-navigation-separator);
       content: '';
       height: 1px;
       left: calc(#{map-get($grid-margin-widths, small)} + #{$sph--x-large});
@@ -221,14 +237,14 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
 
   .p-navigation__item,
   .p-navigation__item--dropdown-toggle {
-
     .is-selected > .p-navigation__link {
-    background-color: var(--color-navigation-background--hover);
+      background-color: var(--color-navigation-background--hover);
 
-    @include vf-highlight-bar(var(--color-navigation-highlight), left, true);
+      @include vf-highlight-bar(var(--color-navigation-highlight), left, true);
 
-    @media (min-width: $breakpoint-navigation-threshold) {
-      @include vf-highlight-bar(var(--color-navigation-highlight, bottom, false));
+      @media (min-width: $breakpoint-navigation-threshold) {
+        @include vf-highlight-bar(var(--color-navigation-highlight, bottom, false));
+      }
     }
 
     @media (min-width: $breakpoint-navigation-threshold) {
@@ -419,6 +435,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     &:visited,
     &:focus,
     &:hover {
+      color: var(--color-navigation-text);
       text-decoration: none;
     }
   }
@@ -542,6 +559,15 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
       top: 0;
       width: 100%;
       z-index: 59;
+    }
+  }
+
+  .p-navigation.has-menu-open,
+  .p-navigation.has-search-open {
+    background-color: var(--color-navigation-background--active);
+
+    @media (min-width: $breakpoint-navigation-threshold) {
+      background-color: transparent;
     }
   }
 
@@ -702,75 +728,8 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     &:focus,
     &:hover,
     &:visited {
+      color: var(--color-navigation-text);
       text-decoration: none;
-    }
-  }
-}
-
-@mixin vf-navigation-theme(
-  // color for the navigation separator on small screens
-  $color-navigation-separator,
-  // color for the navigation background
-  $color-navigation-background,
-  $color-navigation-background--active,
-  // color for the navigation text
-  $color-navigation-text,
-  $color-navigation-background--hover,
-  // color for the navigation highlight bar
-  $color-navigation-highlight,
-  $color-navigation-icon
-) {
-  .p-navigation__link,
-  .p-navigation__link--search-toggle,
-  .p-navigation__toggle--close,
-  .p-navigation__toggle--open,
-  .p-navigation__dropdown-item {
-    &,
-    &:hover,
-    &:visited,
-    &:focus {
-      color: $color-navigation-text;
-    }
-
-    &:hover {
-      background-color: $color-navigation-background--hover;
-    }
-
-    &[aria-pressed='true'],
-    &:active {
-      background-color: $color-navigation-background--active;
-    }
-  }
-
-  .p-navigation__dropdown,
-  .p-navigation__dropdown--right {
-    background-color: $color-navigation-background;
-  }
-
-  [class*='p-navigation__item'].is-selected > .p-navigation__link {
-    background-color: $color-navigation-background--hover;
-
-    @include vf-highlight-bar($color-navigation-highlight, left, true);
-
-    @media (min-width: $breakpoint-navigation-threshold) {
-      @include vf-highlight-bar($color-navigation-highlight, bottom, false);
-    }
-  }
-
-  // add color to separator line for navigation items, navigation links and dropdown items
-  .p-navigation__nav .p-navigation__link::before,
-  .p-navigation__nav .p-navigation__items::before,
-  .p-navigation__nav .p-navigation__items .p-navigation__dropdown-item::before {
-    background: $color-navigation-separator;
-  }
-
-  // on mobile expanded nav needs to match pressed color of the buttons
-  &.has-menu-open .p-navigation__nav,
-  &.has-search-open .p-navigation__nav {
-    background-color: $color-navigation-background--active;
-
-    @media (min-width: $breakpoint-navigation-threshold) {
-      background-color: transparent;
     }
   }
 }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -153,7 +153,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
   }
 
   .p-navigation {
-    @if ($theme-default-hr == 'dark') {
+    @if ($theme-default-nav == 'dark') {
       @extend %dark-version;
     } @else {
       @extend %light-version;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -11,6 +11,25 @@ $sph-navigation-link: 0.3rem;
 $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
 
 @mixin vf-p-navigation {
+  %light-version {
+    --color-navigation-text: #{$colors--light-theme--text-default};
+    --color-navigation-background: #{$colors--light-theme--background-default};
+    --color-navigation-background--hover: #{$colors--light-theme--background-alt};
+    --color-navigation-background--active: #{$colors--light-theme--background-active};
+    --color-navigation-highlight: #{$colors--light-theme--text-default};
+    --color-navigation-separator: #{$colors--light-theme--border-low-contrast};
+    --color-navigation-icon: #{$colors--light-theme--text-default};
+  }
+  %dark-version {
+    --color-navigation-text: #{$colors--dark-theme--text-default};
+    --color-navigation-background: #{$colors--dark-theme--background-default};
+    --color-navigation-background--hover: #{$colors--dark-theme--background-hover};
+    --color-navigation-background--active: #{$colors--dark-theme--background-active};
+    --color-navigation-highlight: #{$colors--dark-theme--text-default};
+    --color-navigation-separator: #{$colors--dark-theme--border-low-contrast};
+    --color-navigation-icon: #{$colors--dark-theme--text-default};
+  }
+
   // placeholders
   %navigation-link-responsive-padding-vertical {
     padding-bottom: $spv--medium;
@@ -118,6 +137,22 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
   }
 
   .p-navigation {
+    @if ($theme-default-hr == 'dark') {
+      @extend %dark-version;
+    } @else {
+      @extend %light-version;
+    }
+
+    &.is-light {
+      @extend %light-version;
+    }
+
+    &.is-dark {
+      @extend %dark-version;
+    }
+
+    background-color: var(--color-navigation-background);
+
     display: flex;
     flex-direction: column;
     flex-shrink: 0;
@@ -186,6 +221,16 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
 
   .p-navigation__item,
   .p-navigation__item--dropdown-toggle {
+
+    .is-selected > .p-navigation__link {
+    background-color: var(--color-navigation-background--hover);
+
+    @include vf-highlight-bar(var(--color-navigation-highlight), left, true);
+
+    @media (min-width: $breakpoint-navigation-threshold) {
+      @include vf-highlight-bar(var(--color-navigation-highlight, bottom, false));
+    }
+
     @media (min-width: $breakpoint-navigation-threshold) {
       $nav-link-max-width: 20em !default;
 
@@ -270,6 +315,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
 
     .p-navigation__logo-title {
       @extend %vf-heading-4;
+      color: var(--color-navigation-text);
       font-size: #{map-get($font-sizes, h4)}rem;
       line-height: map-get($line-heights, x-small);
     }
@@ -444,6 +490,8 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     }
 
     &::after {
+      @include vf-icon-search(var(--color-navigation-icon));
+
       background-position: center;
       background-repeat: no-repeat;
       background-size: contain;
@@ -548,6 +596,8 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     @extend %vf-has-box-shadow;
     @extend %vf-has-round-corners;
 
+    background-color: var(--color-navigation-background);
+
     display: none;
     margin: 0;
     min-width: 100%;
@@ -573,6 +623,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     position: relative;
 
     &::after {
+      @include vf-icon-chevron(var(--color-navigation-icon));
       background-position: center;
       background-repeat: no-repeat;
       background-size: contain;
@@ -609,6 +660,10 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
       .p-navigation__dropdown,
       .p-navigation__dropdown--right {
         display: block;
+      }
+
+      > .p-navigation__link {
+        background-color: var(--color-navigation-background--active);
       }
     }
 
@@ -650,25 +705,6 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
       text-decoration: none;
     }
   }
-
-  // Theming
-  @if ($theme-default-nav == 'dark') {
-    .p-navigation {
-      @include vf-navigation-dark-theme;
-    }
-
-    .p-navigation.is-light {
-      @include vf-navigation-light-theme;
-    }
-  } @else {
-    .p-navigation {
-      @include vf-navigation-light-theme;
-    }
-
-    .p-navigation.is-dark {
-      @include vf-navigation-dark-theme;
-    }
-  }
 }
 
 @mixin vf-navigation-theme(
@@ -684,8 +720,6 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
   $color-navigation-highlight,
   $color-navigation-icon
 ) {
-  background-color: $color-navigation-background;
-
   .p-navigation__link,
   .p-navigation__link--search-toggle,
   .p-navigation__toggle--close,
@@ -706,25 +740,6 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     &:active {
       background-color: $color-navigation-background--active;
     }
-  }
-
-  .p-navigation__logo-title {
-    color: $color-navigation-text;
-  }
-
-  .p-navigation__item--dropdown-toggle {
-    &::after {
-      @include vf-icon-chevron($color-navigation-icon);
-    }
-
-    &.is-active > .p-navigation__link {
-      background-color: $color-navigation-background--active;
-    }
-  }
-
-  .p-navigation__toggle--search::after,
-  .p-navigation__item .p-navigation__link--search-toggle::after {
-    @include vf-icon-search($color-navigation-icon);
   }
 
   .p-navigation__dropdown,
@@ -758,28 +773,4 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
       background-color: transparent;
     }
   }
-}
-
-@mixin vf-navigation-light-theme {
-  @include vf-navigation-theme(
-    $color-navigation-text: $colors--light-theme--text-default,
-    $color-navigation-background: $colors--light-theme--background-default,
-    $color-navigation-background--hover: $colors--light-theme--background-alt,
-    $color-navigation-background--active: $colors--light-theme--background-active,
-    $color-navigation-highlight: $colors--light-theme--text-default,
-    $color-navigation-separator: $colors--light-theme--border-low-contrast,
-    $color-navigation-icon: $colors--light-theme--text-default
-  );
-}
-
-@mixin vf-navigation-dark-theme {
-  @include vf-navigation-theme(
-    $color-navigation-text: $colors--dark-theme--text-default,
-    $color-navigation-background: $colors--dark-theme--background-default,
-    $color-navigation-background--hover: $colors--dark-theme--background-hover,
-    $color-navigation-background--active: $colors--dark-theme--background-active,
-    $color-navigation-highlight: $colors--dark-theme--text-default,
-    $color-navigation-separator: $colors--dark-theme--border-low-contrast,
-    $color-navigation-icon: $colors--dark-theme--text-default
-  );
 }

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -1,4 +1,15 @@
 @mixin vf-p-search-box {
+  %light-version {
+    --color-search-box-background: #{$colors--light-theme--background-inputs};
+    --color-search-box-border: #{$colors--light-theme--border-high-contrast};
+    --color-search-box-text: #{$colors--light-theme--text-default};
+  }
+  %dark-version {
+    --color-search-box-background: #{lighten($colors--dark-theme--background-default, 10%)};
+    --color-search-box-border: #{$color-x-light};
+    --color-search-box-text: #{$colors--dark-theme--text-default};
+  }
+
   %search-box-button {
     display: block;
     height: calc((2 * $spv-nudge + map-get($line-heights, default-text)) - (2 * $bar-thickness)); // side padding + icon width - focus outline width * 2
@@ -24,6 +35,20 @@
   }
 
   .p-search-box {
+    @if ($theme-default-p-search-box == 'dark') {
+      @extend %dark-version;
+    } @else {
+      @extend %light-version;
+    }
+
+    &.is-light {
+      @extend %light-version;
+    }
+
+    &.is-dark {
+      @extend %dark-version;
+    }
+
     display: flex;
     justify-content: flex-end;
     margin-bottom: $input-margin-bottom;
@@ -39,11 +64,18 @@
     }
 
     .p-search-box__input {
+      background-color: var(--color-search-box-background);
+      border-color: var(--color-search-box-border);
+      color: var(--color-search-box-text);
       flex: 1 1 100%;
       margin-bottom: 0;
       padding-right: calc(2 * (2 * $spv-nudge + map-get($line-heights, default-text)));
       position: absolute;
       right: 0;
+
+      &::placeholder {
+        color: var(--color-search-box-text);
+      }
 
       &::-webkit-search-cancel-button {
         -webkit-appearance: none; // stylelint-disable-line property-no-vendor-prefix
@@ -51,6 +83,18 @@
 
       &:not(:valid) ~ .p-search-box__reset {
         display: none;
+      }
+
+      &:active,
+      &:focus,
+      &:hover,
+      &:-internal-autofill-selected,
+      &:-webkit-autofill,
+      &:-webkit-autofill:hover,
+      &:-webkit-autofill:focus {
+        // XXX: remove important once the button {} selector is refactored to use themeing. At the moment, it trumps these.
+        background-color: var(--color-search-box-background) !important;
+        border-color: var(--color-search-box-border) !important;
       }
     }
 
@@ -75,57 +119,6 @@
       border-width: 0;
     }
   }
-
-  @if ($theme-default-p-search-box == 'dark') {
-    .p-search-box__input {
-      @include vf-search-box-dark-theme;
-    }
-
-    .p-search-box.is-light {
-      .p-search-box__input {
-        @include vf-search-box-light-theme;
-      }
-    }
-  } @else {
-    .p-search-box {
-      .p-search-box__input {
-        @include vf-search-box-light-theme;
-      }
-    }
-
-    .p-search-box.is-dark {
-      .p-search-box__input {
-        @include vf-search-box-dark-theme;
-      }
-    }
-  }
-}
-
-@mixin vf-search-box-theme($color-search-box-background, $color-search-box-border, $color-search-box-text) {
-  //XXX: This should inherit from input color theming. Once that becomes available, delete this.
-  background-color: $color-search-box-background;
-  border-color: $color-search-box-border;
-  color: $color-search-box-text;
-
-  &:active,
-  &:focus,
-  &:hover,
-  &:-internal-autofill-selected,
-  &:-webkit-autofill,
-  &:-webkit-autofill:hover,
-  &:-webkit-autofill:focus {
-    // XXX: remove important once the button {} selector is refactored to use themeing. At the moment, it trumps these.
-    background-color: $color-search-box-background !important;
-    border-color: $color-search-box-border !important;
-  }
-}
-
-@mixin vf-search-box-light-theme {
-  @include vf-search-box-theme(
-    $color-search-box-background: $colors--light-theme--background-inputs,
-    $color-search-box-border: $colors--light-theme--border-high-contrast,
-    $color-search-box-text: $colors--light-theme--text-default
-  );
 }
 
 @mixin vf-search-box-dark-theme {

--- a/scss/_patterns_side-navigation-expandable.scss
+++ b/scss/_patterns_side-navigation-expandable.scss
@@ -1,6 +1,33 @@
 @import 'settings';
 
 @mixin vf-p-side-navigation-expandable {
+  %light-version {
+    --color-sidenav-text-active: #{$colors--light-theme--text-default};
+    --color-sidenav-item-background-hover: #{$colors--light-theme--background-hover};
+    --color-sidenav-toggle-icon: #{$colors--light-theme--text-inactive};
+  }
+  %dark-version {
+    --color-sidenav-text-active: #{$colors--dark-theme--text-default};
+    --color-sidenav-item-background-hover: #{$colors--dark-theme--background-hover};
+    --color-sidenav-toggle-icon: #{#999};
+  }
+
+  .p-side-navigation {
+    @if ($theme-default-p-side-navigation == 'dark') {
+      @extend %dark-version;
+    } @else {
+      @extend %light-version;
+    }
+
+    &.is-light {
+      @extend %light-version;
+    }
+
+    &.is-dark {
+      @extend %dark-version;
+    }
+  }
+
   .p-side-navigation__item,
   .p-side-navigation__item--title {
     // position relative for the absolutely positioned `.p-side-navigation__expand` button
@@ -15,6 +42,8 @@
   .p-side-navigation__expand {
     @include vf-button-base;
     background: none;
+
+    background-color: inherit;
     border: 0;
     border-radius: 0;
     font-size: inherit;
@@ -26,9 +55,14 @@
     right: 0;
     top: 0;
 
+    &:hover {
+      background: var(--color-sidenav-item-background-hover);
+      color: var(--color-sidenav-text-active);
+    }
+
     &::before {
       @extend %icon;
-      @include vf-icon-chevron;
+      @include vf-icon-chevron(var(--color-sidenav-toggle-icon));
       content: '';
       transform: rotate(-90deg);
       transition: transform 100ms;
@@ -58,56 +92,4 @@
     transform: translate3d(0, 0, 0);
     visibility: visible;
   }
-
-  // Theming for the expandable variant
-  @if ($theme-default-p-side-navigation == 'dark') {
-    .p-side-navigation,
-    [class*='p-side-navigation--'] {
-      @include vf-side-navigation-expandable-theme-dark;
-
-      &.is-light {
-        @include vf-side-navigation-expandable-theme-light;
-      }
-    }
-  } @else {
-    .p-side-navigation,
-    [class*='p-side-navigation--'] {
-      @include vf-side-navigation-expandable-theme-light;
-
-      &.is-dark {
-        @include vf-side-navigation-expandable-theme-dark;
-      }
-    }
-  }
-}
-
-@mixin vf-side-navigation-expandable-theme($color-sidenav-text-active, $color-sidenav-item-background-hover, $color-sidenav-toggle-icon) {
-  .p-side-navigation__expand {
-    background-color: inherit;
-    &::before {
-      @include vf-icon-chevron($color-sidenav-toggle-icon);
-    }
-
-    &:hover {
-      background: $color-sidenav-item-background-hover;
-      color: $color-sidenav-text-active;
-    }
-  }
-}
-
-@mixin vf-side-navigation-expandable-theme-light {
-  @include vf-side-navigation-expandable-theme(
-    $color-sidenav-text-active: $colors--light-theme--text-default,
-    $color-sidenav-item-background-hover: $colors--light-theme--background-hover,
-    $color-sidenav-toggle-icon: $colors--light-theme--text-inactive
-  );
-}
-
-@mixin vf-side-navigation-expandable-theme-dark {
-  @include vf-side-navigation-expandable-theme(
-    $color-sidenav-text-active: $colors--dark-theme--text-default,
-    $color-sidenav-item-background-hover: $colors--dark-theme--background-hover,
-    // color of toggle icon - needed because of lack of rgba support in icon mixin
-    $color-sidenav-toggle-icon: #999
-  );
 }


### PR DESCRIPTION
## Done

Change the way themes are applied from light and dark mixins to CSS variables.

### The issue now
The problem now is that colours are separated from other styles. All set in a different mixin at the end.
If you want to expand or change the component you have to find the `// Theming` section at the end to figure out on which selector those colours are applied: 
```scss
  // Theming
  @if ($theme-default-p-contextual-menu == 'dark') {
    @include vf-contextual-menu-dark-theme;

    [class*='p-contextual-menu'].is-light {
      @include vf-contextual-menu-light-theme;
    }
  } @else {
    @include vf-contextual-menu-light-theme;

    [class*='p-contextual-menu'].is-dark {
      @include vf-contextual-menu-dark-theme;
    }
  }
```

Then, looking at those light and dark mixins you can see that it duplicates the whole selector tree to apply colours where needed

```scss
@mixin vf-contextual-menu-theme(
  // color of the contextual menu background
  $color-contextual-menu-background,
  // color of the contextual menu border between groups
  $color-contextual-menu-border,
  // color of the contextual menu item link text
  $color-contextual-menu-text,
  // color of the contextual menu item link active background
  $color-contextual-menu-active-background,
  // color of the contextual menu item link hover background
  $color-contextual-menu-hover-background
) {
  .p-contextual-menu__dropdown {
    background: $color-contextual-menu-background;
  }

  .p-contextual-menu__group + .p-contextual-menu__group {
    border-top-color: $color-contextual-menu-border;
  }

  .p-contextual-menu__link {
    &,
    &:active,
    &:hover,
    &:visited {
      background-color: transparent;
      color: $color-contextual-menu-text;
    }

    &:hover {
      background-color: $color-contextual-menu-hover-background;
    }

    &:active {
      background-color: $color-contextual-menu-active-background;
      cursor: default;
    }
  }
}
```

This, in my opinion, is very fragile as it separates styles that should be tightly coupled and could lead to inconsistencies very quickly (and I find it a bit hard to work with to work out on which selector the mixin is applied to then from here, try and target the correct one). Plus it can get a little crazy on components with colour variations like chips and buttons.


### The proposed solution

Instead, what I propose is setting the colours at the top of the mixin using css variables. That way we can set the colours alongside every other property like we would do in any project.

First, we set the placeholders for the component
```scss
  %light-version {
    --color-contextual-menu-background: #{$colors--light-theme--background-default};
    --color-contextual-menu-hover-background: #{$colors--light-theme--background-hover};
    --color-contextual-menu-active-background: #{$colors--light-theme--background-active};
    --color-contextual-menu-border: #{$colors--light-theme--border-default};
    --color-contextual-menu-text: #{$colors--light-theme--text-default};
  }

  %dark-version {
    --color-contextual-menu-background: #{$colors--dark-theme--background-default};
    --color-contextual-menu-hover-background: #{$colors--dark-theme--background-hover};
    --color-contextual-menu-active-background: #{$colors--dark-theme--background-active};
    --color-contextual-menu-border: #{$colors--dark-theme--border-default};
    --color-contextual-menu-text: #{$colors--dark-theme--text-default};
  }
```

Then in the main selector/placeholder, we extend those based on the theme
```scss
    @if ($theme-default-p-contextual-menu == 'dark') {
      @extend %dark-version;
    } @else {
      @extend %light-version;
    }

    &.is-light {
      @extend %light-version;
    }

    &.is-dark {
      @extend %dark-version;
    }
```

And then we can just declare the colours alongside the other properties using the variables
```scss
  .p-contextual-menu__dropdown {
    @extend %vf-has-box-shadow;
    @extend %vf-has-round-corners;

    background: var(--color-contextual-menu-background);
    display: none;
    margin: 0;
    ...
```

### Going further

I kept the default theming logic 
```scss
    @if ($theme-default-p-contextual-menu == 'dark') {
      @extend %dark-version;
    } @else {
      @extend %light-version;
    }
``` 
as to not create a breaking change.

This is controlled by the https://github.com/canonical/vanilla-framework/blob/main/scss/_settings_themes.scss#L1-L10 file
```scss
$theme-default-forms: 'light' !default;
$theme-default-hr: 'light' !default;
$theme-default-nav: 'light' !default;
$theme-default-p-side-navigation: 'light' !default;
$theme-default-p-search-box: 'light' !default;
$theme-default-p-divider: 'light' !default;
$theme-default-p-contextual-menu: 'light' !default;
$theme-default-p-inline-list--middot: 'light' !default;
$theme-default-p-button: 'light' !default;
$theme-default-p-chip: 'light' !default;
```
I personally think this is a useless abstraction and not the way we should think about themes.
If we removed it, the way themes are applied could be simplified even further by getting rid of the placeholders:

```scss
  %p-contextual-menu {
    display: inline-block;
    margin: 0;
    position: relative;

    --color-contextual-menu-background: #{$colors--light-theme--background-default};
    --color-contextual-menu-hover-background: #{$colors--light-theme--background-hover};
    --color-contextual-menu-active-background: #{$colors--light-theme--background-active};
    --color-contextual-menu-border: #{$colors--light-theme--border-default};
    --color-contextual-menu-text: #{$colors--light-theme--text-default};

    &.is-dark {
        --color-contextual-menu-background: #{$colors--dark-theme--background-default};
        --color-contextual-menu-hover-background: #{$colors--dark-theme--background-hover};
        --color-contextual-menu-active-background: #{$colors--dark-theme--background-active};
        --color-contextual-menu-border: #{$colors--dark-theme--border-default};
        --color-contextual-menu-text: #{$colors--dark-theme--text-default};
    }
  }
```

And then going even further, if we imagine that the theme is applied globally by a class on the `<body>` element, we could have all the colour settings abstracted into this and away from the components themselves.


## QA

- Open [demo](https://vanilla-framework-4771.demos.haus/)
- Check that all the updated components look the same
- Check Percy to make sure nothing else broke.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


