### PR TITLE
Update breadcrumb's bottom margin

### DIFF
--- a/scss/_patterns_breadcrumbs.scss
+++ b/scss/_patterns_breadcrumbs.scss
@@ -10,7 +10,7 @@
   }
 
   .p-breadcrumbs__items {
-    margin-bottom: $spv--large;
+    margin-bottom: 0;
     margin-left: 0;
     padding-left: 0;
   }
@@ -19,7 +19,6 @@
     @extend %small-caps-text;
 
     display: inline-block;
-    margin-bottom: $spv-nudge-compensation;
 
     &:not(:first-of-type) {
       text-indent: $sph--large;


### PR DESCRIPTION
## Done

Reduce margin-bottom on breadcrumbs to 1rem
Make the breadcrumbs use small caps

Fixes https://github.com/canonical/vanilla-framework/issues/4818

## QA

- Open [demo](https://vanilla-framework-4842.demos.haus/docs/examples/patterns/breadcrumbs)
- See that the bottom margin is 1rem
- See that the breadcrumbs use small caps

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

