### PR TITLE
Add teal accent colour

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -7,11 +7,11 @@
     - component: Accented headings
       url: /docs/base/typography#accented-headings
       status: New
-      notes: We've added a new class <code>.is-accented</code> to highlight headings with the accent colour.
+      notes: We've added a new class <code>.is-accent</code> to highlight headings with the accent colour.
     - component: Accented rules
       url: /docs/patterns/rule#highlighted
       status: New
-      notes: We've added a new class <code>.is-accented</code> to highlight rules with the accent colour.
+      notes: We've added a new class <code>.is-accent</code> to highlight rules with the accent colour.
     - component: Paper background
       url: /docs/base/paper
       status: New

--- a/releases.yml
+++ b/releases.yml
@@ -1,5 +1,17 @@
 - version: 4.0.0
   features:
+    - component: Colours
+      url: /docs/settings/color-settings
+      status: Updated
+      notes: We've updated our brand colour to Ubuntu orange and added a teal accent colour.
+    - component: Accented headings
+      url: /docs/base/typography#accented-headings
+      status: New
+      notes: We've added a new class <code>.is-accented</code> to highlight headings with the accent colour.
+    - component: Accented rules
+      url: /docs/patterns/rule#highlighted
+      status: New
+      notes: We've added a new class <code>.is-accented</code> to highlight rules with the accent colour.
     - component: Paper background
       url: /docs/base/paper
       status: New

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -1,6 +1,14 @@
 @mixin vf-b-typography-definitions {
+  %vf-is-accented {
+    &.is-accented {
+      color: $color-accent;
+    }
+  }
+
   //@section Heading styling in placeholders
   %vf-heading-2 {
+    @extend %vf-is-accented;
+
     font-size: #{map-get($font-sizes, h2-mobile)}rem;
     font-style: normal;
     font-weight: 180;
@@ -28,6 +36,8 @@
   }
 
   %vf-heading-3 {
+    @extend %vf-is-accented;
+
     font-size: #{map-get($font-sizes, h3-mobile)}rem;
     font-style: normal;
     font-weight: 550;
@@ -50,6 +60,8 @@
   }
 
   %vf-heading-4 {
+    @extend %vf-is-accented;
+
     font-size: #{map-get($font-sizes, h4-mobile)}rem;
     font-style: normal;
     font-weight: 275;

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -1,13 +1,13 @@
 @mixin vf-b-typography-definitions {
-  %vf-is-accented {
-    &.is-accented {
+  %vf-is-accent {
+    &.is-accent {
       color: $color-accent;
     }
   }
 
   //@section Heading styling in placeholders
   %vf-heading-2 {
-    @extend %vf-is-accented;
+    @extend %vf-is-accent;
 
     font-size: #{map-get($font-sizes, h2-mobile)}rem;
     font-style: normal;
@@ -36,7 +36,7 @@
   }
 
   %vf-heading-3 {
-    @extend %vf-is-accented;
+    @extend %vf-is-accent;
 
     font-size: #{map-get($font-sizes, h3-mobile)}rem;
     font-style: normal;
@@ -60,7 +60,7 @@
   }
 
   %vf-heading-4 {
-    @extend %vf-is-accented;
+    @extend %vf-is-accent;
 
     font-size: #{map-get($font-sizes, h4-mobile)}rem;
     font-style: normal;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -251,7 +251,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     }
 
     .p-navigation__logo-tag {
-      background-color: $color-accent;
+      background-color: $color-brand;
       height: $navigation-logo-tag-height;
       left: 0;
       position: absolute;

--- a/scss/_patterns_rule.scss
+++ b/scss/_patterns_rule.scss
@@ -9,4 +9,8 @@
   .p-rule--highlight {
     @include vf-highlight-bar($color-dark);
   }
+
+  .p-rule--highlight.is-accented {
+    @include vf-highlight-bar($color-accent);
+  }
 }

--- a/scss/_patterns_rule.scss
+++ b/scss/_patterns_rule.scss
@@ -10,7 +10,7 @@
     @include vf-highlight-bar($color-dark);
   }
 
-  .p-rule--highlight.is-accented {
+  .p-rule--highlight.is-accent {
     @include vf-highlight-bar($color-accent);
   }
 }

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -204,8 +204,7 @@ $colors--paper-theme--background-active: rgba($color-x-dark, $active-background-
 $colors--paper-theme--background-hover: rgba($color-x-dark, $hover-background-opacity-amount) !default;
 
 // Branding colors
-$color-brand: #333 !default;
+$color-brand: #e95420 !default;
 $color-brand-dark: $color-brand !default;
-$color-brand-background: $colors--dark-theme--background-default;
-$color-accent: #e95420 !default;
-$color-accent-background: $color-brand !default;
+$color-accent: #0f95a1 !default;
+$color-accent-background: $colors--dark-theme--background-default !default; // changed from "brand" colour to dark theme background

--- a/templates/docs/base/typography.md
+++ b/templates/docs/base/typography.md
@@ -159,6 +159,14 @@ better suits your document style and tree.
 View example of the mixed headings pattern
 </a></div>
 
+## Accented headings
+
+The accent colour can be sparingly used to highlight headings to help them stand out from the rest of the page.
+
+<div class="embedded-example"><a href="/docs/examples/base/headings-accented/" class="js-example">
+View example of the accented headings pattern
+</a></div>
+
 ## Line length
 
 Line length, measured in number of characters per line (CPL), has been shown to affect reading speed and comprehension. While there is little consensus on what the optimal CPL value is, most studies test with values between 45 and 95 characters per line. <a href="https://en.wikipedia.org/wiki/Line_length">Wikipedia</a> has a good historical overview and a list of studies on the subject.

--- a/templates/docs/examples/base/headings-accented.html
+++ b/templates/docs/examples/base/headings-accented.html
@@ -1,0 +1,8 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Headings / Accented{% endblock %}
+
+{% block standalone_css %}base{% endblock %}
+
+{% block content %}
+<h1 class="is-accented">This is a sample of an accented heading</h1>
+{% endblock %}

--- a/templates/docs/examples/base/headings-accented.html
+++ b/templates/docs/examples/base/headings-accented.html
@@ -4,5 +4,5 @@
 {% block standalone_css %}base{% endblock %}
 
 {% block content %}
-<h1 class="is-accented">This is a sample of an accented heading</h1>
+<h1 class="is-accent">This is a sample of an accented heading</h1>
 {% endblock %}

--- a/templates/docs/examples/layouts/brochure-site/_25-75-nested.html
+++ b/templates/docs/examples/layouts/brochure-site/_25-75-nested.html
@@ -9,7 +9,7 @@
     <div class="col">
       <div class="row">
         <div class="col-medium-2 col-3">
-          <hr class="p-rule--highlight">
+          <hr class="p-rule--highlight is-accented">
           <h4 class="p-heading--2"><strong>950+</strong><br>Employees</h4>
         </div>
         <div class="col-medium-2 col-3">

--- a/templates/docs/examples/layouts/brochure-site/_25-75-nested.html
+++ b/templates/docs/examples/layouts/brochure-site/_25-75-nested.html
@@ -9,7 +9,7 @@
     <div class="col">
       <div class="row">
         <div class="col-medium-2 col-3">
-          <hr class="p-rule--highlight is-accented">
+          <hr class="p-rule--highlight is-accent">
           <h4 class="p-heading--2"><strong>950+</strong><br>Employees</h4>
         </div>
         <div class="col-medium-2 col-3">

--- a/templates/docs/migration-guide-to-v4.md
+++ b/templates/docs/migration-guide-to-v4.md
@@ -127,6 +127,16 @@ To highlight sections of the page you can use a new white strip `p-strip--white`
 
 For more information see [our documentation of paper background ](/docs/base/paper), [white strip component](/docs/patterns/strip#white-strip) or [brochure layout guidelines](/docs/layouts/brochure).
 
+## Brand and accent colours
+
+In Vanilla 4.0 we clean up some of the colours used in the design system and introduce a new accent colour. The brand colour in `$color-brand` variable is updated to the Ubuntu orange value `#E95420` (from previous "brandless" `#333`). We also update the `$color-accent` variable to a new teal colour value `#0F95A1`.
+
+### How to update
+
+This change is automatic and doesn’t require any migration unless you have overridden the `$color-brand` or `$color-accent` values yourself. You should remove any overrides and use the new values if possible. If you are using these variables anywhere make sure that relevant styles still work with the new values.
+
+If you are using the `$color-brand` or `$color-accent` variable in any custom styles or components, make sure to verify they work as expected and review them with visual designer to make sure the new colours are used correctly.
+
 ## New components
 
 Before releasing Vanilla 4.0 we started adding new components to help building brochure sites in a new style. While these are not technically new to 4.0, it’s worth taking the migration opportunity and learning more about them, and start using them where feasible.

--- a/templates/docs/patterns/rule.md
+++ b/templates/docs/patterns/rule.md
@@ -24,6 +24,8 @@ View example of a default horizontal rule
 
 You can add a highlight to a rule to make it stand out more. This is useful for drawing attention to a section of content.
 
+Highlighted rule can also be accented by adding `is-accented` modifier class.
+
 <div class="embedded-example"><a href="/docs/examples/patterns/rule/highlight" class="js-example">
 View example of a highlighted rule
 </a></div>

--- a/templates/docs/patterns/rule.md
+++ b/templates/docs/patterns/rule.md
@@ -14,13 +14,13 @@ It "anchors" elements that are far apart, and at risk of appearing floating in s
 
 It indicates the direction in which we want the viewer to read the content.
 
-### Default
+## Default
 
 <div class="embedded-example"><a href="/docs/examples/patterns/rule/default" class="js-example">
 View example of a default horizontal rule
 </a></div>
 
-### Highlighted
+## Highlighted
 
 You can add a highlight to a rule to make it stand out more. This is useful for drawing attention to a section of content.
 

--- a/templates/docs/patterns/rule.md
+++ b/templates/docs/patterns/rule.md
@@ -24,7 +24,7 @@ View example of a default horizontal rule
 
 You can add a highlight to a rule to make it stand out more. This is useful for drawing attention to a section of content.
 
-Highlighted rule can also be accented by adding `is-accented` modifier class.
+Highlighted rule can also be accented by adding `is-accent` modifier class.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/rule/highlight" class="js-example">
 View example of a highlighted rule

--- a/templates/docs/settings/color-settings.md
+++ b/templates/docs/settings/color-settings.md
@@ -57,9 +57,9 @@ These guidelines are the framework upon which we have built our system for how c
       </p>
     </div>
     <div class="col-2 p-card u-no-padding">
-      <div class="p-strip is-shallow is-bordered" style="background-color: #333"></div>
+      <div class="p-strip is-shallow is-bordered" style="background-color: #e95420"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
-        $color-brand<br><span class="p-muted-heading">#333</span>
+        $color-brand<br><span class="p-muted-heading">#e95420</span>
       </p>
     </div>
   </div>
@@ -97,23 +97,13 @@ These guidelines are the framework upon which we have built our system for how c
       </p>
     </div>
     <div class="col-2 p-card u-no-padding">
-      <div class="p-strip is-shallow is-bordered" style="background-color: #e95420"></div>
+      <div class="p-strip is-shallow is-bordered" style="background-color: #0f95a1"></div>
       <p class="p-card__content u-no-margin" style="padding: 1rem">
-        $color-accent<br><span class="p-muted-heading">#e95420</span>
-      </p>
-    </div>
-    <div class="col-2 p-card u-no-padding">
-      <div class="p-strip is-shallow is-bordered" style="background-color: #333"></div>
-      <p class="p-card__content u-no-margin" style="padding: 1rem">
-        $color-accent-background<br><span class="p-muted-heading">#333</span>
+        $color-accent<br><span class="p-muted-heading">#0f95a1</span>
       </p>
     </div>
   </div>
 </div>
-
-You can define a brand color (`$color-brand`) that can be used for call-to-action buttons and other highlights across the framework. The default Vanilla brand color is `$color-dark`.
-
-<img class="p-image--bordered" src="https://assets.ubuntu.com/v1/7446a44a-basics-brand-color.png" alt="">
 
 ## Accessibility
 


### PR DESCRIPTION
## Done

Adds teal as accent colour, Ubuntu orange is now properly the brand colour.

Fixes [WD-3103](https://warthogs.atlassian.net/browse/WD-3103)

## QA

- Open [demo](https://vanilla-framework-4799.demos.haus/docs/settings/color-settings)
- Review examples with accented headings and rules
  - https://vanilla-framework-4799.demos.haus/docs/examples/base/headings-accented
  - https://vanilla-framework-4799.demos.haus/docs/examples/patterns/rule/highlight
- Review updated documentation:
  - Colour docs:  https://vanilla-framework-4799.demos.haus/docs/settings/color-settings
  - Accented headings: https://vanilla-framework-4799.demos.haus/docs/base/typography#accented-headings
  - Accented rule: https://vanilla-framework-4799.demos.haus/docs/patterns/rule#highlighted

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).



[WD-3103]: https://warthogs.atlassian.net/browse/WD-3103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ