### PR TITLE
Add examples of hero sections

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -20,6 +20,10 @@
       url: /docs/patterns/strip#suru-strip
       status: Deprecated
       notes: Strips with old style of the Suru are now deprecated and should not be used on any new pages. Use a blank strip or new Suru component instead.
+    - component: Brochure site / Section examples
+      url: /docs/layouts/brochure#section-examples
+      status: New
+      notes: We've added examples of some brochure site hero sections.
 - version: 4.0.0
   features:
     - component: Migration guide

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -251,6 +251,12 @@
         &:nth-of-type(2) {
           @include vf-grid-column(4);
         }
+
+        // if there is only one column we offset it to the right
+        &:only-of-type {
+          @include vf-grid-column(4);
+          grid-column-start: calc(3);
+        }
       }
 
       @media (min-width: $threshold-6-12-col) {

--- a/templates/docs/examples/brochure/hero-25-75.html
+++ b/templates/docs/examples/brochure/hero-25-75.html
@@ -1,0 +1,43 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Hero / 25/75{% endblock %}
+
+{% block style %}
+{% endblock %}
+
+{% set is_paper = True %}
+{% block content %}
+
+<section>
+    <div class="row--25-75">
+        <div class="col">
+            <h1>H1: 2-3 words</h1>
+        </div>
+        <div class="col">
+            <div class="p-section">
+                <h2>H2: 5-15 words, up to 3 rows of copy...</h2>
+            </div>
+        </div>
+    </div>
+    <div class="row--25-75">
+        <div class="col">
+            <img src="https://assets.ubuntu.com/v1/b200e162-design.svg" alt="" width="80">
+        </div>
+        <div class="col">
+            <div class="p-section">
+                <p>Multi-cloud (also referred to as multi cloud or multicloud) is a concept that refers to using multiple clouds from more than one cloud service provider at the same time. The term is also used to refer to the simultaneous running of bare metal, virtualised and containerised workloads.</p>
+            </div>
+        </div>
+    </div>
+    <div class="row--25-75">
+        <div class="col">
+            <div class="p-section">
+                <hr>
+                <a href="#" class="p-button--positive">CTA up to 3 words</a>
+                <a href="#" class="p-button">Optional button</a>
+                <a href="#">Link CTA up to 5 words</a>
+            </div>
+        </div>
+    </div>
+</section>
+
+{% endblock %}

--- a/templates/docs/examples/brochure/hero-25-75.html
+++ b/templates/docs/examples/brochure/hero-25-75.html
@@ -8,7 +8,7 @@
 {% block content %}
 
 <section>
-    <div class="row--25-75">
+    <div class="row--25-75 is-split-on-medium">
         <div class="col">
             <h1>H1: 2-3 words</h1>
         </div>
@@ -18,7 +18,7 @@
             </div>
         </div>
     </div>
-    <div class="row--25-75">
+    <div class="row--25-75 is-split-on-medium">
         <div class="col">
             <img src="https://assets.ubuntu.com/v1/b200e162-design.svg" alt="" width="80">
         </div>
@@ -28,16 +28,16 @@
             </div>
         </div>
     </div>
-    <div class="row--25-75">
+    <div class="row--25-75 is-split-on-medium">
         <div class="col">
-            <div class="p-section">
-                <hr>
-                <a href="#" class="p-button--positive">CTA up to 3 words</a>
-                <a href="#" class="p-button">Optional button</a>
-                <a href="#">Link CTA up to 5 words</a>
-            </div>
+            <hr>
+            <a href="#" class="p-button--positive">CTA up to 3 words</a>
+            <a href="#" class="p-button">Optional button</a>
+            <a href="#">Link CTA up to 5 words</a>
+            <!-- p-section spacing not needed because it's followed by suru -->
         </div>
     </div>
+    <div class="p-suru"></div>
 </section>
 
 {% endblock %}

--- a/templates/docs/examples/brochure/hero-25-75.html
+++ b/templates/docs/examples/brochure/hero-25-75.html
@@ -14,7 +14,7 @@
         </div>
         <div class="col">
             <div class="p-section">
-                <h2>H2: 5-15 words, up to 3 rows of copy...</h2>
+                <p class="p-heading--2">H2: 5-15 words, up to 3 rows of copy...</p>
             </div>
         </div>
     </div>

--- a/templates/docs/examples/brochure/hero-50-50.html
+++ b/templates/docs/examples/brochure/hero-50-50.html
@@ -1,0 +1,30 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Hero / 50/50{% endblock %}
+
+{% block style %}
+{% endblock %}
+
+{% set is_paper = True %}
+{% block content %}
+<section>
+    <div class="row--50-50">
+        <div class="col">
+            <h1>H1: 3-8 words</h1>
+        </div>
+        <div class="col">
+            <div class="p-section">
+                <h2>H2: 5-13 words, up to 3 rows of copy...</h2>
+            </div>
+            <div class="p-section">
+                <p>Multi-cloud (also referred to as multi cloud or multicloud) is a concept that refers to using multiple clouds from more than one cloud service provider at the same time. The term is also used to refer to the simultaneous running of bare metal, virtualised and containerised workloads.</p>
+                <p>In conjunction with a hybrid cloud architecture, the multi-cloud approach enables organisations to optimise their infrastructure costs. Multi-cloud reflects the reality of most organisations today and is expected to become the standard for cloud infrastructure in the coming years.</p>
+            </div>
+            <div class="p-section">
+                <hr>
+                <a href="#" class="p-button--positive">CTA up to 3 words</a>
+                <a href="#" class="p-button">CTA up to 3 words</a>
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/templates/docs/examples/brochure/hero-50-50.html
+++ b/templates/docs/examples/brochure/hero-50-50.html
@@ -13,7 +13,7 @@
         </div>
         <div class="col">
             <div class="p-section">
-                <h2>H2: 5-13 words, up to 3 rows of copy...</h2>
+                <p class="p-heading--2">H2: 5-13 words, up to 3 rows of copy...</p>
             </div>
             <div class="p-section">
                 <p>Multi-cloud (also referred to as multi cloud or multicloud) is a concept that refers to using multiple clouds from more than one cloud service provider at the same time. The term is also used to refer to the simultaneous running of bare metal, virtualised and containerised workloads.</p>

--- a/templates/docs/examples/brochure/hero-75-offset.html
+++ b/templates/docs/examples/brochure/hero-75-offset.html
@@ -12,7 +12,7 @@
         <div class="col">
             <div class="p-section">
                 <h1>H1: 3-5 words</h1>
-                <h2>H2: 5-15 words, up to 3 rows of copy...</h2>
+                <p class="p-heading--2">H2: 5-15 words, up to 3 rows of copy...</p>
             </div>
             <div class="p-section">
                 <p>Multi-cloud (also referred to as multi cloud or multicloud) is a concept that refers to using multiple clouds from more than one cloud service provider at the same time. The term is also used to refer to the simultaneous running of bare metal, virtualised and containerised workloads.</p>

--- a/templates/docs/examples/brochure/hero-75-offset.html
+++ b/templates/docs/examples/brochure/hero-75-offset.html
@@ -1,0 +1,31 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Hero / 75 offset{% endblock %}
+
+{% block style %}
+{% endblock %}
+
+{% set is_paper = True %}
+{% block content %}
+
+<section>
+    <div class="row--25-75">
+        <div class="col">
+            <div class="p-section">
+                <h1>H1: 3-5 words</h1>
+                <h2>H2: 5-15 words, up to 3 rows of copy...</h2>
+            </div>
+            <div class="p-section">
+                <p>Multi-cloud (also referred to as multi cloud or multicloud) is a concept that refers to using multiple clouds from more than one cloud service provider at the same time. The term is also used to refer to the simultaneous running of bare metal, virtualised and containerised workloads.</p>
+                <p>In conjunction with a hybrid cloud architecture, the multi-cloud approach enables organisations to optimise their infrastructure costs. Multi-cloud reflects the reality of most organisations today and is expected to become the standard for cloud infrastructure in the coming years.</p>
+            </div>
+            <div class="p-section">
+                <hr>
+                <a href="#" class="p-button--positive">CTA up to 3 words</a>
+                <a href="#" class="p-button">Optional button</a>
+                <a href="#">Link CTA up to 5 words</a>
+            </div>
+        </div>
+    </div>
+</section>
+
+{% endblock %}

--- a/templates/docs/examples/brochure/hero-75-offset.html
+++ b/templates/docs/examples/brochure/hero-75-offset.html
@@ -8,7 +8,7 @@
 {% block content %}
 
 <section>
-    <div class="row--25-75">
+    <div class="row--25-75 is-split-on-medium">
         <div class="col">
             <div class="p-section">
                 <h1>H1: 3-5 words</h1>
@@ -18,14 +18,14 @@
                 <p>Multi-cloud (also referred to as multi cloud or multicloud) is a concept that refers to using multiple clouds from more than one cloud service provider at the same time. The term is also used to refer to the simultaneous running of bare metal, virtualised and containerised workloads.</p>
                 <p>In conjunction with a hybrid cloud architecture, the multi-cloud approach enables organisations to optimise their infrastructure costs. Multi-cloud reflects the reality of most organisations today and is expected to become the standard for cloud infrastructure in the coming years.</p>
             </div>
-            <div class="p-section">
-                <hr>
-                <a href="#" class="p-button--positive">CTA up to 3 words</a>
-                <a href="#" class="p-button">Optional button</a>
-                <a href="#">Link CTA up to 5 words</a>
-            </div>
+            <hr>
+            <a href="#" class="p-button--positive">CTA up to 3 words</a>
+            <a href="#" class="p-button">Optional button</a>
+            <a href="#">Link CTA up to 5 words</a>
+            <!-- p-section spacing not needed because it's followed by suru -->
         </div>
     </div>
+    <div class="p-suru"></div>
 </section>
 
 {% endblock %}

--- a/templates/docs/layouts/brochure.md
+++ b/templates/docs/layouts/brochure.md
@@ -205,6 +205,23 @@ it is very compact - as the headings do not push the body text down.</li>
   <div class="embedded-example"><a href="/docs/examples/brochure/25-75-split-responsive-structure" class="js-example">View an example of 25/75 responsive split</a></div>
 </section>
 
+<section class="p-section">
+  <div class="row">
+    <hr class="p-rule">
+  </div>
+  <div class="row--25-75">
+    <div class="col">
+      <div class="p-section">
+        <h2>Section examples</h2>
+        <p>Below we present a few examples of how the sections can be used in practice. The examples are not meant to be exhaustive, but rather to give you a sense of how some commonly used sections can be built.</p>
+      </div>
+    </div>
+  </div>
+  <div class="embedded-example"><a href="/docs/examples/brochure/hero-75-offset" class="js-example">View an example of the hero section with offset 75 layout</a></div>
+  <div class="embedded-example"><a href="/docs/examples/brochure/hero-25-75" class="js-example">View an example of the hero section with 25/75 layout</a></div>
+  <div class="embedded-example"><a href="/docs/examples/brochure/hero-50-50" class="js-example">View an example of the hero section with 50/50 layout</a></div>
+</section>
+
 <div class="p-notification--caution">
   <div class="p-notification__content">
     <h5 class="p-notification__title">Work in progress</h5>

--- a/templates/docs/layouts/brochure.md
+++ b/templates/docs/layouts/brochure.md
@@ -217,8 +217,29 @@ it is very compact - as the headings do not push the body text down.</li>
       </div>
     </div>
   </div>
+  <div class="row--25-75">
+    <div class="col">
+      <hr class="p-rule">
+      <h3>Hero 75 offset</h3>
+      <p>The most common hero variant based on 25/75 grid with empty first column. Sub-heading, paragraph text section and CTA section are optional. This kind of hero is usually followed by a suru, and in such case the last content section of the hero should not have bottom spacing of its own.</p>
+    </div>
+  </div>
   <div class="embedded-example"><a href="/docs/examples/brochure/hero-75-offset" class="js-example">View an example of the hero section with offset 75 layout</a></div>
+  <div class="row--25-75">
+    <div class="col">
+      <hr class="p-rule">
+      <h3>Hero 25/75</h3>
+      <p>Hero based on 25/75 grid should be used for hero sections with shorter main title or more complicated content structure (including longer text or additional images).</p>
+    </div>
+  </div>
   <div class="embedded-example"><a href="/docs/examples/brochure/hero-25-75" class="js-example">View an example of the hero section with 25/75 layout</a></div>
+  <div class="row--25-75">
+    <div class="col">
+      <hr class="p-rule">
+      <h3>Hero 50/50</h3>
+      <p>Hero 50/50 can be used on pages where the 50/50 split is used predominantely. Usually it will not be followed by suru, as the default suru is aligned with 25/75 grid split.</p>
+    </div>
+  </div>
   <div class="embedded-example"><a href="/docs/examples/brochure/hero-50-50" class="js-example">View an example of the hero section with 50/50 layout</a></div>
 </section>
 


### PR DESCRIPTION
## Done

Add examples of new brochure site hero sections

Fixes [WD-5139](https://warthogs.atlassian.net/browse/WD-5139)

## TODO

- [x] surus are needed to complete hero exampels
- [x] responsive 25-75 row needed
- [ ] ~bordered rows and columns needed~ _(descoped for now due to spacing issues)_

## QA

- Open [demo](https://vanilla-framework-4843.demos.haus/docs/layouts/brochure#section-examples)
- Review new hero section examples:
  - https://vanilla-framework-4843.demos.haus/docs/examples/brochure/hero-25-75
  - https://vanilla-framework-4843.demos.haus/docs/examples/brochure/hero-50-50
  - https://vanilla-framework-4843.demos.haus/docs/examples/brochure/hero-75-offset
- Review updated documentation:
  - https://vanilla-framework-4843.demos.haus/docs/layouts/brochure#section-examples


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1253" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/8064b7a5-f7b3-4d75-8264-6c4a0a0e940b">



[WD-5139]: https://warthogs.atlassian.net/browse/WD-5139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ