### PR TITLE
Remove Vanilla 3 changes from "What's new" page

### DIFF
--- a/templates/docs/changelog-v2.md
+++ b/templates/docs/changelog-v2.md
@@ -6,8 +6,6 @@ context:
 
 # Vanilla v2 Changelog
 
-<hr>
-
 <table>
   <thead>
     <tr>

--- a/templates/docs/changelog-v3.html
+++ b/templates/docs/changelog-v3.html
@@ -1,0 +1,74 @@
+{% extends "_layouts/docs.html" %}
+
+{% block content %}
+
+<h1>Vanilla v3 changelog</h1>
+
+<table aria-label="Vanilla v3 changelog">
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for version in releaseNotes if version.version.startswith("3.") %}
+    {% for feature in version.features if feature.status!="Removed" %}
+    <tr>
+      <th><a href="{{ feature.url }}">{{ feature.component|safe }}</a></th>
+      <td>
+        {% if feature.status=="New" %}
+        <span class="p-status-label--positive">
+        {% elif feature.status=="Updated" %}
+        <span class="p-status-label--information">
+        {% elif feature.status=="Deprecated" %}
+        <span class="p-status-label--negative">
+        {% elif updatedFeatures[url]=="In Progress" %}
+        <span class="p-status-label--caution">
+        {% endif %}
+        {{ feature.status }}</span>
+      </td>
+      <td>{{ version.version }}</td>
+      <td>{{ feature.notes | safe }}</td>
+    </tr>
+
+    {% endfor %}
+    {% endfor %}
+
+  </tbody>
+</table>
+
+<h2> Components removed in 3.0</h2>
+
+The table below lists all the removed components and utilities in 3.0. For more information about how migrate to Vanilla 3.0 from previous versions, see <a href="/docs/migration-guide-to-v3">the migration guide</a>.
+
+<table aria-label="What's new in Vanilla {{versionMinor}}">
+  <thead>
+    <tr>
+      <th style="width: 20%">Component</th>
+      <th style="width: 15%">Status</th>
+      <th style="width: 10%">Version</th>
+      <th style="width: 55%">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for version in releaseNotes %}
+    {% for feature in version.features if feature.status=="Removed" %}
+    <tr>
+      <th><a href="{{ feature.url }}">{{ feature.component|safe }}</a></th>
+      <td>
+        <span class="p-status-label--negative">Removed</span>
+      </td>
+      <td>{{ version.version }}</td>
+      <td>{{ feature.notes | safe }}</td>
+    </tr>
+
+    {% endfor %}
+    {% endfor %}
+  </tbody>
+</table>
+
+To see what changed in Vanilla v2, see the <a href="/docs/changelog-v2">changelog for v2</a> page.
+{% endblock %}

--- a/templates/docs/whats-new.html
+++ b/templates/docs/whats-new.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/docs.html" %}
 
 {% block content %}
-
+<section class="p-section">
 <h1>  What's new in Vanilla {{versionMinor}} </h1>
 
 <hr>
@@ -40,7 +40,7 @@ When we add, make significant updates, or deprecate a component we update their 
   </tbody>
 </table>
 
-<h2>Previously in Vanilla v3</h2>
+<h2>Previously in Vanilla v4</h2>
 
 <table aria-label="Previously in Vanilla v3">
   <thead>
@@ -52,7 +52,7 @@ When we add, make significant updates, or deprecate a component we update their 
     </tr>
   </thead>
   <tbody>
-    {% for version in releaseNotes[1:] %}
+    {% for version in releaseNotes[1:] if version.version.startswith("4.") %}
     {% for feature in version.features if feature.status!="Removed" %}
     <tr>
       <th><a href="{{ feature.url }}">{{ feature.component|safe }}</a></th>
@@ -74,41 +74,13 @@ When we add, make significant updates, or deprecate a component we update their 
 
     {% endfor %}
     {% endfor %}
-    
+
   </tbody>
 </table>
 
-<h2> Components removed in 3.0</h2>
+To see what changed in Vanilla v3, see the <a href="/docs/changelog-v3">changelog for v3</a> page.
 
-The table below lists all the removed components and utilities in 3.0. For more information about how migrate to Vanilla 3.0 from previous versions, see <a href="/docs/migration-guide-to-v3">the migration guide</a>.
-
-<table aria-label="What's new in Vanilla {{versionMinor}}">
-  <thead>
-    <tr>
-      <th style="width: 20%">Component</th>
-      <th style="width: 15%">Status</th>
-      <th style="width: 10%">Version</th>
-      <th style="width: 55%">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for version in releaseNotes %}
-    {% for feature in version.features if feature.status=="Removed" %}
-    <tr>
-      <th><a href="{{ feature.url }}">{{ feature.component|safe }}</a></th>
-      <td>
-        <span class="p-status-label--negative">Removed</span>
-      </td>
-      <td>{{ version.version }}</td>
-      <td>{{ feature.notes | safe }}</td>
-    </tr>
-
-    {% endfor %}
-    {% endfor %}
-  </tbody>
-</table>
-
-To see what changed in Vanilla v2, see the <a href="/docs/changelog-v2">changelog for v2</a> page.
+</section>
 
 <h2>Status key</h2>
 


### PR DESCRIPTION
## Done

Removes Vanilla 3 changelog from "What's new" page and moves it to separate changelog page.

## QA

- Open [demo](https://vanilla-framework-4851.demos.haus/docs/whats-new)
- Make sure what's new page only lists changes from Vanilla 4: https://vanilla-framework-4851.demos.haus/docs/whats-new
- Check if new v3 page lists all changes from Vanilla 3: https://vanilla-framework-4851.demos.haus/docs/changelog-v3

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
