### PR TITLE
Make sure logo tag backround is not configurable

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -251,7 +251,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     }
 
     .p-navigation__logo-tag {
-      background-color: $color-brand;
+      background-color: $color-ubuntu;
       height: $navigation-logo-tag-height;
       left: 0;
       position: absolute;

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -207,7 +207,8 @@ $colors--paper-theme--background-active: rgba($color-x-dark, $active-background-
 $colors--paper-theme--background-hover: rgba($color-x-dark, $hover-background-opacity-amount) !default;
 
 // Branding colors
-$color-brand: #e95420 !default;
+$color-ubuntu: #e95420; // Ubuntu orange, should not be overridden
+$color-brand: $color-ubuntu !default;
 $color-brand-dark: $color-brand !default;
 $color-accent: #0f95a1 !default;
 $color-accent-background: $colors--dark-theme--background-default !default; // changed from "brand" colour to dark theme background


### PR DESCRIPTION
## Done

Uses Ubuntu orange colour directly in logo tag, to make sure it can't be changed via `$color-brand` variable.

## QA

Demo: https://vanilla-framework-4821.demos.haus/

