### PR TITLE
Breadcrumbs - chevrons to slashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_breadcrumbs.scss
+++ b/scss/_patterns_breadcrumbs.scss
@@ -25,7 +25,7 @@
     }
 
     &:not(:first-of-type)::before {
-      content: '\2215';
+      content: '/';
       margin-left: -0.75rem;
       margin-right: 0.5rem;
     }

--- a/scss/_patterns_breadcrumbs.scss
+++ b/scss/_patterns_breadcrumbs.scss
@@ -25,7 +25,7 @@
     }
 
     &:not(:first-of-type)::before {
-      content: '\203A';
+      content: '\2215';
       margin-left: -0.75rem;
       margin-right: 0.5rem;
     }


### PR DESCRIPTION
## Done

Changed the breadcrumb style from chevrons to forward slashes on the breadcrumbs component 

Fixes https://github.com/canonical/vanilla-framework/issues/4768

## QA

- Open demo https://vanilla-framework-4811.demos.haus/docs/examples/patterns/breadcrumbs
- Go to Examples tab > [Breadcrumbs](https://vanilla-framework-4811.demos.haus/docs/examples/patterns/breadcrumbs) (under Components heading)
- Inspect the ".p-breadcrumbs__item:not(:first-of-type)::before" markup - The content unicode has been changed to a forward slash

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
