### PR TITLE
Add suru component

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -12,6 +12,10 @@
       url: /docs/patterns/suru
       status: New
       notes: We've added a new Suru component.
+    - component: Suru strips
+      url: /docs/patterns/strip#suru-strip
+      status: Deprecated
+      notes: Strips with old style of the Suru are now deprecated and should not be used on any new pages. Use a blank strip or new Suru component instead.
 - version: 4.0.0
   features:
     - component: Migration guide

--- a/releases.yml
+++ b/releases.yml
@@ -8,6 +8,10 @@
       url: /docs/patterns/grid#2575-responsive
       status: New
       notes: We've added a new responsive variant to 27/75 grid component.
+    - component: Suru
+      url: /docs/patterns/suru
+      status: New
+      notes: We've added a new Suru component.
 - version: 4.0.0
   features:
     - component: Migration guide

--- a/scss/_patterns_suru.scss
+++ b/scss/_patterns_suru.scss
@@ -2,18 +2,20 @@
 
 @mixin vf-p-suru {
   .p-suru {
-    aspect-ratio: 5.1775700934579; // exact aspect ration of the image
+    aspect-ratio: calc(2216 / 428); // aspect ratio calculated from image dimensions
     background-image: url('#{$assets-path}7f34ade9-website_suru_25.jpg');
     background-size: contain;
     display: none; // only show suru on large screens
     margin: 0 auto;
     max-width: $grid-max-width;
 
+    // show suru only on large screens
     @media (min-width: $breakpoint-large) {
       display: block;
     }
 
     &.is-dark {
+      aspect-ratio: calc(2580 / 501); // aspect ratio calculated from image dimensions
       background-image: url('#{$assets-path}9469ef82-1_website_suru_DARK_25%20(1)122.jpg');
     }
   }

--- a/scss/_patterns_suru.scss
+++ b/scss/_patterns_suru.scss
@@ -1,0 +1,20 @@
+@import 'settings';
+
+@mixin vf-p-suru {
+  .p-suru {
+    aspect-ratio: 5.1775700934579; // exact aspect ration of the image
+    background-image: url('#{$assets-path}7f34ade9-website_suru_25.jpg');
+    background-size: contain;
+    display: none; // only show suru on large screens
+    margin: 0 auto;
+    max-width: $grid-max-width;
+
+    @media (min-width: $breakpoint-large) {
+      display: block;
+    }
+
+    &.is-dark {
+      background-image: url('#{$assets-path}9469ef82-1_website_suru_DARK_25%20(1)122.jpg');
+    }
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -53,6 +53,7 @@
 @import 'patterns_table-sortable';
 @import 'patterns_tabs';
 @import 'patterns_tooltips';
+@import 'patterns_suru';
 
 // Layouts
 @import 'layouts_application';
@@ -142,6 +143,7 @@
   @include vf-p-table-sortable;
   @include vf-p-tabs;
   @include vf-p-tooltips;
+  @include vf-p-suru;
 
   // Layouts
   @include vf-l-application;

--- a/scss/standalone/patterns_suru.scss
+++ b/scss/standalone/patterns_suru.scss
@@ -1,0 +1,4 @@
+@import '../vanilla';
+@include vf-base;
+
+@include vf-p-suru;

--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -94,6 +94,8 @@
       url: /docs/patterns/status-labels
     - title: Strip
       url: /docs/patterns/strip
+    - title: Suru
+      url: /docs/patterns/suru
     - title: Switch
       url: /docs/patterns/switch
     - title: Table of contents

--- a/templates/410.html
+++ b/templates/410.html
@@ -1,12 +1,12 @@
 {% extends "_layouts/site.html" %}
 
 {% block content %}
-<div id="main-content" class="p-strip--suru-topped">
+<div id="main-content" class="p-strip">
   <div class="row">
     <div class="col 12">
       <h1 class="u-no-margin--bottom">410 - Page deleted</h1>
     </div>
-  </div>  
+  </div>
 </div>
 
 <div class="p-strip is-shallow">

--- a/templates/docs/examples/brochure/_50-50.html
+++ b/templates/docs/examples/brochure/_50-50.html
@@ -53,3 +53,5 @@
     </div>
   </div>
 </section>
+
+<div class="p-suru"></div>

--- a/templates/docs/examples/patterns/suru/dark.html
+++ b/templates/docs/examples/patterns/suru/dark.html
@@ -1,0 +1,11 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Suru / Dark{% endblock %}
+
+{% block standalone_css %}patterns_suru{% endblock %}
+
+{% set is_paper = True %}
+{% block content %}
+<div class="p-strip--dark" style="background: #262626;">
+    <div class="p-suru is-dark"></div>
+</div>
+{% endblock %}

--- a/templates/docs/examples/patterns/suru/dark.html
+++ b/templates/docs/examples/patterns/suru/dark.html
@@ -3,9 +3,11 @@
 
 {% block standalone_css %}patterns_suru{% endblock %}
 
-{% set is_paper = True %}
+{% block style %}
+{# default dark background on the exanple body #}
+<style>body { background: #262626; }</style>
+{% endblock %}
+
 {% block content %}
-<div class="p-strip--dark" style="background: #262626;">
-    <div class="p-suru is-dark"></div>
-</div>
+<div class="p-suru is-dark"></div>
 {% endblock %}

--- a/templates/docs/examples/patterns/suru/default.html
+++ b/templates/docs/examples/patterns/suru/default.html
@@ -1,0 +1,9 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Suru{% endblock %}
+
+{% block standalone_css %}patterns_suru{% endblock %}
+
+{% set is_paper = True %}
+{% block content %}
+<div class="p-suru"></div>
+{% endblock %}

--- a/templates/docs/patterns/strip/index.md
+++ b/templates/docs/patterns/strip/index.md
@@ -86,6 +86,15 @@ View example of the pattern strip is-shallow
 
 ## Suru strip
 
+<span class="p-status-label--negative">Deprecated</span>
+
+<div class="p-notification--negative">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Deprecated</h5>
+    <p class="p-notification__message">Strips with old style of the Suru are now deprecated and should not be used on any new pages. Use a blank strip or <a href="/docs/patterns/suru">new Suru component</a> instead.</p>
+  </div>
+</div>
+
 This is a patterned strip that is ideal for overview or main pages, and can be used with images.
 
 The colours of the solid gradient are based on `$color-brand` by default. The gradient colours can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables. A dark colour scheme is recommended, as the text colour is light by default.
@@ -95,6 +104,15 @@ View example of the Suru strip pattern
 </a></div>
 
 ## Topped Suru strip
+
+<span class="p-status-label--negative">Deprecated</span>
+
+<div class="p-notification--negative">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Deprecated</h5>
+    <p class="p-notification__message">Strips with old style of the Suru are now deprecated and should not be used on any new pages. Use a blank strip or <a href="/docs/patterns/suru">new Suru component</a> instead.</p>
+  </div>
+</div>
 
 This is a patterned strip that is ideal for content pages.
 

--- a/templates/docs/patterns/suru.md
+++ b/templates/docs/patterns/suru.md
@@ -8,9 +8,9 @@ context:
 
 <hr>
 
-Suru component can be used to display a visual separation between two sections of content.
+The Suru component can be used to display a visual separation between two sections of content.
 
-By default Suru should be used on the paper background. When used on dark background, add `is-dark` modifier class.
+By default, Suru should be used on the paper background. When used on dark background, add `is-dark` modifier class.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/suru/default" class="js-example">
 View example of the default Suru component

--- a/templates/docs/patterns/suru.md
+++ b/templates/docs/patterns/suru.md
@@ -1,0 +1,36 @@
+---
+wrapper_template: '_layouts/docs.html'
+context:
+  title: Suru | Components
+---
+
+# Suru
+
+<hr>
+
+Suru component can be used to display a visual separation between two sections of content.
+
+By default Suru should be used on the paper background. When used on dark background, add `is-dark` modifier class.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/suru/default" class="js-example">
+View example of the default Suru component
+</a></div>
+
+<div class="embedded-example"><a href="/docs/examples/patterns/suru/dark" class="js-example">
+View example of the dark Suru component
+</a></div>
+
+## Import
+
+To import just this component into your project, copy the snippet below and include it in your main Sass file.
+
+```scss
+// import Vanilla and include base mixins
+// this only needs to happen once in a given project
+@import 'vanilla-framework';
+@include vf-base;
+
+@include vf-p-suru;
+```
+
+For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.


### PR DESCRIPTION
## Done

Adds new suru component, for the new style of suru.
Deprecates the use of old suru strip.

Fixes [WD-5196](https://warthogs.atlassian.net/browse/WD-5196)

## QA

- Open [demo](https://vanilla-framework-4849.demos.haus/docs/patterns/suru)
- Review suru examples:
  - https://vanilla-framework-4849.demos.haus/docs/examples/patterns/suru/dark
  - https://vanilla-framework-4849.demos.haus/docs/examples/patterns/suru/default
- Review updated documentation:
  - https://vanilla-framework-4849.demos.haus/docs/patterns/suru
  - https://vanilla-framework-4849.demos.haus/docs/patterns/strip#suru-strip

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]


[WD-5196]: https://warthogs.atlassian.net/browse/WD-5196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ