### PR TITLE
Reduce form input width - 10em to 8em

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -31,7 +31,7 @@
     font-weight: $font-weight-regular-text;
     line-height: map-get($line-heights, default-text);
     margin-bottom: $input-margin-bottom;
-    min-width: 10em;
+    min-width: 8em;
     padding-left: $sph--small;
     padding-right: $sph--small;
     vertical-align: baseline;


### PR DESCRIPTION
## Done

Reduced the input width to remedy the issue with the form input field on a smaller screen window. 

Fixes https://github.com/canonical/vanilla-framework/issues/4761

## QA

- Open [demo](https://vanilla-framework-4798.demos.haus/docs/examples/base/forms/input)
- Visit Examples Tab > Forms/Input link (under base)
  - https://vanilla-framework-4798.demos.haus/docs/examples/base/forms/input
- Inspect <input> div and check min-width property. Should have changed from 10em to 8em

What for:
- Visit https://ubuntu.com/blog.
- Before fix, when window has width just over 620px the input field border line is cut off
- After fix, the line stays centred 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

