### PR TITLE
Add responsive variant of 25/75 grid

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -4,6 +4,10 @@
       url: /docs/base/typography#display-headings
       status: New
       notes: We've added a new display heading component.
+    - component: Responsive 27/75 grid
+      url: /docs/patterns/grid#2575-responsive
+      status: New
+      notes: We've added a new responsive variant to 27/75 grid component.
 - version: 4.0.0
   features:
     - component: Migration guide

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -241,6 +241,36 @@
     }
   }
 
+  .row--25-75.is-responsive {
+    > .col {
+      @media (min-width: $threshold-4-6-col) {
+        &:nth-of-type(1) {
+          @include vf-grid-column(2);
+        }
+
+        &:nth-of-type(2) {
+          @include vf-grid-column(4);
+        }
+      }
+
+      @media (min-width: $threshold-6-12-col) {
+        &:nth-of-type(1) {
+          @include vf-grid-column($col-25);
+        }
+
+        &:nth-of-type(2) {
+          @include vf-grid-column($col-75);
+        }
+
+        // if there is only one column we offset it to the right
+        &:only-of-type {
+          grid-column-start: calc($col-25 + 1);
+          @include vf-grid-column($col-75);
+        }
+      }
+    }
+  }
+
   .row--25-25-50 {
     @extend %vf-row;
 

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -241,7 +241,7 @@
     }
   }
 
-  .row--25-75.is-responsive {
+  .row--25-75.is-split-on-medium {
     > .col {
       @media (min-width: $threshold-4-6-col) {
         &:nth-of-type(1) {

--- a/templates/docs/examples/brochure/25-75-split-responsive-structure.html
+++ b/templates/docs/examples/brochure/25-75-split-responsive-structure.html
@@ -1,0 +1,11 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Brochure site / 25/75 responsive structure{% endblock %}
+
+{% block style %}
+{% endblock %}
+
+{% block content %}
+
+{% include "/docs/examples/brochure/_25-75-responsive-structure.html" %}
+
+{% endblock %}

--- a/templates/docs/examples/brochure/_25-75-responsive-structure.html
+++ b/templates/docs/examples/brochure/_25-75-responsive-structure.html
@@ -1,10 +1,10 @@
-<div class="row--25-75 is-responsive grid-demo">
+<div class="row--25-75 is-split-on-medium grid-demo">
   <div class="col">
     <h4>25/75 responsive split</h4>
   </div>
   <div class="col">
     <p>Use 25/75 responsive split on sections with narrow first column (usually a heading) followed by large content area that isn't split into smaller columns.</p>
     <p>On medium screens it becomes a split of 2 columns + 4 columns.</p>
-    <p>To achieve that use <code>row--25-75 is-responsive</code> class names on the row and <code>col</code> on the columns.</p>
+    <p>To achieve that use <code>row--25-75 is-split-on-medium</code> class names on the row and <code>col</code> on the columns.</p>
   </div>
 </div>

--- a/templates/docs/examples/brochure/_25-75-responsive-structure.html
+++ b/templates/docs/examples/brochure/_25-75-responsive-structure.html
@@ -1,0 +1,10 @@
+<div class="row--25-75 is-responsive grid-demo">
+  <div class="col">
+    <h4>25/75 responsive split</h4>
+  </div>
+  <div class="col">
+    <p>Use 25/75 responsive split on sections with narrow first column (usually a heading) followed by large content area that isn't split into smaller columns.</p>
+    <p>On medium screens it becomes a split of 2 columns + 4 columns.</p>
+    <p>To achieve that use <code>row--25-75 is-responsive</code> class names on the row and <code>col</code> on the columns.</p>
+  </div>
+</div>

--- a/templates/docs/examples/brochure/_25-75.html
+++ b/templates/docs/examples/brochure/_25-75.html
@@ -1,5 +1,5 @@
 <section class="p-section">
-    <div class="row--25-75 is-responsive">
+    <div class="row--25-75 is-split-on-medium">
         <div class="col">
             <p class="p-muted-heading">Our mission</p>
         </div>

--- a/templates/docs/examples/brochure/_25-75.html
+++ b/templates/docs/examples/brochure/_25-75.html
@@ -1,5 +1,5 @@
 <section class="p-section">
-    <div class="row--25-75">
+    <div class="row--25-75 is-responsive">
         <div class="col">
             <p class="p-muted-heading">Our mission</p>
         </div>

--- a/templates/docs/examples/patterns/grid/25-75-responsive.html
+++ b/templates/docs/examples/patterns/grid/25-75-responsive.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="grid-demo">
-  <div class="row--25-75 is-responsive">
+  <div class="row--25-75 is-split-on-medium">
     <div class="col">
       <span>25</span>
     </div>

--- a/templates/docs/examples/patterns/grid/25-75-responsive.html
+++ b/templates/docs/examples/patterns/grid/25-75-responsive.html
@@ -1,0 +1,17 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Grid / 25/75{% endblock %}
+
+{% block standalone_css %}patterns_grid{% endblock %}
+
+{% block content %}
+<div class="grid-demo">
+  <div class="row--25-75 is-responsive">
+    <div class="col">
+      <span>25</span>
+    </div>
+    <div class="col">
+      <span>75</span>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/docs/layouts/brochure.md
+++ b/templates/docs/layouts/brochure.md
@@ -202,6 +202,7 @@ it is very compact - as the headings do not push the body text down.</li>
     </div>
   </div>
   <div class="embedded-example"><a href="/docs/examples/brochure/25-75-split-structure" class="js-example">View an example of 25/75 split</a></div>
+  <div class="embedded-example"><a href="/docs/examples/brochure/25-75-split-responsive-structure" class="js-example">View an example of 25/75 responsive split</a></div>
 </section>
 
 <div class="p-notification--caution">

--- a/templates/docs/patterns/grid/index.md
+++ b/templates/docs/patterns/grid/index.md
@@ -55,13 +55,13 @@ Read also: [Breakpoints](/docs/settings/breakpoint-settings)
 
 There are some special classes to help you build [common layout patterns](/docs/layouts/brochure). Instead of deciding how many columns each element should use for different screen sizes, use one of these classes on the grid container, and the child elements will be arranged automatically as long as they have the `col` class.
 
-|                              | Large screens | Medium screens | Small screens   |
-| ---------------------------- | ------------- | -------------- | --------------- |
-| `.row--50-50`                | 50/50         | 50/50          | 100/100         |
-| `.row--25-75`                | 25/75         | 100/100        | 100/100         |
-| `.row--25-75 .is-responsive` | 25/75         | 33/66          | 100/100         |
-| `.row--25-25-50`             | 25/25/50      | 50/50/100      | 100/100/100     |
-| `.row--25-25-25-25`          | 25/25/25/25   | 50/50/50/50    | 100/100/100/100 |
+|                                   | Large screens | Medium screens | Small screens   |
+| --------------------------------- | ------------- | -------------- | --------------- |
+| `.row--50-50`                     | 50/50         | 50/50          | 100/100         |
+| `.row--25-75`                     | 25/75         | 100/100        | 100/100         |
+| `.row--25-75 .is-split-on-medium` | 25/75         | 33/66          | 100/100         |
+| `.row--25-25-50`                  | 25/25/50      | 50/50/100      | 100/100/100     |
+| `.row--25-25-25-25`               | 25/25/25/25   | 50/50/50/50    | 100/100/100/100 |
 
 ### 50/50
 
@@ -81,7 +81,7 @@ See responsive variant below if you want to keep the split layout on medium scre
 
 #### 25/75 responsive
 
-Use the responsive variant by adding the `.is-responsive` class to the row container when you want to keep the split layout on medium screens. This is usually used when the main content part does not split further into columns.
+Use the responsive variant by adding the `.is-split-on-medium` class to the row container when you want to keep the split layout on medium screens. This is usually used when the main content part does not split further into columns.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/grid/25-75-responsive/" class="js-example">
     View example of 25/75 grid layout

--- a/templates/docs/patterns/grid/index.md
+++ b/templates/docs/patterns/grid/index.md
@@ -55,12 +55,13 @@ Read also: [Breakpoints](/docs/settings/breakpoint-settings)
 
 There are some special classes to help you build [common layout patterns](/docs/layouts/brochure). Instead of deciding how many columns each element should use for different screen sizes, use one of these classes on the grid container, and the child elements will be arranged automatically as long as they have the `col` class.
 
-|                     | Large screens | Medium screens | Small screens   |
-| ------------------- | ------------- | -------------- | --------------- |
-| `.row--50-50`       | 50/50         | 50/50          | 100/100         |
-| `.row--25-75`       | 25/75         | 100/100        | 100/100         |
-| `.row--25-25-50`    | 25/25/50      | 50/50/100      | 100/100/100     |
-| `.row--25-25-25-25` | 25/25/25/25   | 50/50/50/50    | 100/100/100/100 |
+|                              | Large screens | Medium screens | Small screens   |
+| ---------------------------- | ------------- | -------------- | --------------- |
+| `.row--50-50`                | 50/50         | 50/50          | 100/100         |
+| `.row--25-75`                | 25/75         | 100/100        | 100/100         |
+| `.row--25-75 .is-responsive` | 25/75         | 33/66          | 100/100         |
+| `.row--25-25-50`             | 25/25/50      | 50/50/100      | 100/100/100     |
+| `.row--25-25-25-25`          | 25/25/25/25   | 50/50/50/50    | 100/100/100/100 |
 
 ### 50/50
 
@@ -70,7 +71,19 @@ There are some special classes to help you build [common layout patterns](/docs/
 
 ### 25/75
 
+The default variant of 25/75 split sets the layout only on large screens, stacking both columns on top of each other on small and medium screens. This is usually useful when main large column splits further with nested grid that would require full width of the page on medium screens.
+
+See responsive variant below if you want to keep the split layout on medium screens.
+
 <div class="embedded-example"><a href="/docs/examples/patterns/grid/25-75/" class="js-example">
+    View example of 25/75 grid layout
+</a></div>
+
+#### 25/75 responsive
+
+Use the responsive variant by adding the `.is-responsive` class to the row container when you want to keep the split layout on medium screens. This is usually used when the main content part does not split further into columns.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/grid/25-75-responsive/" class="js-example">
     View example of 25/75 grid layout
 </a></div>
 


### PR DESCRIPTION
## Done

Adds responsive variant to 25/75 grid

Fixes [WD-5125](https://warthogs.atlassian.net/browse/WD-5125)

## QA

- Open [demo](https://vanilla-framework-4846.demos.haus/docs/patterns/grid#2575-responsive)
- Make sure responsive variant works as expected on medium screens
- Review updated documentation:
  - https://vanilla-framework-4846.demos.haus/docs/patterns/grid#2575-responsive
  - https://vanilla-framework-4846.demos.haus/docs/layouts/brochure#-the-2575-split-

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).



[WD-5125]: https://warthogs.atlassian.net/browse/WD-5125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ