### PR TITLE
Add display headings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.1.0
+  features:
+    - component: Display headings
+      url: /docs/base/typography#display-headings
+      status: New
+      notes: We've added a new display heading component.
 - version: 4.0.0
   features:
     - component: Migration guide

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -41,11 +41,14 @@
     font-size: #{map-get($font-sizes, display-mobile)}rem;
     font-weight: 100;
     line-height: map-get($line-heights, display-mobile);
-    padding-top: 0;
+    margin-bottom: map-get($sp-after, display-mobile) - map-get($nudges, display-mobile);
+    padding-top: map-get($nudges, display-mobile);
 
     @media (min-width: $breakpoint-heading-threshold) {
       font-size: #{map-get($font-sizes, display)}rem;
       line-height: map-get($line-heights, display);
+      margin-bottom: map-get($sp-after, display) - map-get($nudges, display);
+      padding-top: map-get($nudges, display);
     }
   }
 

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -35,6 +35,20 @@
     font-weight: 550;
   }
 
+  %vf-heading-display {
+    @extend %vf-heading-2;
+
+    font-size: #{map-get($font-sizes, display-mobile)}rem;
+    font-weight: 100;
+    line-height: map-get($line-heights, display-mobile);
+    padding-top: 0;
+
+    @media (min-width: $breakpoint-heading-threshold) {
+      font-size: #{map-get($font-sizes, display)}rem;
+      line-height: map-get($line-heights, display);
+    }
+  }
+
   %vf-heading-3 {
     @extend %vf-is-accent;
 

--- a/scss/_patterns_headings.scss
+++ b/scss/_patterns_headings.scss
@@ -2,6 +2,10 @@
 
 // Default breadcrumbs styling
 @mixin vf-p-headings {
+  .p-heading--display {
+    @extend %vf-heading-display;
+  }
+
   .p-heading--1 {
     @extend %vf-heading-1;
   }

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -40,6 +40,8 @@ $line-heights: (
 
 // baseline nudges for type scale ratio of (16/14)^2
 $nudges: (
+  display: 0.35rem,
+  display-mobile: 0.25rem,
   h1-large: 0.55rem,
   h1-mobile: 0.55rem,
   h1: 0.55rem,
@@ -92,6 +94,8 @@ $sph--x-large: $sp-unit * 3 !default;
 
 // Space after text elements
 $sp-after: (
+  display: $spv--x-large,
+  display-mobile: $spv--x-large,
   h1: $spv--x-large,
   h1-mobile: $spv--x-large,
   h2: $spv--x-large,

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -8,6 +8,8 @@ $sp-unit-ratio: 0.5 !default;
 $sp-unit: 1rem * $sp-unit-ratio !default;
 
 $font-sizes: (
+  display: 5,
+  display-mobile: 4,
   h1: 2.5,
   h1-mobile: 2,
   h2: 2.5,
@@ -21,6 +23,8 @@ $font-sizes: (
 ) !default;
 
 $line-heights: (
+  display: 11 * $sp-unit,
+  display-mobile: 9 * $sp-unit,
   h1: 6 * $sp-unit,
   h1-mobile: 5 * $sp-unit,
   h2: 6 * $sp-unit,

--- a/templates/docs/base/typography.md
+++ b/templates/docs/base/typography.md
@@ -159,6 +159,14 @@ better suits your document style and tree.
 View example of the mixed headings pattern
 </a></div>
 
+## Display headings
+
+Display headings are reserved for the titles of important bespoke pages. They should be used sparingly by adding the `.p-heading--display` class to a `h1` heading element.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/headings/display/" class="js-example">
+View example of the display headings pattern
+</a></div>
+
 ## Accented headings
 
 The accent colour can be sparingly used to highlight headings to help them stand out from the rest of the page.

--- a/templates/docs/examples/patterns/headings/display.html
+++ b/templates/docs/examples/patterns/headings/display.html
@@ -1,0 +1,8 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Headings / Display{% endblock %}
+
+{% block standalone_css %}patterns_headings{% endblock %}
+
+{% block content %}
+<h1 class="p-heading--display">Build at speed.<br>Operate at scale.</h1>
+{% endblock %}


### PR DESCRIPTION
## Done

Adds display variant of heading component `p-heading--display`

Fixes [WD-5124](https://warthogs.atlassian.net/browse/WD-5124)

## QA

- Open [demo](https://vanilla-framework-4840.demos.haus/docs/base/typography#display-headings)
- Check if display headings work correctly (on different screen sizes)
- Review updated documentation:
  - https://vanilla-framework-4840.demos.haus/docs/base/typography#display-headings

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1242" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/c0b7219b-2bd9-47a8-a15d-76ae0fa2293e">


[WD-5124]: https://warthogs.atlassian.net/browse/WD-5124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ