### PR TITLE
Fix chevron top on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -598,8 +598,8 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
 
       @media (min-width: $breakpoint-navigation-threshold) {
         right: calc($sph--small + 1px); // 1px for the border on selects. this aligns it with any selects underneath
-        transform: rotate(0deg);
         top: calc($spv--large + map-get($nudges, x-small));
+        transform: rotate(0deg);
       }
     }
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -588,7 +588,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
       position: absolute;
       right: map-get($grid-margin-widths, small);
       text-indent: calc(100% + 10rem);
-      top: calc($spv--large + map-get($nudges, x-small));
+      top: $spv--large;
       transform: rotate(-90deg);
       width: map-get($icon-sizes, default);
 
@@ -599,6 +599,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
       @media (min-width: $breakpoint-navigation-threshold) {
         right: calc($sph--small + 1px); // 1px for the border on selects. this aligns it with any selects underneath
         transform: rotate(0deg);
+        top: calc($spv--large + map-get($nudges, x-small));
       }
     }
 


### PR DESCRIPTION
## Done

Set chevron top to 1rem on mobile and 1.25rem on desktop

Fixes [#4758](https://github.com/canonical/vanilla-framework/issues/4758)

## QA

- Open [demo](http://0.0.0.0:8101/docs/examples/patterns/navigation/dropdown#navigation)
- Check chevron height in mobile and desktop mode using developer tools


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).