### PR TITLE
Use is-dark class name for consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.0.0-alpha.3",
+  "version": "4.0.0-rc.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -11,11 +11,11 @@
     - component: Links dark theme
       url: /docs/patterns/links#dark
       status: New
-      notes: We've added a new class <code>.on-dark</code> to use the links on dark backgrounds.
+      notes: We've added a new class <code>.is-dark</code> to use the links on dark backgrounds.
     - component: Rules dark theme
       url: /docs/patterns/rule#dark-theme
       status: New
-      notes: We've added a new class <code>.on-dark</code> to use the rules on dark backgrounds.
+      notes: We've added a new class <code>.is-dark</code> to use the rules on dark backgrounds.
     - component: Colours
       url: /docs/settings/color-settings
       status: Updated

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -46,8 +46,7 @@
       @include vf-hr-dark-theme;
     }
 
-    hr.is-light, // deprecated, use on-light instead
-    hr.on-light {
+    hr.is-light {
       @include vf-hr-light-theme;
     }
   } @else {
@@ -55,8 +54,7 @@
       @include vf-hr-light-theme;
     }
 
-    hr.is-dark, // deprecated, use on-dark instead
-    hr.on-dark {
+    hr.is-dark {
       @include vf-hr-dark-theme;
     }
   }

--- a/scss/_base_links.scss
+++ b/scss/_base_links.scss
@@ -28,7 +28,7 @@
       color: $color-link-visited;
     }
 
-    &.on-dark {
+    &.is-dark {
       color: $color-link-dark;
 
       &:visited {

--- a/scss/_patterns_rule.scss
+++ b/scss/_patterns_rule.scss
@@ -10,7 +10,7 @@
   .p-rule--muted {
     background-color: $colors--light-theme--border-low-contrast;
 
-    &.on-dark {
+    &.is-dark {
       background-color: $colors--dark-theme--border-low-contrast;
     }
   }
@@ -18,7 +18,7 @@
   .p-rule--highlight {
     @include vf-highlight-bar($colors--light-theme--text-default);
 
-    &.on-dark {
+    &.is-dark {
       @include vf-highlight-bar($colors--dark-theme--text-default);
     }
 

--- a/templates/docs/examples/patterns/links/links-dark.html
+++ b/templates/docs/examples/patterns/links/links-dark.html
@@ -5,6 +5,6 @@
 
 {% block content %}
 <div class="p-strip--dark">
-  <a href="#" class="p-link on-dark">Package & publish your app</a>
+  <a href="#" class="p-link is-dark">Package & publish your app</a>
 </div>
 {% endblock %}

--- a/templates/docs/examples/patterns/rule/dark.html
+++ b/templates/docs/examples/patterns/rule/dark.html
@@ -7,7 +7,7 @@
 
 <div class="p-strip--dark">
     <div class="u-fixed-width p-block">
-      <hr class="p-rule--highlight on-dark">
+      <hr class="p-rule--highlight is-dark">
       <h2>
         <strong>
           A broad portfolio.
@@ -18,16 +18,16 @@
     <div class="p-block">
       <div class="row--25-75">
         <div class="col">
-          <hr class="p-rule on-dark">
+          <hr class="p-rule is-dark">
           <div class="row">
             <div class="col-6">
               <h2>One stable platform <br>for everything open source</h2>
               <p>Build with confidence using the world's favourite Linux operating system. <br>Ubuntu delivers long-term supported releases every two years.</p>
             </div>
             <div class="col-3">
-              <h2><a href="#">Desktop&nbsp;›</a></h2>
-              <hr class="p-rule--muted on-dark u-hide--medium">
-              <h2><a href="#">Server&nbsp;›</a></h2>
+              <h2><a class="p-link is-dark" href="#">Desktop&nbsp;›</a></h2>
+              <hr class="p-rule--muted is-dark u-hide--medium">
+              <h2><a class="is-dark" href="#">Server&nbsp;›</a></h2>
             </div>
           </div>
         </div>

--- a/templates/docs/migration-guide-to-v4.md
+++ b/templates/docs/migration-guide-to-v4.md
@@ -118,7 +118,7 @@ If you are using the dark strip (`.p-strip--dark`) make sure to test them to see
 
 ### Links on dark background
 
-In Vanilla 4.0 we introduced a new link style for links on dark background. Instead of using the default link colour or existing inverted link, new class `on-dark` should be added to text links that are placed on dark background. The inverted link `p-link--inverted` should be used only for links on backgrounds of unknown dark colour or on top of images.
+In Vanilla 4.0 we introduced a new link style for links on dark background. Instead of using the default link colour or existing inverted link, new class `is-dark` should be added to text links that are placed on dark background. The inverted link `p-link--inverted` should be used only for links on backgrounds of unknown dark colour or on top of images.
 
 ## Paper background
 
@@ -165,7 +165,7 @@ New rule component provides a consistent way of adding horizontal lines that are
 
 Use the new component in places where previously an `hr` with `u-no-margin--bottom` class name was used.
 
-To use rule component on dark backgrounds use the `on-dark` modifier class.
+To use rule component on dark backgrounds use the `is-dark` modifier class.
 
 For more information see [the rule component documentation](/docs/patterns/rule) or [brochure layout guidelines](/docs/layouts/brochure).
 

--- a/templates/docs/patterns/links/index.md
+++ b/templates/docs/patterns/links/index.md
@@ -24,7 +24,7 @@ View example of the soft link pattern
 
 ## Dark
 
-The `.on-dark` class should be added on links that are placed on a solid dark background (`#2d2d2d` or darker).
+The `.is-dark` class should be added on links that are placed on a solid dark background (`#2d2d2d` or darker).
 
 <div class="embedded-example"><a href="/docs/examples/patterns/links/links-dark/" class="js-example">
 View example of the dark link pattern

--- a/templates/docs/patterns/rule.md
+++ b/templates/docs/patterns/rule.md
@@ -40,7 +40,7 @@ View example of a highlighted rule
 
 ## Dark theme
 
-To use rule component on dark background, add `on-dark` modifier class.
+To use rule component on dark background, add `is-dark` modifier class.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/rule/dark" class="js-example">
 View example of a highlighted rule on dark background


### PR DESCRIPTION
## Done

Revert from using `on-dark` class to switch theme, to keep new components consistent with existing themes.

## QA

- Open [demo](https://vanilla-framework-4819.demos.haus/docs/patterns/rule#dark-theme)
- Review updated documentation:
  - Dark rules: https://vanilla-framework-4819.demos.haus/docs/patterns/rule#dark-theme
  - Dark links: https://vanilla-framework-4819.demos.haus/docs/patterns/links#dark

