### PR TITLE
Use ps5 registry

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1,6 +1,6 @@
 domain: vanillaframework.io
 
-image: prod-comms.docker-registry.canonical.com/vanillaframework.io
+image: prod-comms.ps5.docker-registry.canonical.com/vanillaframework.io
 
 env:
   - name: SENTRY_DSN


### PR DESCRIPTION
I've updated https://jenkins.canonical.com/webteam/job/vanillaframework.io-staging/ and https://jenkins.canonical.com/webteam/job/vanillaframework.io-production/ to pull the appropriate registry from the konf file.