### PR TITLE
Fix top border visible in split lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -111,17 +111,17 @@ $list-step-bullet-margin: $sph--x-large;
 }
 
 @mixin vf-list-item-divided {
-  box-shadow: inset 0px 1px 0px 0px $color-mid-x-light;
+  box-shadow: inset 0px -1px 0px 0px $color-mid-x-light;
   margin: 0;
   padding-bottom: $sph--large;
   padding-top: $sph--small;
 
-  &:first-child {
+  &:last-child {
     box-shadow: none;
   }
 
   .p-list--divided > .p-list__item:first-child {
-    box-shadow: inset 0px 1px 0px 0px $color-mid-x-light;
+    box-shadow: inset 0px -1px 0px 0px $color-mid-x-light;
   }
 }
 


### PR DESCRIPTION
## Done

Set border box shadow to bottom in split lists

Fixes [#4748](https://github.com/canonical/vanilla-framework/issues/4748)

## QA

- Open [demo](http://0.0.0.0:8101/docs/patterns/lists#split)
- Review split list border 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
![Screenshot from 2023-08-01 17-38-03](https://github.com/canonical/vanilla-framework/assets/14212201/dea5d356-5578-408e-af8d-25891c1c27a8)
