### PR TITLE
Add utility to limit max width of text lists

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -8,6 +8,10 @@
       url: /docs/patterns/strip#white-strip
       status: New
       notes: We've added a new white strip component to highlight the content on new paper background.
+    - component: Text max width utility
+      url: /docs/utilities/text-max-width
+      status: New
+      notes: We've added a new utility class <code>.u-text-max-width</code> to limit the width of text lists.
 - version: 3.15.0
   features:
     - component: Sliding navigation

--- a/scss/_utilities_text-max-width.scss
+++ b/scss/_utilities_text-max-width.scss
@@ -1,0 +1,14 @@
+@import 'settings';
+
+// Force child text elements (such as list items) to use text max width
+@mixin vf-u-text-max-width {
+  // currently we only need this on list items, as paragraphs and headings have max width by default
+
+  // stylelint-disable selector-max-type -- Utility needs to target elements
+  ul.u-text-max-width,
+  ol.u-text-max-width,
+  .u-text-max-width ul,
+  .u-text-max-width ol {
+    max-width: $text-max-width !important;
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -83,6 +83,7 @@
 @import 'utilities_vertical-spacing';
 @import 'utilities_vertically-center';
 @import 'utilities_no-print';
+@import 'utilities_text-max-width';
 
 // Include all the CSS
 @mixin vanilla {
@@ -170,4 +171,5 @@
   @include vf-u-show;
   @include vf-u-visualise-baseline;
   @include vf-u-no-print;
+  @include vf-u-text-max-width;
 }

--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -134,6 +134,8 @@
       url: /docs/utilities/padding-collapse
     - title: Table cell padding overlap
       url: /docs/utilities/table-cell-padding-overlap
+    - title: Text max width
+      url: /docs/utilities/text-max-width
     - title: Text with icon
       url: /docs/utilities/has-icon
     - title: Truncation

--- a/templates/docs/examples/utilities/text-max-width-container.html
+++ b/templates/docs/examples/utilities/text-max-width-container.html
@@ -1,0 +1,21 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Text max width / Container{% endblock %}
+
+{% block standalone_css %}patterns_lists{% endblock %}
+
+{% block content %}
+<div class="u-text-max-width">
+  <p>Reduce your average CVE exposure time from 98 days to 1 day with expanded CVE patching, ten-years security maintenance, optional support and operations for the full stack of open-source applications.</p>
+
+  <ol>
+    <li>How to check for and apply security updates on your Ubuntu machine, including security updates for Ubuntu Universe packages which are only available with Ubuntu Pro</li>
+    <li>Design and build
+      <ol>
+        <li>1870 packages are from Ubuntu Main/ Restricted repository which means that they receive Ubuntu LTS updates until 2025. This is covered without any subscription but can be expanded with Ubuntu Pro for additional 5 years, until 2030.</li>
+        <li>Integration requirements</li>
+      </ol>
+    </li>
+    <li>281 packages are from Ubuntu Universe/ Multiverse repository and they come with no security assurance with Ubuntu LTS. They would be covered by Ubuntu Pro and there might be beta security updates available for them today. Let’s find out if that is the case.</li>
+  </ol>
+</div>
+{% endblock %}

--- a/templates/docs/examples/utilities/text-max-width-divided.html
+++ b/templates/docs/examples/utilities/text-max-width-divided.html
@@ -1,0 +1,19 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Text max width / Divided{% endblock %}
+
+{% block standalone_css %}patterns_lists{% endblock %}
+
+{% block content %}
+<p>Reduce your average CVE exposure time from 98 days to 1 day with expanded CVE patching, ten-years security maintenance, optional support and operations for the full stack of open-source applications.</p>
+
+<ul class="p-list--divided u-text-max-width">
+  <li class="p-list__item has-bullet">How to check for and apply security updates on your Ubuntu machine, including security updates for Ubuntu Universe packages which are only available with Ubuntu Pro</li>
+  <li class="p-list__item has-bullet">Design and build
+    <ul class="p-list--divided">
+      <li class="p-list__item has-bullet">1870 packages are from Ubuntu Main/ Restricted repository which means that they receive Ubuntu LTS updates until 2025. This is covered without any subscription but can be expanded with Ubuntu Pro for additional 5 years, until 2030.</li>
+      <li class="p-list__item has-bullet">Integration requirements</li>
+    </ul>
+  </li>
+  <li class="p-list__item has-bullet">281 packages are from Ubuntu Universe/ Multiverse repository and they come with no security assurance with Ubuntu LTS. They would be covered by Ubuntu Pro and there might be beta security updates available for them today. Let’s find out if that is the case.</li>
+</ul>
+{% endblock %}

--- a/templates/docs/examples/utilities/text-max-width.html
+++ b/templates/docs/examples/utilities/text-max-width.html
@@ -1,0 +1,19 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Text max width{% endblock %}
+
+{% block standalone_css %}patterns_lists{% endblock %}
+
+{% block content %}
+<p>Reduce your average CVE exposure time from 98 days to 1 day with expanded CVE patching, ten-years security maintenance, optional support and operations for the full stack of open-source applications.</p>
+
+<ul class="u-text-max-width">
+  <li>How to check for and apply security updates on your Ubuntu machine, including security updates for Ubuntu Universe packages which are only available with Ubuntu Pro</li>
+  <li>Design and build
+    <ul>
+      <li>1870 packages are from Ubuntu Main/ Restricted repository which means that they receive Ubuntu LTS updates until 2025. This is covered without any subscription but can be expanded with Ubuntu Pro for additional 5 years, until 2030.</li>
+      <li>Integration requirements</li>
+    </ul>
+  </li>
+  <li>281 packages are from Ubuntu Universe/ Multiverse repository and they come with no security assurance with Ubuntu LTS. They would be covered by Ubuntu Pro and there might be beta security updates available for them today. Let’s find out if that is the case.</li>
+</ul>
+{% endblock %}

--- a/templates/docs/layouts/brochure.md
+++ b/templates/docs/layouts/brochure.md
@@ -32,7 +32,7 @@ context:
       <p class="u-no-margin--bottom">
         A page is a sequence of sections sandwiched between a header and a footer. To create a successful page, we need to get 3 things right:
       <p>
-      <ul class="p-list--divided" style="max-width: 40rem">{# TODO: replace with max-width utility when implemented #}
+      <ul class="p-list--divided u-text-max-width">
         <li class="p-list__item has-bullet">choose section layouts that present content effectively,</li>
         <li class="p-list__item has-bullet">prevent adjacent sections from competing for attention,</li>
         <li class="p-list__item has-bullet">ensure the choices above, which are made individually per section, resulting in a coherent, well-paced page.</li>
@@ -83,7 +83,7 @@ context:
     </div>
     <div class="col">
       <p>To remedy the “off by one column” problem, we use a system inspired by an oct-tree: Widths are multiples of 25% of the available space. This simple rule decimates the available choices, which has the following beneficial effects on our layouts:</p>
-      <ul class="p-list--divided" style="max-width: 40rem">{# TODO: replace with max-width utility when implemented #}
+      <ul class="p-list--divided u-text-max-width">
         <li class="p-list__item has-bullet">creates up to 4 invisible "fault lines" (at 0%, 25%, 50%, 75%, or at the start of the first, fourth, sixth and ninth column), to one of which all content, across all sections, aligns</li>
         <li class="p-list__item has-bullet">facilitates scanning/skimming, enabling the reader to quickly navigate by headings for example </li>
         <li class="p-list__item has-bullet">induces a strong sense of internal coherence, order and consistency</li>
@@ -112,7 +112,7 @@ context:
     </div>
     <div class="col">
       <p>Before we look at examples, let's highlight a couple of considerations used in conjunction with the 25% rule:</p>
-      <ul class="p-list--divided" style="max-width: 40rem">{# TODO: replace with max-width utility when implemented #}
+      <ul class="p-list--divided u-text-max-width">
         <li class="p-list__item has-bullet">Place larger blocks on the right-hand side of smaller blocks.  For example, if a heading is longer than the accompanying text, it would work better directly above it, rather than to the left of the text.</li>
         <li class="p-list__item has-bullet">Do not allow the quest for consistency to lead to monotony. Be mindful of pacing, and aim to create a rhythm of contrasts (large vs small, white space vs dense copy, etc ). This helps keep the page interesting and engaging.</li>
       </ul>
@@ -133,7 +133,7 @@ context:
           The 50/50 split
       </h2>
       <p>The 50/50 split is a very versatile layout. It places a short scannable part of the content (usually a heading) on the left-hand side. The rest of the content goes into the right-hand side. A few of the benefits of this layout:</p>
-      <ul class="p-list--divided" style="max-width: 40rem">{# TODO: replace with max-width utility when implemented #}
+      <ul class="p-list--divided u-text-max-width">
         <li class="p-list__item has-bullet">provides enough width for large headings (e.g. an h2) and long paragraphs;</li>
         <li class="p-list__item has-bullet">makes it easy to scan by headings;</li>
 <li class="p-list__item has-bullet">

--- a/templates/docs/migration-guide-to-v4.md
+++ b/templates/docs/migration-guide-to-v4.md
@@ -59,7 +59,7 @@ If you have any custom styles or components built on top of Vanilla headings, or
 
 You can search your codebase for any names listed below to find places that may be affected:
 
-<ul class="p-list--divided" style="max-width: 40rem">
+<ul class="p-list--divided u-text-max-width">
   <li class="p-list__item has-bullet">
     Elements <code>h1</code>, <code>h2</code>, <code>h3</code>, <code>h4</code>, (<code>h5</code>, <code>h6</code> if you want to be thorough)
   </li>
@@ -81,7 +81,7 @@ This change is automatic and doesn’t require any migration unless you have ove
 
 Search your codebase for `$grid-max-width`:
 
-<ul class="p-list--divided" style="max-width: 40rem">
+<ul class="p-list--divided u-text-max-width">
   <li class="p-list__item has-bullet">
     If you are overriding its value, make sure you still have to. It’s best to revert to default.
   </li>

--- a/templates/docs/utilities/text-max-width.md
+++ b/templates/docs/utilities/text-max-width.md
@@ -1,0 +1,36 @@
+---
+wrapper_template: '_layouts/docs.html'
+context:
+  title: Text max width | Utilities
+---
+
+# Text max width
+
+<hr>
+
+To limit the width of text elements, such as lists to match the max width of paragraphs and headings use the `.u-text-max-width` utility class on the list element itself, or on a parent element.
+
+<div class="embedded-example"><a href="/docs/examples/utilities/text-max-width-divided/" class="js-example">
+View example of the text max width utility
+</a></div>
+
+When class can't be applied to the list element itself, for example when the list is generated from Markdown or Discourse, you can apply the utility class to a parent element.
+
+<div class="embedded-example"><a href="/docs/examples/utilities/text-max-width-container/" class="js-example">
+View example of the text max width utility
+</a></div>
+
+## Import
+
+To import just this utility into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework';
+@include vf-base;
+
+@include vf-u-text-max-width;
+```
+
+For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/utilities/text-max-width.md
+++ b/templates/docs/utilities/text-max-width.md
@@ -8,7 +8,9 @@ context:
 
 <hr>
 
-To limit the width of text elements, such as lists to match the max width of paragraphs and headings use the `.u-text-max-width` utility class on the list element itself, or on a parent element.
+We aim to limit text to a measure (line width) of around 90 characters. This is done for readability purposes, and is already applied to paragraphs and headings.
+
+To limit the width of text lists to match the line width of paragraphs use the `.u-text-max-width` utility class on the list element itself, or on a parent element.
 
 <div class="embedded-example"><a href="/docs/examples/utilities/text-max-width-divided/" class="js-example">
 View example of the text max width utility


### PR DESCRIPTION
## Done

Adds utility to limit max width of text lists to match text elements.

Fixes [WD-2949](https://warthogs.atlassian.net/browse/WD-2949)

## QA

- Open [demo](https://vanilla-framework-4781.demos.haus/docs/utilities/text-max-width)
- Review new examples:
  - Util class on list: https://vanilla-framework-4781.demos.haus/docs/examples/utilities/text-max-width-container
  - Util class on container: https://vanilla-framework-4781.demos.haus/docs/examples/utilities/text-max-width-container
  - Util on divided list: https://vanilla-framework-4781.demos.haus/docs/examples/utilities/text-max-width-divided
- Review updated documentation:
  - https://vanilla-framework-4781.demos.haus/docs/utilities/text-max-width

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

<img width="687" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/3b233f71-fdd4-4217-a5db-1247a7e9fbc5">



[WD-2949]: https://warthogs.atlassian.net/browse/WD-2949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ