### PR TITLE
Update text colour to 000

### DIFF
--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -61,7 +61,7 @@ $code-inline-padding: 0.25rem;
 
   pre {
     background-color: $color-code-background;
-    color: $color-dark;
+    color: $colors--light-theme--text-default;
     display: block;
     margin-bottom: $spv--x-large;
     margin-top: 0;

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -25,7 +25,7 @@
     border: 0 solid transparent;
     border-bottom: $input-border-thickness solid $colors--light-theme--text-default;
     border-radius: 0;
-    color: $color-dark;
+    color: $colors--light-theme--text-default;
     font-family: unquote($font-base-family);
     font-size: 1rem;
     font-weight: $font-weight-regular-text;
@@ -198,7 +198,7 @@
     background-repeat: no-repeat;
     background-size: map-get($icon-sizes, default);
     box-shadow: none;
-    color: $color-dark;
+    color: $colors--light-theme--text-default;
     min-height: map-get($line-heights, default-text);
     padding-right: calc($default-icon-size + 2 * $sph--small);
     text-indent: 0.01px;

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -25,12 +25,12 @@
 
   %vf-bg--light {
     background-color: $color-light;
-    color: $color-dark;
+    color: $colors--light-theme--text-default;
   }
 
   %vf-bg--x-light {
     background-color: $color-x-light;
-    color: $color-dark;
+    color: $colors--light-theme--text-default;
   }
 
   %vf-card-padding {

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -8,7 +8,7 @@
 
   // stylelint-disable selector-max-type -- base styles can use type selectors
   html {
-    color: $color-dark;
+    color: $colors--light-theme--text-default;
     font-family: unquote($font-base-family);
     // These vendor prefixes are unique and cannot be added by autoprefixer
     -moz-osx-font-smoothing: grayscale;

--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -34,9 +34,9 @@
 // Test value of bg $color and return light or dark text color accordingly
 @function vf-contrast-text-color($color) {
   @if (lightness($color) > 55) {
-    @return $color-dark; // Lighter background, return dark color
+    @return $colors--light-theme--text-default; // Lighter background, return dark color
   } @else {
-    @return $color-x-light; // Darker background, return light color
+    @return $colors--dark-theme--text-default; // Darker background, return light color
   }
 }
 
@@ -44,9 +44,9 @@
 // variable.
 @function vf-determine-text-color($background-color) {
   @if (lightness($background-color) > 50) {
-    @return $color-dark;
+    @return $colors--light-theme--text-default;
   } @else {
-    @return $color-x-light;
+    @return $colors--dark-theme--text-default;
   }
 }
 

--- a/scss/_patterns_article-pagination.scss
+++ b/scss/_patterns_article-pagination.scss
@@ -17,7 +17,7 @@
 
   .p-article-pagination__label,
   .p-article-pagination__title {
-    color: $color-dark;
+    color: $colors--light-theme--text-default;
     display: block;
     margin-top: 0;
     width: 100%;

--- a/scss/_patterns_badge.scss
+++ b/scss/_patterns_badge.scss
@@ -3,7 +3,7 @@
 @mixin vf-p-badge {
   %vf-badge {
     @extend %x-small-text;
-    background-color: $color-dark;
+    background-color: $colors--light-theme--text-default;
     border-radius: 1rem;
     box-sizing: content-box;
     color: $color-x-light;

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -33,7 +33,7 @@
 @mixin vf-p-card-overlay {
   .p-card--overlay {
     background: transparentize($color-x-light, 0.1);
-    color: $color-dark;
+    color: $colors--light-theme--text-default;
     margin-bottom: $spv--x-large;
     overflow: auto;
     padding: $spv--large;

--- a/scss/_patterns_code-snippet.scss
+++ b/scss/_patterns_code-snippet.scss
@@ -115,7 +115,7 @@ $code-snippet-header-v-spacing: $spv--small;
     .p-code-snippet__dropdown {
       background-color: $color-transparent;
       border: 0;
-      color: $color-dark;
+      color: $colors--light-theme--text-default;
       margin-bottom: 0;
       margin-left: $sph--small;
       min-width: min-content;

--- a/scss/_patterns_form-password-toggle.scss
+++ b/scss/_patterns_form-password-toggle.scss
@@ -18,7 +18,7 @@
   .p-form-password-toggle + [type='text'] {
     &[readonly],
     &[readonly='readonly'] {
-      color: $color-dark;
+      color: $colors--light-theme--text-default;
     }
   }
 }

--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -2,10 +2,10 @@
 
 @mixin vf-p-links {
   .p-link--soft {
-    color: $color-dark;
+    color: $colors--light-theme--text-default;
 
     &:visited {
-      color: $color-dark;
+      color: $colors--light-theme--text-default;
       text-decoration: none;
     }
 
@@ -70,7 +70,7 @@
   }
 
   .p-top__link {
-    color: $color-dark;
+    color: $colors--light-theme--text-default;
     padding: 0 $sph--small 0 $sph--large;
     text-decoration: none;
   }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -77,7 +77,7 @@ $list-step-bullet-margin: $sph--x-large;
     }
 
     &::before {
-      color: $color-dark;
+      color: $colors--light-theme--text-default;
       content: counters(list-item, '.') '. ';
       display: inline-block;
       text-align: right;
@@ -86,7 +86,7 @@ $list-step-bullet-margin: $sph--x-large;
 
   %vf-list-item-bullet {
     &::before {
-      color: $color-dark;
+      color: $colors--light-theme--text-default;
       content: '•';
       display: inline-block;
       text-align: right;

--- a/scss/_patterns_media-object.scss
+++ b/scss/_patterns_media-object.scss
@@ -10,7 +10,7 @@
   %vf-meta-list-item {
     @extend %small-text;
 
-    color: $color-dark;
+    color: $colors--light-theme--text-default;
     padding-left: map-get($icon-sizes, default) + $sph--large;
   }
 

--- a/scss/_patterns_pagination.scss
+++ b/scss/_patterns_pagination.scss
@@ -8,7 +8,7 @@
     &.is-active,
     &[aria-current='page'] {
       background-color: scale-color($color-x-light, $lightness: -$active-background-opacity-amount * 100%);
-      color: $color-dark;
+      color: $colors--light-theme--text-default;
       text-decoration: none;
     }
   }

--- a/scss/_patterns_status-label.scss
+++ b/scss/_patterns_status-label.scss
@@ -36,7 +36,7 @@
     @extend %vf-status-label;
 
     background-color: $color-caution;
-    color: $color-dark;
+    color: $colors--light-theme--text-default;
   }
 
   .p-status-label--information,

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -64,7 +64,7 @@
     background-size: cover;
 
     &.is-light {
-      color: $color-dark;
+      color: $colors--light-theme--text-default;
     }
 
     &.is-dark {

--- a/scss/_patterns_table-of-contents.scss
+++ b/scss/_patterns_table-of-contents.scss
@@ -36,11 +36,11 @@
 
     .p-table-of-contents__link {
       border-bottom: 0;
-      color: $color-dark;
+      color: $colors--light-theme--text-default;
       margin-bottom: $sp-x-small;
 
       &:visited {
-        color: $color-dark;
+        color: $colors--light-theme--text-default;
       }
 
       &:hover {

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -44,7 +44,7 @@
 
       align-items: center;
       border: none;
-      color: $color-dark;
+      color: $colors--light-theme--text-default;
       display: flex;
       gap: $sph--small;
       height: 100%;

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -95,7 +95,7 @@ $states: (
 // --border-low-contrast  - low contrast version of border color, to be used when border needs more visibility (separators)
 
 // Light theme
-$colors--light-theme--text-default: #111 !default;
+$colors--light-theme--text-default: #000 !default;
 $colors--light-theme--text-muted: rgba($color-x-dark, $muted-text-opacity-amount) !default;
 $colors--light-theme--text-inactive: rgba($color-x-dark, $inactive-text-opacity-amount) !default;
 

--- a/templates/docs/migration-guide-to-v4.md
+++ b/templates/docs/migration-guide-to-v4.md
@@ -104,6 +104,12 @@ Old versions of global-nav have a setting for max width that may need to be adju
 
 Please make sure to review any templates or components that may make assumptions based on page width.
 
+## Updated text colour
+
+Vanilla 4.0 changes the default text colour to black `#000` (from previous `#111`). This change is automatic and doesn’t require any migration.
+
+If you have used the previous text colour (either by its value `#111` or by variable name `$color-dark`) in any custom styles or components, make sure to update them to use the new colour.
+
 ## Paper background
 
 Vanilla 4.0 introduces a new page background used on the brochure sites. It can be applied by adding the `is-paper` class to the body element.

--- a/templates/docs/utilities/functions.md
+++ b/templates/docs/utilities/functions.md
@@ -32,9 +32,9 @@ This function tests the value of the background's colour and returns light or da
 ```scss
 @function vf-determine-text-color($background-color) {
   @if (lightness($background-color) > 50) {
-    @return $color-dark;
+    @return $colors--light-theme--text-default;
   } @else {
-    @return $color-x-light;
+    @return $colors--dark-theme--text-default;
   }
 }
 ```


### PR DESCRIPTION
## Done

Updates default text colour to be black `#000` instead of dark grey `#111`

Fixes [WD-4561](https://warthogs.atlassian.net/browse/WD-4561)
Fixes #4784 

## QA

- Open [demo](https://vanilla-framework-4786.demos.haus/)
- Make sure all default text is black.
- Review updated documentation:
  - Check that migration guide mentions the colour change: https://vanilla-framework-4786.demos.haus/docs/migration-guide-to-v4#updated-text-colour

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).



[WD-4561]: https://warthogs.atlassian.net/browse/WD-4561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ