### PR TITLE
Remove rounded corners

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1,5 +1,9 @@
 - version: 4.0.0
   features:
+    - component: Border radius setting
+      url: /docs/settings/placeholder-settings
+      status: Deprecated
+      notes: We removed rounder corners from all Vanilla components and deprecated the use of <code>$border-radius</code> variable.
     - component: Links dark theme
       url: /docs/patterns/links#dark
       status: New

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -26,7 +26,6 @@ $code-inline-padding: 0.25rem;
   kbd,
   samp {
     background-color: $color-code-background;
-    border-radius: $border-radius;
     box-decoration-break: slice;
     color: inherit;
     line-height: map-get($line-heights, default-text) - $code-inline-padding;

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -240,7 +240,6 @@
   fieldset {
     @extend %vf-card;
     @extend %vf-is-bordered;
-    @extend %vf-has-round-corners;
 
     margin-left: 0;
     margin-right: 0;

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -7,6 +7,8 @@
   @include vf-b-typography-definitions;
 
   // Styling
+
+  // deprecated, will be removed in future version of Vanilla
   %vf-has-round-corners {
     border-radius: $border-radius;
   }

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -12,7 +12,6 @@
   .p-card {
     @extend %vf-card;
     @extend %vf-is-bordered;
-    @extend %vf-has-round-corners;
 
     padding: calc($spv--large - 1px);
   }
@@ -22,7 +21,6 @@
   %p-card--highlighted {
     @extend %vf-card;
     @extend %vf-has-box-shadow;
-    @extend %vf-has-round-corners;
   }
 
   .p-card--highlighted {
@@ -44,7 +42,6 @@
   .p-card--muted {
     @extend %vf-bg--light;
     @extend %vf-has-box-shadow;
-    @extend %vf-has-round-corners;
 
     margin-bottom: $spv--x-large;
     overflow: auto;

--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -14,7 +14,6 @@
   // Dropdown element for contextual menu
   .p-contextual-menu__dropdown {
     @extend %vf-has-box-shadow;
-    @extend %vf-has-round-corners;
 
     display: none;
     margin: 0;
@@ -79,7 +78,6 @@
     width: 100%;
 
     &:hover {
-      border-radius: $border-radius;
       text-decoration: none;
     }
   }

--- a/scss/_patterns_media-object.scss
+++ b/scss/_patterns_media-object.scss
@@ -28,7 +28,6 @@
 
   .p-media-object__image {
     align-self: flex-start;
-    border-radius: $border-radius;
     flex-basis: inherit;
     flex-shrink: 0;
     margin-right: $sph--large;

--- a/scss/_patterns_modal.scss
+++ b/scss/_patterns_modal.scss
@@ -23,7 +23,6 @@
   .p-modal__dialog {
     @extend %vf-card;
     @extend %vf-has-box-shadow;
-    @extend %vf-has-round-corners;
 
     left: $sph--x-large;
     margin-bottom: 0;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -552,7 +552,6 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
   .p-navigation__dropdown,
   .p-navigation__dropdown--right {
     @extend %vf-has-box-shadow;
-    @extend %vf-has-round-corners;
 
     display: none;
     margin: 0;

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -79,7 +79,6 @@ $notification-text-margin-bottom: $spv--large - $spv-nudge;
     background-position: $sph--large $notification-icon-vert-offset;
     background-repeat: no-repeat;
     background-size: map-get($icon-sizes, default);
-    border-radius: 0 $border-radius $border-radius 0;
     margin-bottom: $spv--x-large;
     padding-bottom: calc($spv--small - 1px);
     padding-left: $notification-content-icon-space;

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -73,7 +73,6 @@
       @include vf-transition(opacity, fast);
 
       background-color: $color-x-light;
-      border-radius: $border-radius;
       box-shadow: $box-shadow;
       opacity: 1;
       padding: $input-vertical-padding $sph--large 0;

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -60,7 +60,6 @@
 
       border-left-style: solid;
       border-left-width: 1px;
-      border-radius: 0 $border-radius $border-radius 0;
       margin-right: $bar-thickness;
     }
   }

--- a/scss/_patterns_segmented-control.scss
+++ b/scss/_patterns_segmented-control.scss
@@ -1,7 +1,7 @@
 @mixin vf-p-segmented-control {
   .p-segmented-control,
   // p-tab-buttons is deprecated,
-  // please use p-segmented-control instead 
+  // please use p-segmented-control instead
   .p-tab-buttons {
     .p-segmented-control__list,
     .p-tab-buttons__list {
@@ -35,14 +35,6 @@
           top: 0;
           width: $input-border-thickness;
         }
-      }
-
-      &:first-child {
-        border-radius: $border-radius 0 0 $border-radius;
-      }
-
-      &:last-child {
-        border-radius: 0 $border-radius $border-radius 0;
       }
     }
 

--- a/scss/_patterns_status-label.scss
+++ b/scss/_patterns_status-label.scss
@@ -6,7 +6,6 @@
     @extend %x-small-text;
     @extend %u-no-margin--bottom--small;
 
-    border-radius: $border-radius;
     display: inline-block;
     font-weight: $font-weight-bold;
     padding: map-get($nudges, x-small) $sph--small;

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -45,7 +45,6 @@ $knob-size: $sp-unit * 2;
     width: $knob-size * 2;
 
     &::before {
-      @extend %vf-has-round-corners;
       @extend %vf-has-box-shadow;
       @include vf-transition($duration: slow);
 

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -26,7 +26,6 @@
 
         tr {
           border: $border;
-          border-radius: $border-radius;
           display: block;
           margin-bottom: $spv--x-large;
           padding: 0 $sph--large;

--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -36,7 +36,6 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
 
     background-color: $color-dark;
     border: 0;
-    border-radius: $border-radius;
     color: $color-x-light;
     display: none;
     left: -2 * $triangle-height;

--- a/scss/_settings_placeholders.scss
+++ b/scss/_settings_placeholders.scss
@@ -4,7 +4,7 @@
 // Global placeholder settings
 $input-border-thickness: 1.5px;
 $bar-thickness: 0.1875rem !default; // 3px at 16px fontsize, expressed in rems so it scales with text if the root font-size changes at a breakpoint
-$border-radius: $sp-unit * 0.25 !default;
+$border-radius: 0; // deprecated, will be removed in future version of Vanilla
 $border: $input-border-thickness solid $color-mid-light !default;
 $box-shadow: 0 1px 1px 0 transparentize($color-x-dark, 0.85), 0 2px 2px -1px transparentize($color-x-dark, 0.85), 0 0 3px 0 transparentize($color-x-dark, 0.8) !default;
 $box-shadow--deep: 0 0 2rem 0 rgba($color-x-dark, $shadow-opacity) !default;

--- a/templates/docs/settings/placeholder-settings.md
+++ b/templates/docs/settings/placeholder-settings.md
@@ -25,11 +25,6 @@ Vanilla uses several global placeholders to share common styles between componen
       <td>Navigation, notification</td>
     </tr>
     <tr>
-      <td><code>$border-radius</code></td>
-      <td><a href="https://github.com/canonical/vanilla-framework/blob/main/scss/_settings_placeholders.scss#L6-L9"><code>$sp-unit * 0.25</code></a></td>
-      <td>Button, Card, Code, Form, Media object, Switch, Tooltip</td>
-    </tr>
-    <tr>
       <td><code>$border</code></td>
       <td><a href="https://github.com/canonical/vanilla-framework/blob/main/scss/_settings_placeholders.scss#L6-L9"><code>1px solid $color-mid-light</code></a></td>
       <td>Card, Code, Form, Search box</td>
@@ -38,6 +33,11 @@ Vanilla uses several global placeholders to share common styles between componen
       <td><code>$box-shadow</code></td>
       <td class="u-truncate"><a href="https://github.com/canonical/vanilla-framework/blob/main/scss/_settings_placeholders.scss#L6-L9"><code>0 1px 1px 0 transparentize($color-x-dark, 0.85), 0 2px 2px -1px transparentize($color-x-dark, 0.85), 0 0 3px 0 transparentize($color-x-dark, 0.8)</code></a></td>
       <td>Card (highlighted), Modal, Notification, Switch</td>
+    </tr>
+    <tr>
+      <td><code>$border-radius</code></td>
+      <td><a href="https://github.com/canonical/vanilla-framework/blob/main/scss/_settings_placeholders.scss#L6-L9"><code>0</code></a></td>
+      <td><span class="p-status-label--negative">Deprecated</span> This variable should not be used or modified, it will be removed in future version of Vanilla.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Done

Removes rounded corners (changes border-radius to 0), deprecates the use of `$border-radius` variable and `%vf-has-rounded-corners` placeholder.

Fixes [WD-539](https://warthogs.atlassian.net/browse/WD-539)

## QA

- Open [demo](https://vanilla-framework-4810.demos.haus/docs/settings/placeholder-settings)
- Review affected components:
  - Cards https://vanilla-framework-4810.demos.haus/docs/patterns/card
  - Code https://vanilla-framework-4810.demos.haus/docs/base/code
  - Contextual menu https://vanilla-framework-4810.demos.haus/docs/patterns/contextual-menu
  - Fieldset: https://vanilla-framework-4810.demos.haus/docs/base/forms#fieldset
  - Modal https://vanilla-framework-4810.demos.haus/docs/patterns/modal
  - Media object https://vanilla-framework-4810.demos.haus/docs/patterns/media-object
  - Navigation (dropdowns) https://vanilla-framework-4810.demos.haus/docs/patterns/navigation#dropdown
  - Notification https://vanilla-framework-4810.demos.haus/docs/patterns/notification
  - Search and Filter (expanded dropdown) https://vanilla-framework-4810.demos.haus/docs/patterns/search-and-filter
  - Search box https://vanilla-framework-4810.demos.haus/docs/patterns/search-box
  - Segmented control https://vanilla-framework-4810.demos.haus/docs/patterns/segmented-control
  - Status label https://vanilla-framework-4810.demos.haus/docs/patterns/status-labels
  - Table mobile card (mobile card view) https://vanilla-framework-4810.demos.haus/docs/base/tables#responsive
  - Tooltips https://vanilla-framework-4810.demos.haus/docs/patterns/tooltips
- Review updated documentation:
  - https://vanilla-framework-4810.demos.haus/docs/settings/placeholder-settings


[WD-539]: https://warthogs.atlassian.net/browse/WD-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ