### PR TITLE
Implement white strips for paper background

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -4,6 +4,10 @@
       url: /docs/base/paper
       status: New
       notes: We've added new paper background colour that can be added to the body element using <code>is-paper</code> class name. Components designed for white backgrounds (like inputs) can use <code>on-paper</code> class to adjust for the new background.
+    - component: White strip
+      url: /docs/patterns/strip#white-strip
+      status: New
+      notes: We've added a new white strip component to highlight the content on new paper background.
 - version: 3.14.0
   features:
     - component: Common grid patterns

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -24,19 +24,26 @@
     @extend %vf-strip;
 
     background-color: transparent;
+  }
 
-    &--light {
-      @extend %vf-strip;
+  .p-strip--light {
+    @extend %vf-strip;
 
-      background-color: $color-light;
-    }
+    background-color: $color-light;
+  }
 
-    &--dark {
-      @extend %vf-strip;
+  .p-strip--dark {
+    @extend %vf-strip;
 
-      background-color: $color-dark;
-      color: $color-light;
-    }
+    background-color: $color-dark;
+    color: $color-light;
+  }
+
+  .p-strip--white {
+    @extend %vf-strip;
+
+    background-color: $color-x-light;
+    color: $colors--light-theme--text-default;
   }
 }
 

--- a/templates/docs/examples/layouts/brochure-site/_25-75-offset.html
+++ b/templates/docs/examples/layouts/brochure-site/_25-75-offset.html
@@ -1,7 +1,7 @@
-<div class="p-strip is-deep">
+<div class="p-strip--white is-deep">
     <div class="row--25-75">
         <div class="col">
-            <h1 class="p-heading--2"><strong>Company culture</strong></h1>
+            <h1>Company culture</h1>
             <h2>We believe that talent is evenly distributed around the world.&nbsp; Diversity is part of our strength. What unifies us isn’t our background,&nbsp; it’s our mission to amplify open source.</h2>
         </div>
     </div>

--- a/templates/docs/examples/patterns/strips/white.html
+++ b/templates/docs/examples/patterns/strips/white.html
@@ -1,0 +1,18 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Strips / White (on paper){% endblock %}
+
+{% block standalone_css %}patterns_strip{% endblock %}
+
+{% set is_paper = true %}
+{% block content %}
+<p>Some placeholder text to show body background...</p>
+<div class="p-strip--white">
+  <div class="row--25-75">
+      <div class="col">
+          <h1>Company culture</h1>
+          <h2>We believe that talent is evenly distributed around the world.&nbsp; Diversity is part of our strength. What unifies us isn’t our background,&nbsp; it’s our mission to amplify open source.</h2>
+      </div>
+  </div>
+</div>
+<p>Some placeholder text to show body background...</p>
+{% endblock %}

--- a/templates/docs/examples/patterns/strips/white.html
+++ b/templates/docs/examples/patterns/strips/white.html
@@ -5,14 +5,7 @@
 
 {% set is_paper = true %}
 {% block content %}
-<p>Some placeholder text to show body background...</p>
-<div class="p-strip--white">
-  <div class="row--25-75">
-      <div class="col">
-          <h1>Company culture</h1>
-          <h2>We believe that talent is evenly distributed around the world.&nbsp; Diversity is part of our strength. What unifies us isn’t our background,&nbsp; it’s our mission to amplify open source.</h2>
-      </div>
-  </div>
-</div>
-<p>Some placeholder text to show body background...</p>
+
+{% include "/docs/examples/layouts/brochure-site/_25-75-offset.html" %}
+
 {% endblock %}

--- a/templates/docs/patterns/strip/index.md
+++ b/templates/docs/patterns/strip/index.md
@@ -16,6 +16,16 @@ View example of the strip light pattern
 View example of the strip dark pattern
 </a></div>
 
+## White strip
+
+<span class="p-status-label--positive">New</span>
+
+The purpose of the white strip is to display some highlighted content on white background when page background is non-white (for when using paper page background).
+
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/white/" class="js-example">
+View example of the white strip
+</a></div>
+
 ## Accent strip
 
 The purpose of the strip accent pattern is to display content with a


### PR DESCRIPTION
## Done

Adds new white variant of strip `p-strip--white` that can be used with new paper background.

Fixes WD-3892

## QA

- Open [demo](https://vanilla-framework-4773.demos.haus/docs/patterns/strip#white-strip) with new white strip docs
- Review the docs and the example

NOTE: Circle CI job for running Percy is failing because or attempted merge with main branch. We are merging this PR to vanilla-4.0 branch, so it's fine for it to fail here.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1184" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/1d4bdd92-60dd-4e34-b8dc-8469fd7826b7">
