### PR TITLE
Add paper colour variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -18,6 +18,8 @@ $color-caution: #f99b11 !default;
 $color-positive: #0e8420 !default;
 $color-information: #24598f !default;
 
+$color-paper: #f3f3f3 !default;
+
 // for dark themes
 $color-negative-dark: #a11223 !default;
 $color-positive-dark: #008013 !default;


### PR DESCRIPTION
## Done

Adds `$color-paper` variable for new page background (fully introduced in v4.0).

## QA

Just check the code if new variable is added with correct value `#f3f3f3`.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


