### PR TITLE
Dark theme for forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.2.0
+  features:
+    - component: Forms / Dark
+      url: /docs/base/forms#dark-theme
+      status: New
+      notes: We've added a new dark version for the forms inputs.
 - version: 4.1.0
   features:
     - component: Tabs

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -248,7 +248,7 @@
   // stylelint-enable selector-max-type
 }
 
-@mixin vf-input-theme($color-background-default, $color-background-hover, $color-background-active, $color-background-option, $color-border, $color-text) {
+@mixin vf-input-theme($color-background-default, $color-background-hover, $color-background-active, $color-background-option, $color-border, $color-text, $color-text-placeholder) {
   background-color: $color-background-default;
   border-color: $color-border;
   color: $color-text;
@@ -273,6 +273,10 @@
   option:checked {
     background-color: $color-background-active;
   }
+
+  &::placeholder {
+    color: $color-text-placeholder;
+  }
 }
 
 @mixin vf-input-light-theme {
@@ -282,7 +286,8 @@
     $color-background-active: $colors--light-theme--background-active,
     $color-background-option: $colors--light-theme--background-alt,
     $color-border: $colors--light-theme--text-default,
-    $color-text: $colors--light-theme--text-default
+    $color-text: $colors--light-theme--text-default,
+    $color-text-placeholder: $colors--light-theme--text-muted
   );
 }
 
@@ -297,7 +302,8 @@
     $color-background-active: $colors--paper-theme--background-active,
     $color-background-option: $colors--light-theme--background-alt,
     $color-border: $colors--light-theme--text-default,
-    $color-text: $colors--light-theme--text-default
+    $color-text: $colors--light-theme--text-default,
+    $color-text-placeholder: $colors--light-theme--text-muted
   );
 }
 
@@ -308,6 +314,7 @@
     $color-background-active: $colors--dark-theme--background-active,
     $color-background-option: $colors--dark-theme--background-alt,
     $color-border: $colors--dark-theme--border-high-contrast,
-    $color-text: $colors--dark-theme--text-default
+    $color-text: $colors--dark-theme--text-default,
+    $color-text-placeholder: $colors--dark-theme--text-muted
   );
 }

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -68,22 +68,29 @@
       }
     }
 
-    // adjust input background color for paper theme
+    // Theming
+    @if ($theme-default-forms == 'dark') {
+      @include vf-input-dark-theme;
 
-    // XXX: currently these colours are transparent,
-    // so they work both on paper and white backgrounds.
-    // We may need later to add a specific override for
-    // a white background within paper themed pages.
-    .is-paper & {
-      background-color: $colors--paper-theme--background-inputs;
-
-      &:hover {
-        background-color: $colors--paper-theme--background-hover;
+      &.is-light {
+        @include vf-input-light-theme;
       }
 
-      &:active,
-      &:focus {
-        background-color: $colors--paper-theme--background-active;
+      .is-paper &,
+      &.is-paper {
+        @include vf-input-paper-theme;
+      }
+    } @else {
+      @include vf-input-light-theme;
+
+      .is-dark &,
+      &.is-dark {
+        @include vf-input-dark-theme;
+      }
+
+      .is-paper &,
+      &.is-paper {
+        @include vf-input-paper-theme;
       }
     }
   }
@@ -193,12 +200,10 @@
     -webkit-appearance: none;
     appearance: none;
     // stylelint-enable property-no-vendor-prefix
-    background-color: $colors--light-theme--background-hover;
     background-position: right $sph--small center;
     background-repeat: no-repeat;
     background-size: map-get($icon-sizes, default);
     box-shadow: none;
-    color: $colors--light-theme--text-default;
     min-height: map-get($line-heights, default-text);
     padding-right: calc($default-icon-size + 2 * $sph--small);
     text-indent: 0.01px;
@@ -208,10 +213,6 @@
       cursor: pointer;
     }
 
-    option {
-      background-color: white;
-    }
-
     &[multiple],
     &[size] {
       background-image: none;
@@ -219,7 +220,6 @@
       height: auto;
 
       option {
-        background-color: $colors--light-theme--background-hover;
         font-weight: $font-weight-regular-text;
         line-height: calc($sp-unit * 2 - 2px);
         padding: $spv--x-small 0;
@@ -246,4 +246,53 @@
     padding: calc($spv--large - $input-border-thickness);
   }
   // stylelint-enable selector-max-type
+}
+
+@mixin vf-input-theme($color-background-default, $color-background-hover, $color-background-active, $color-border, $color-text) {
+  background-color: $color-background-default;
+  border-color: $color-border;
+  color: $color-text;
+
+  &:hover {
+    background-color: $color-background-hover;
+  }
+
+  &:active,
+  &:focus {
+    background-color: $color-background-active;
+  }
+}
+
+@mixin vf-input-light-theme {
+  @include vf-input-theme(
+    $color-background-default: $colors--light-theme--background-inputs,
+    $color-background-hover: $colors--light-theme--background-hover,
+    $color-background-active: $colors--light-theme--background-active,
+    $color-border: $colors--light-theme--text-default,
+    $color-text: $colors--light-theme--text-default
+  );
+}
+
+@mixin vf-input-paper-theme {
+  // XXX: currently these colours are transparent,
+  // so they work both on paper and white backgrounds.
+  // We may need later to add a specific override for
+  // a white background within paper themed pages.
+  @include vf-input-theme(
+    $color-background-default: $colors--paper-theme--background-inputs,
+    $color-background-hover: $colors--paper-theme--background-hover,
+    $color-background-active: $colors--paper-theme--background-active,
+    $color-border: $colors--light-theme--text-default,
+    $color-text: $colors--light-theme--text-default
+  );
+}
+
+@mixin vf-input-dark-theme {
+  @include vf-input-theme(
+    $color-background-default: $colors--dark-theme--background-inputs,
+    $color-background-hover: $colors--dark-theme--background-hover,
+    $color-background-active: $colors--dark-theme--background-active,
+    $color-border: $colors--dark-theme--border-high-contrast,
+    $color-text: $colors--dark-theme--text-default
+  );
 }

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -270,7 +270,7 @@
   }
 
   // stylelint-disable-next-line selector-max-type -- base styles can use type selectors
-  option:checked {
+  option:checked:not(:disabled) {
     background-color: $color-background-active;
   }
 

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -248,7 +248,7 @@
   // stylelint-enable selector-max-type
 }
 
-@mixin vf-input-theme($color-background-default, $color-background-hover, $color-background-active, $color-border, $color-text) {
+@mixin vf-input-theme($color-background-default, $color-background-hover, $color-background-active, $color-background-option, $color-border, $color-text) {
   background-color: $color-background-default;
   border-color: $color-border;
   color: $color-text;
@@ -261,6 +261,18 @@
   &:focus {
     background-color: $color-background-active;
   }
+
+  // stylelint-disable-next-line selector-max-type -- base styles can use type selectors
+  option,
+  option:checked {
+    background-color: $color-background-option;
+    color: $color-text;
+  }
+
+  // stylelint-disable-next-line selector-max-type -- base styles can use type selectors
+  option:checked {
+    background-color: $color-background-active;
+  }
 }
 
 @mixin vf-input-light-theme {
@@ -268,6 +280,7 @@
     $color-background-default: $colors--light-theme--background-inputs,
     $color-background-hover: $colors--light-theme--background-hover,
     $color-background-active: $colors--light-theme--background-active,
+    $color-background-option: $colors--light-theme--background-alt,
     $color-border: $colors--light-theme--text-default,
     $color-text: $colors--light-theme--text-default
   );
@@ -282,6 +295,7 @@
     $color-background-default: $colors--paper-theme--background-inputs,
     $color-background-hover: $colors--paper-theme--background-hover,
     $color-background-active: $colors--paper-theme--background-active,
+    $color-background-option: $colors--light-theme--background-alt,
     $color-border: $colors--light-theme--text-default,
     $color-text: $colors--light-theme--text-default
   );
@@ -292,6 +306,7 @@
     $color-background-default: $colors--dark-theme--background-inputs,
     $color-background-hover: $colors--dark-theme--background-hover,
     $color-background-active: $colors--dark-theme--background-active,
+    $color-background-option: $colors--dark-theme--background-alt,
     $color-border: $colors--dark-theme--border-high-contrast,
     $color-text: $colors--dark-theme--text-default
   );

--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -38,12 +38,12 @@
   background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4.5 6v6a1.5 1.5 0 001.356 1.493L6 13.5h4a1.5 1.5 0 001.493-1.356L11.5 12V6H13v6a3 3 0 01-3 3H6a3 3 0 01-3-3V6h1.5zm3 0v5.994H6V6h1.5zm2.498 0v5.994h-1.5V6h1.5zM8.5 0A2.5 2.5 0 0111 2.5V3h3v1.5H2V3h3v-.5A2.5 2.5 0 017.5 0h1zm0 1.5h-1a1 1 0 00-.993.883L6.5 2.5V3h3v-.5a1 1 0 00-.883-.993L8.5 1.5z' fill='#{vf-url-friendly-color($color)}' fill-rule='evenodd'/%3E%3C/svg%3E");
 }
 
-@mixin vf-icon-error($color: $color-negative) {
-  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Ccircle stroke='#{vf-url-friendly-color($color)}' stroke-width='1.5' fill='#{vf-url-friendly-color($color)}' cx='8' cy='8' r='6.25'/%3E%3Cpath fill='%23FFF' fill-rule='nonzero' d='M10.282 4.638l1.06 1.06L9.05 7.99l2.293 2.292-1.06 1.06L7.99 9.05 5.7 11.343l-1.06-1.06 2.29-2.293L4.64 5.7l1.06-1.06 2.291 2.29z'/%3E%3C/g%3E%3C/svg%3E");
+@mixin vf-icon-error($color: $color-negative, $color-symbol: $color-x-light) {
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Ccircle stroke='#{vf-url-friendly-color($color)}' stroke-width='1.5' fill='#{vf-url-friendly-color($color)}' cx='8' cy='8' r='6.25'/%3E%3Cpath fill='#{vf-url-friendly-color($color-symbol)}' fill-rule='nonzero' d='M10.282 4.638l1.06 1.06L9.05 7.99l2.293 2.292-1.06 1.06L7.99 9.05 5.7 11.343l-1.06-1.06 2.29-2.293L4.64 5.7l1.06-1.06 2.291 2.29z'/%3E%3C/g%3E%3C/svg%3E");
 }
 
-@mixin vf-icon-warning($color: $color-caution) {
-  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M9.34 1.2l5.842 11.627A1.5 1.5 0 0113.842 15H2.158a1.5 1.5 0 01-1.34-2.173L6.66 1.2a1.5 1.5 0 012.68 0z' fill='#{vf-url-friendly-color($color)}'/%3E%3Cpath d='M8.5 11a.5.5 0 01.492.41L9 11.5v1a.5.5 0 01-.41.492L8.5 13h-1a.5.5 0 01-.492-.41L7 12.5v-1a.5.5 0 01.41-.492L7.5 11h1zM9 5v4.5H7V5h2z' fill='%23FFF'/%3E%3C/g%3E%3C/svg%3E");
+@mixin vf-icon-warning($color: $color-caution, $color-symbol: $color-x-light) {
+  background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M9.34 1.2l5.842 11.627A1.5 1.5 0 0113.842 15H2.158a1.5 1.5 0 01-1.34-2.173L6.66 1.2a1.5 1.5 0 012.68 0z' fill='#{vf-url-friendly-color($color)}'/%3E%3Cpath d='M8.5 11a.5.5 0 01.492.41L9 11.5v1a.5.5 0 01-.41.492L8.5 13h-1a.5.5 0 01-.492-.41L7 12.5v-1a.5.5 0 01.41-.492L7.5 11h1zM9 5v4.5H7V5h2z' fill='#{vf-url-friendly-color($color-symbol)}'/%3E%3C/g%3E%3C/svg%3E");
 }
 
 @mixin vf-icon-external-link($color) {
@@ -70,8 +70,8 @@
   background-image: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.964 1a5.964 5.964 0 014.709 9.623l4.303 4.305-1.06 1.06-4.306-4.305A5.964 5.964 0 116.963 1zm0 1.5a4.464 4.464 0 100 8.927 4.464 4.464 0 000-8.927z' fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero'/%3E%3C/svg%3E");
 }
 
-@mixin vf-icon-success($bg-color: $color-positive, $fg-color: $color-x-light) {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cg fill='none' fill-rule='nonzero'%3E%3Cpath fill='#{vf-url-friendly-color($bg-color)}' d='M8 1a7 7 0 110 14A7 7 0 018 1zm2.83 3.502L6.863 9.884 5.174 8.096l-1.09 1.03 2.92 3.096 5.034-6.83-1.208-.89z'/%3E%3Cpath fill='#{vf-url-friendly-color($fg-color)}' d='M10.83 4.502l1.208.89-5.033 6.83-2.922-3.096 1.091-1.03 1.689 1.789z'/%3E%3C/g%3E%3C/svg%3E");
+@mixin vf-icon-success($color: $color-positive, $color-symbol: $color-x-light) {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cg fill='none' fill-rule='nonzero'%3E%3Cpath fill='#{vf-url-friendly-color($color)}' d='M8 1a7 7 0 110 14A7 7 0 018 1zm2.83 3.502L6.863 9.884 5.174 8.096l-1.09 1.03 2.92 3.096 5.034-6.83-1.208-.89z'/%3E%3Cpath fill='#{vf-url-friendly-color($color-symbol)}' d='M10.83 4.502l1.208.89-5.033 6.83-2.922-3.096 1.091-1.03 1.689 1.789z'/%3E%3C/g%3E%3C/svg%3E");
 }
 
 @mixin vf-icon-share($color) {

--- a/scss/_patterns_form-help-text.scss
+++ b/scss/_patterns_form-help-text.scss
@@ -11,4 +11,32 @@
       margin-left: $sph--large + $form-tick-box-size;
     }
   }
+
+  @if ($theme-default-forms == 'dark') {
+    .p-form-help-text {
+      @include vf-form-help-text-dark-theme;
+    }
+  } @else {
+    .p-form-help-text {
+      @include vf-form-help-text-light-theme;
+    }
+  }
+
+  .is-dark .p-form-help-text,
+  .p-form-help-text.is-dark {
+    @include vf-form-help-text-dark-theme;
+  }
+
+  .is-light .p-form-help-text,
+  .p-form-help-text.is-light {
+    @include vf-form-help-text-light-theme;
+  }
+}
+
+@mixin vf-form-help-text-dark-theme {
+  color: $colors--dark-theme--text-muted;
+}
+
+@mixin vf-form-help-text-light-theme {
+  color: $colors--light-theme--text-muted;
 }

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -18,19 +18,6 @@
   }
 
   .is-success {
-    .p-form-validation__input {
-      background-color: $color-positive-background;
-      border-bottom-color: $color-positive;
-
-      &:hover {
-        background-color: $color-positive-background--hover;
-      }
-
-      &:focus {
-        background-color: $color-positive-background--focus;
-      }
-    }
-
     .p-form-validation__message {
       @extend %vf-validation-wrapper;
       @include vf-icon-success($color-positive);
@@ -40,39 +27,15 @@
   }
 
   .is-caution {
-    .p-form-validation__input {
-      background-color: $color-caution-background;
-      border-bottom-color: $color-caution;
-
-      &:hover {
-        background-color: $color-caution-background--hover;
-      }
-
-      &:focus {
-        background-color: $color-caution-background--focus;
-      }
-    }
-
     .p-form-validation__message {
       @extend %vf-validation-wrapper;
       @include vf-icon-warning($color-caution);
+
+      color: $color-caution;
     }
   }
 
   .is-error {
-    .p-form-validation__input {
-      background-color: $color-negative-background;
-      border-bottom-color: $color-negative;
-
-      &:hover {
-        background-color: $color-negative-background--hover;
-      }
-
-      &:focus {
-        background-color: $color-negative-background--focus;
-      }
-    }
-
     .p-form-validation__message {
       @extend %vf-validation-wrapper;
       @include vf-icon-error($color-negative);
@@ -80,4 +43,141 @@
       color: $color-negative;
     }
   }
+
+  // Theming
+  @if ($theme-default-forms == 'dark') {
+    .p-form-validation__input {
+      .is-success & {
+        @include vf-form-validation-success-dark-theme;
+      }
+
+      .is-caution & {
+        @include vf-form-validation-caution-dark-theme;
+      }
+
+      .is-error & {
+        @include vf-form-validation-error-dark-theme;
+      }
+    }
+  } @else {
+    .p-form-validation__input {
+      .is-success & {
+        @include vf-form-validation-success-light-theme;
+      }
+
+      .is-caution & {
+        @include vf-form-validation-caution-light-theme;
+      }
+
+      .is-error & {
+        @include vf-form-validation-error-light-theme;
+      }
+    }
+  }
+
+  .is-success .p-form-validation__input {
+    .is-dark &,
+    &.is-dark {
+      @include vf-form-validation-success-dark-theme;
+    }
+
+    &.is-light {
+      @include vf-form-validation-success-light-theme;
+    }
+  }
+
+  .is-caution .p-form-validation__input {
+    .is-dark &,
+    &.is-dark {
+      @include vf-form-validation-caution-dark-theme;
+    }
+
+    &.is-light {
+      @include vf-form-validation-caution-light-theme;
+    }
+  }
+
+  .is-error .p-form-validation__input {
+    .is-dark &,
+    &.is-dark {
+      @include vf-form-validation-error-dark-theme;
+    }
+
+    &.is-light {
+      @include vf-form-validation-error-light-theme;
+    }
+  }
+}
+
+@mixin vf-form-validation-state-theme($color-background-default, $color-background-hover, $color-background-active, $color-border, $color-text) {
+  background-color: $color-background-default;
+  border-bottom-color: $color-border;
+
+  &:hover {
+    background-color: $color-background-hover;
+  }
+
+  &:focus {
+    background-color: $color-background-active;
+  }
+}
+
+@mixin vf-form-validation-success-dark-theme {
+  @include vf-form-validation-state-theme(
+    $color-background-default: map-get($colors-dark-theme--tinted-backgrounds, 'positive', 'default'),
+    $color-background-hover: map-get($colors-dark-theme--tinted-backgrounds, 'positive', 'hover'),
+    $color-background-active: map-get($colors-dark-theme--tinted-backgrounds, 'positive', 'active'),
+    $color-border: $color-positive,
+    $color-text: $color-positive
+  );
+}
+
+@mixin vf-form-validation-caution-dark-theme {
+  @include vf-form-validation-state-theme(
+    $color-background-default: map-get($colors-dark-theme--tinted-backgrounds, 'caution', 'default'),
+    $color-background-hover: map-get($colors-dark-theme--tinted-backgrounds, 'caution', 'hover'),
+    $color-background-active: map-get($colors-dark-theme--tinted-backgrounds, 'caution', 'active'),
+    $color-border: $color-caution,
+    $color-text: $color-caution
+  );
+}
+
+@mixin vf-form-validation-error-dark-theme {
+  @include vf-form-validation-state-theme(
+    $color-background-default: map-get($colors-dark-theme--tinted-backgrounds, 'negative', 'default'),
+    $color-background-hover: map-get($colors-dark-theme--tinted-backgrounds, 'negative', 'hover'),
+    $color-background-active: map-get($colors-dark-theme--tinted-backgrounds, 'negative', 'active'),
+    $color-border: $color-negative,
+    $color-text: $color-negative
+  );
+}
+
+@mixin vf-form-validation-success-light-theme {
+  @include vf-form-validation-state-theme(
+    $color-background-default: $color-positive-background,
+    $color-background-hover: $color-positive-background--hover,
+    $color-background-active: $color-positive-background--focus,
+    $color-border: $color-positive,
+    $color-text: $color-positive
+  );
+}
+
+@mixin vf-form-validation-caution-light-theme {
+  @include vf-form-validation-state-theme(
+    $color-background-default: $color-caution-background,
+    $color-background-hover: $color-caution-background--hover,
+    $color-background-active: $color-caution-background--focus,
+    $color-border: $color-caution,
+    $color-text: $color-caution
+  );
+}
+
+@mixin vf-form-validation-error-light-theme {
+  @include vf-form-validation-state-theme(
+    $color-background-default: $color-negative-background,
+    $color-background-hover: $color-negative-background--hover,
+    $color-background-active: $color-negative-background--focus,
+    $color-border: $color-negative,
+    $color-text: $color-negative
+  );
 }

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -19,7 +19,6 @@
   }
 
   // Theming
-  // stylelint-disable no-duplicate-selectors -- allow duplicate selectors in theme overrides
   @if ($theme-default-forms == 'dark') {
     .p-form-validation__input {
       .is-success & {
@@ -169,8 +168,6 @@
       @include vf-form-validation-input-error-light-theme;
     }
   }
-
-  // stylelint-enable no-duplicate-selectors
 }
 
 @mixin vf-form-validation-input-state-theme($color-background-default, $color-background-hover, $color-background-active, $color-border, $color-text) {

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -13,29 +13,9 @@
 
   .p-form-validation__message {
     @extend %small-text;
+    @extend %vf-validation-wrapper;
 
     margin-top: -$sp-unit;
-  }
-
-  .is-success {
-    .p-form-validation__message {
-      @extend %vf-validation-wrapper;
-      @include vf-icon-success($color-positive);
-    }
-  }
-
-  .is-caution {
-    .p-form-validation__message {
-      @extend %vf-validation-wrapper;
-      @include vf-icon-warning($color-caution);
-    }
-  }
-
-  .is-error {
-    .p-form-validation__message {
-      @extend %vf-validation-wrapper;
-      @include vf-icon-error($color-negative);
-    }
   }
 
   // Theming
@@ -306,24 +286,30 @@
 
 @mixin vf-form-validation-message-success-dark-theme {
   @include vf-form-validation-message-state-theme($color-text: map-get($colors-dark-theme--tinted-borders, 'positive'));
+  @include vf-icon-success(map-get($colors-dark-theme--tinted-borders, 'positive'));
 }
 
 @mixin vf-form-validation-message-caution-dark-theme {
   @include vf-form-validation-message-state-theme($color-text: map-get($colors-dark-theme--tinted-borders, 'caution'));
+  @include vf-icon-warning(map-get($colors-dark-theme--tinted-borders, 'caution'));
 }
 
 @mixin vf-form-validation-message-error-dark-theme {
   @include vf-form-validation-message-state-theme($color-text: map-get($colors-dark-theme--tinted-borders, 'negative'));
+  @include vf-icon-error(map-get($colors-dark-theme--tinted-borders, 'negative'));
 }
 
 @mixin vf-form-validation-message-success-light-theme {
   @include vf-form-validation-message-state-theme($color-text: $color-positive);
+  @include vf-icon-success($color-positive);
 }
 
 @mixin vf-form-validation-message-caution-light-theme {
   @include vf-form-validation-message-state-theme($color-text: $colors--light-theme--text-default);
+  @include vf-icon-warning($color-caution);
 }
 
 @mixin vf-form-validation-message-error-light-theme {
   @include vf-form-validation-message-state-theme($color-text: $color-negative);
+  @include vf-icon-error($color-negative);
 }

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -21,8 +21,6 @@
     .p-form-validation__message {
       @extend %vf-validation-wrapper;
       @include vf-icon-success($color-positive);
-
-      color: $color-positive;
     }
   }
 
@@ -30,8 +28,6 @@
     .p-form-validation__message {
       @extend %vf-validation-wrapper;
       @include vf-icon-warning($color-caution);
-
-      color: $color-caution;
     }
   }
 
@@ -39,77 +35,202 @@
     .p-form-validation__message {
       @extend %vf-validation-wrapper;
       @include vf-icon-error($color-negative);
-
-      color: $color-negative;
     }
   }
 
   // Theming
+  // stylelint-disable no-duplicate-selectors -- allow duplicate selectors in theme overrides
   @if ($theme-default-forms == 'dark') {
     .p-form-validation__input {
       .is-success & {
-        @include vf-form-validation-success-dark-theme;
+        @include vf-form-validation-input-success-dark-theme;
       }
 
       .is-caution & {
-        @include vf-form-validation-caution-dark-theme;
+        @include vf-form-validation-input-caution-dark-theme;
       }
 
       .is-error & {
-        @include vf-form-validation-error-dark-theme;
+        @include vf-form-validation-input-error-dark-theme;
+      }
+    }
+
+    .p-form-validation__message {
+      .is-success & {
+        @include vf-form-validation-message-success-dark-theme;
+      }
+
+      .is-caution & {
+        @include vf-form-validation-message-caution-dark-theme;
+      }
+
+      .is-error & {
+        @include vf-form-validation-message-error-dark-theme;
       }
     }
   } @else {
     .p-form-validation__input {
       .is-success & {
-        @include vf-form-validation-success-light-theme;
+        @include vf-form-validation-input-success-light-theme;
       }
 
       .is-caution & {
-        @include vf-form-validation-caution-light-theme;
+        @include vf-form-validation-input-caution-light-theme;
       }
 
       .is-error & {
-        @include vf-form-validation-error-light-theme;
+        @include vf-form-validation-input-error-light-theme;
+      }
+    }
+
+    .p-form-validation__message {
+      .is-success & {
+        @include vf-form-validation-message-success-light-theme;
+      }
+
+      .is-caution & {
+        @include vf-form-validation-message-caution-light-theme;
+      }
+
+      .is-error & {
+        @include vf-form-validation-message-error-light-theme;
       }
     }
   }
 
+  // when is-dark/is-light is set on root p-form-validation element or its parent
+  .is-dark .is-success,
+  .is-success.is-dark {
+    .p-form-validation__input {
+      @include vf-form-validation-input-success-dark-theme;
+    }
+    .p-form-validation__message {
+      @include vf-form-validation-message-success-dark-theme;
+    }
+  }
+
+  .is-light .is-success,
+  .is-success.is-light {
+    .p-form-validation__input {
+      @include vf-form-validation-input-success-light-theme;
+    }
+    .p-form-validation__message {
+      @include vf-form-validation-message-success-light-theme;
+    }
+  }
+
+  .is-dark .is-caution,
+  .is-caution.is-dark {
+    .p-form-validation__input {
+      @include vf-form-validation-input-caution-dark-theme;
+    }
+    .p-form-validation__message {
+      @include vf-form-validation-message-caution-dark-theme;
+    }
+  }
+
+  .is-light .is-caution,
+  .is-caution.is-light {
+    .p-form-validation__input {
+      @include vf-form-validation-input-caution-light-theme;
+    }
+    .p-form-validation__message {
+      @include vf-form-validation-message-caution-light-theme;
+    }
+  }
+
+  .is-dark .is-error,
+  .is-error.is-dark {
+    .p-form-validation__input {
+      @include vf-form-validation-input-error-dark-theme;
+    }
+    .p-form-validation__message {
+      @include vf-form-validation-message-error-dark-theme;
+    }
+  }
+
+  .is-light .is-error,
+  .is-error.is-light {
+    .p-form-validation__input {
+      @include vf-form-validation-input-error-light-theme;
+    }
+    .p-form-validation__message {
+      @include vf-form-validation-message-error-light-theme;
+    }
+  }
+
+  // when is-dark/is-light is set on p-form-validation__input element
   .is-success .p-form-validation__input {
     .is-dark &,
     &.is-dark {
-      @include vf-form-validation-success-dark-theme;
+      @include vf-form-validation-input-success-dark-theme;
     }
 
     &.is-light {
-      @include vf-form-validation-success-light-theme;
+      @include vf-form-validation-input-success-light-theme;
     }
   }
 
   .is-caution .p-form-validation__input {
     .is-dark &,
     &.is-dark {
-      @include vf-form-validation-caution-dark-theme;
+      @include vf-form-validation-input-caution-dark-theme;
     }
 
     &.is-light {
-      @include vf-form-validation-caution-light-theme;
+      @include vf-form-validation-input-caution-light-theme;
     }
   }
 
   .is-error .p-form-validation__input {
     .is-dark &,
     &.is-dark {
-      @include vf-form-validation-error-dark-theme;
+      @include vf-form-validation-input-error-dark-theme;
     }
 
     &.is-light {
-      @include vf-form-validation-error-light-theme;
+      @include vf-form-validation-input-error-light-theme;
     }
   }
+
+  // when is-dark/is-light is set on p-form-validation__message element
+  .is-success .p-form-validation__message {
+    .is-dark &,
+    &.is-dark {
+      @include vf-form-validation-message-success-dark-theme;
+    }
+
+    &.is-light {
+      @include vf-form-validation-message-success-light-theme;
+    }
+  }
+
+  .is-caution .p-form-validation__message {
+    .is-dark &,
+    &.is-dark {
+      @include vf-form-validation-message-caution-dark-theme;
+    }
+
+    &.is-light {
+      @include vf-form-validation-message-caution-light-theme;
+    }
+  }
+
+  .is-error .p-form-validation__message {
+    .is-dark &,
+    &.is-dark {
+      @include vf-form-validation-message-error-dark-theme;
+    }
+
+    &.is-light {
+      @include vf-form-validation-message-error-light-theme;
+    }
+  }
+
+  // stylelint-enable no-duplicate-selectors
 }
 
-@mixin vf-form-validation-state-theme($color-background-default, $color-background-hover, $color-background-active, $color-border, $color-text) {
+@mixin vf-form-validation-input-state-theme($color-background-default, $color-background-hover, $color-background-active, $color-border, $color-text) {
   background-color: $color-background-default;
   border-bottom-color: $color-border;
 
@@ -122,38 +243,38 @@
   }
 }
 
-@mixin vf-form-validation-success-dark-theme {
-  @include vf-form-validation-state-theme(
+@mixin vf-form-validation-input-success-dark-theme {
+  @include vf-form-validation-input-state-theme(
     $color-background-default: map-get($colors-dark-theme--tinted-backgrounds, 'positive', 'default'),
     $color-background-hover: map-get($colors-dark-theme--tinted-backgrounds, 'positive', 'hover'),
     $color-background-active: map-get($colors-dark-theme--tinted-backgrounds, 'positive', 'active'),
-    $color-border: $color-positive,
-    $color-text: $color-positive
+    $color-border: map-get($colors-dark-theme--tinted-borders, 'positive'),
+    $color-text: map-get($colors-dark-theme--tinted-borders, 'positive')
   );
 }
 
-@mixin vf-form-validation-caution-dark-theme {
-  @include vf-form-validation-state-theme(
+@mixin vf-form-validation-input-caution-dark-theme {
+  @include vf-form-validation-input-state-theme(
     $color-background-default: map-get($colors-dark-theme--tinted-backgrounds, 'caution', 'default'),
     $color-background-hover: map-get($colors-dark-theme--tinted-backgrounds, 'caution', 'hover'),
     $color-background-active: map-get($colors-dark-theme--tinted-backgrounds, 'caution', 'active'),
-    $color-border: $color-caution,
-    $color-text: $color-caution
+    $color-border: map-get($colors-dark-theme--tinted-borders, 'caution'),
+    $color-text: map-get($colors-dark-theme--tinted-borders, 'caution')
   );
 }
 
-@mixin vf-form-validation-error-dark-theme {
-  @include vf-form-validation-state-theme(
+@mixin vf-form-validation-input-error-dark-theme {
+  @include vf-form-validation-input-state-theme(
     $color-background-default: map-get($colors-dark-theme--tinted-backgrounds, 'negative', 'default'),
     $color-background-hover: map-get($colors-dark-theme--tinted-backgrounds, 'negative', 'hover'),
     $color-background-active: map-get($colors-dark-theme--tinted-backgrounds, 'negative', 'active'),
-    $color-border: $color-negative,
-    $color-text: $color-negative
+    $color-border: map-get($colors-dark-theme--tinted-borders, 'negative'),
+    $color-text: map-get($colors-dark-theme--tinted-borders, 'negative')
   );
 }
 
-@mixin vf-form-validation-success-light-theme {
-  @include vf-form-validation-state-theme(
+@mixin vf-form-validation-input-success-light-theme {
+  @include vf-form-validation-input-state-theme(
     $color-background-default: $color-positive-background,
     $color-background-hover: $color-positive-background--hover,
     $color-background-active: $color-positive-background--focus,
@@ -162,8 +283,8 @@
   );
 }
 
-@mixin vf-form-validation-caution-light-theme {
-  @include vf-form-validation-state-theme(
+@mixin vf-form-validation-input-caution-light-theme {
+  @include vf-form-validation-input-state-theme(
     $color-background-default: $color-caution-background,
     $color-background-hover: $color-caution-background--hover,
     $color-background-active: $color-caution-background--focus,
@@ -172,12 +293,40 @@
   );
 }
 
-@mixin vf-form-validation-error-light-theme {
-  @include vf-form-validation-state-theme(
+@mixin vf-form-validation-input-error-light-theme {
+  @include vf-form-validation-input-state-theme(
     $color-background-default: $color-negative-background,
     $color-background-hover: $color-negative-background--hover,
     $color-background-active: $color-negative-background--focus,
     $color-border: $color-negative,
     $color-text: $color-negative
   );
+}
+
+@mixin vf-form-validation-message-state-theme($color-text) {
+  color: $color-text;
+}
+
+@mixin vf-form-validation-message-success-dark-theme {
+  @include vf-form-validation-message-state-theme($color-text: map-get($colors-dark-theme--tinted-borders, 'positive'));
+}
+
+@mixin vf-form-validation-message-caution-dark-theme {
+  @include vf-form-validation-message-state-theme($color-text: map-get($colors-dark-theme--tinted-borders, 'caution'));
+}
+
+@mixin vf-form-validation-message-error-dark-theme {
+  @include vf-form-validation-message-state-theme($color-text: map-get($colors-dark-theme--tinted-borders, 'negative'));
+}
+
+@mixin vf-form-validation-message-success-light-theme {
+  @include vf-form-validation-message-state-theme($color-text: $color-positive);
+}
+
+@mixin vf-form-validation-message-caution-light-theme {
+  @include vf-form-validation-message-state-theme($color-text: $colors--light-theme--text-default);
+}
+
+@mixin vf-form-validation-message-error-light-theme {
+  @include vf-form-validation-message-state-theme($color-text: $color-negative);
 }

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -170,40 +170,6 @@
     }
   }
 
-  // when is-dark/is-light is set on p-form-validation__message element
-  .is-success .p-form-validation__message {
-    .is-dark &,
-    &.is-dark {
-      @include vf-form-validation-message-success-dark-theme;
-    }
-
-    &.is-light {
-      @include vf-form-validation-message-success-light-theme;
-    }
-  }
-
-  .is-caution .p-form-validation__message {
-    .is-dark &,
-    &.is-dark {
-      @include vf-form-validation-message-caution-dark-theme;
-    }
-
-    &.is-light {
-      @include vf-form-validation-message-caution-light-theme;
-    }
-  }
-
-  .is-error .p-form-validation__message {
-    .is-dark &,
-    &.is-dark {
-      @include vf-form-validation-message-error-dark-theme;
-    }
-
-    &.is-light {
-      @include vf-form-validation-message-error-light-theme;
-    }
-  }
-
   // stylelint-enable no-duplicate-selectors
 }
 

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -109,7 +109,6 @@
     }
   }
 
-  .is-light .is-success,
   .is-success.is-light {
     .p-form-validation__input {
       @include vf-form-validation-input-success-light-theme;
@@ -129,7 +128,6 @@
     }
   }
 
-  .is-light .is-caution,
   .is-caution.is-light {
     .p-form-validation__input {
       @include vf-form-validation-input-caution-light-theme;
@@ -149,7 +147,6 @@
     }
   }
 
-  .is-light .is-error,
   .is-error.is-light {
     .p-form-validation__input {
       @include vf-form-validation-input-error-light-theme;

--- a/scss/_patterns_form-validation.scss
+++ b/scss/_patterns_form-validation.scss
@@ -252,17 +252,17 @@
 
 @mixin vf-form-validation-message-success-dark-theme {
   @include vf-form-validation-message-state-theme($color-text: map-get($colors-dark-theme--tinted-borders, 'positive'));
-  @include vf-icon-success(map-get($colors-dark-theme--tinted-borders, 'positive'));
+  @include vf-icon-success($color: map-get($colors-dark-theme--tinted-borders, 'positive'), $color-symbol: $colors--dark-theme--background-default);
 }
 
 @mixin vf-form-validation-message-caution-dark-theme {
   @include vf-form-validation-message-state-theme($color-text: map-get($colors-dark-theme--tinted-borders, 'caution'));
-  @include vf-icon-warning(map-get($colors-dark-theme--tinted-borders, 'caution'));
+  @include vf-icon-warning($color: map-get($colors-dark-theme--tinted-borders, 'caution'), $color-symbol: $colors--dark-theme--background-default);
 }
 
 @mixin vf-form-validation-message-error-dark-theme {
   @include vf-form-validation-message-state-theme($color-text: map-get($colors-dark-theme--tinted-borders, 'negative'));
-  @include vf-icon-error(map-get($colors-dark-theme--tinted-borders, 'negative'));
+  @include vf-icon-error($color: map-get($colors-dark-theme--tinted-borders, 'negative'), $color-symbol: $colors--dark-theme--background-default);
 }
 
 @mixin vf-form-validation-message-success-light-theme {

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -157,6 +157,7 @@ $colors--dark-theme--text-inactive: rgba($colors--dark-theme--text-default, $ina
 
 $colors--dark-theme--background-default: #262626 !default;
 $colors--dark-theme--background-alt: #2d2d2d !default;
+$colors--dark-theme--background-inputs: rgba($colors--dark-theme--text-default, $input-background-opacity-amount) !default;
 $colors--dark-theme--background-active: rgba($colors--dark-theme--text-default, $active-background-opacity-amount) !default;
 $colors--dark-theme--background-hover: rgba($colors--dark-theme--text-default, $hover-background-opacity-amount) !default;
 $colors--dark-theme--background-overlay: transparentize($color-dark, 0.15) !default;

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -197,7 +197,7 @@ $colors-dark-theme--tinted-backgrounds: (
 $colors-dark-theme--tinted-borders: (
   neutral: hsl(0deg 0% 65%),
   positive: #62a36c,
-  caution: hsl(27deg 80% 65%),
+  caution: #c48831,
   negative: #d17b85,
   information: hsl(210deg 80% 65%),
 );

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -196,9 +196,9 @@ $colors-dark-theme--tinted-backgrounds: (
 
 $colors-dark-theme--tinted-borders: (
   neutral: hsl(0deg 0% 65%),
-  positive: hsl(129deg 60% 65%),
+  positive: #62a36c,
   caution: hsl(27deg 80% 65%),
-  negative: hsl(353deg 80% 70%),
+  negative: #d17b85,
   information: hsl(210deg 80% 65%),
 );
 

--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -218,6 +218,18 @@ When using a password field, use this pattern to allow the user to toggle the pa
 View example of the password toggle
 </a></div>
 
+## Dark theme
+
+By default the form elements are displayed in the light theme. To display them in the dark theme, add the class `.is-dark` to the input elements.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/forms/forms-dark/" class="js-example">
+View example of the dark form elements
+</a></div>
+
+<div class="embedded-example"><a href="/docs/examples/patterns/forms/form-validation-dark/" class="js-example">
+View example of the dark form elements
+</a></div>
+
 ## Accessibility
 
 Validated form input elements should indicate errors with `aria-invalid` attribute.

--- a/templates/docs/examples/patterns/forms/form-validation-dark.html
+++ b/templates/docs/examples/patterns/forms/form-validation-dark.html
@@ -13,28 +13,28 @@
 {% endblock %}
 {% block content %}
 <form>
-  <div class="p-form-validation is-error">
+  <div class="p-form-validation is-error is-dark">
     <label for="exampleTextInputError">Email address</label>
-    <input class="p-form-validation__input is-dark" type="email" id="exampleTextInputError" placeholder="example@canonical.com" name="exampleTextInputError" autocomplete="email" aria-invalid="true" aria-describedby="exampleInputErrorMessage" />
+    <input class="p-form-validation__input" type="email" id="exampleTextInputError" placeholder="example@canonical.com" name="exampleTextInputError" autocomplete="email" aria-invalid="true" aria-describedby="exampleInputErrorMessage" />
     <p class="p-form-validation__message" id="exampleInputErrorMessage">This field is required.</p>
   </div>
 
-  <div class="p-form-validation is-caution">
+  <div class="p-form-validation is-caution is-dark">
     <label for="exampleTextInputCaution">Mail configuration ID</label>
-    <input class="p-form-validation__input is-dark" type="text" id="exampleTextInputCaution" placeholder="14" name="exampleTextInputCaution" autocomplete="on" aria-describedby="exampleInputCautionMessage"/>
+    <input class="p-form-validation__input" type="text" id="exampleTextInputCaution" placeholder="14" name="exampleTextInputCaution" autocomplete="on" aria-describedby="exampleInputCautionMessage"/>
     <p class="p-form-validation__message" id="exampleInputCautionMessage">No validation is performed in preview mode.</p>
   </div>
 
-  <div class="p-form-validation is-success">
+  <div class="p-form-validation is-success is-dark">
     <label for="exampleTextInputSuccess">Card number</label>
-    <input class="p-form-validation__input is-dark" type="text" id="exampleTextInputSuccess" placeholder="**** **** **** ****" name="exampleTextInputSuccess" autocomplete="off" aria-describedby="exampleInputSuccessMessage"/>
+    <input class="p-form-validation__input" type="text" id="exampleTextInputSuccess" placeholder="**** **** **** ****" name="exampleTextInputSuccess" autocomplete="off" aria-describedby="exampleInputSuccessMessage"/>
     <p class="p-form-validation__message" id="exampleInputSuccessMessage">Verified.</p>
   </div>
 
-  <div class="p-form-validation is-error">
+  <div class="p-form-validation is-error is-dark">
     <label for="exampleSelectInputError">Ubuntu releases</label>
     <div class="p-form-validation__select-wrapper">
-      <select class="p-form-validation__input is-dark" id="exampleSelectInputError" name="exampleSelectInputError" aria-invalid="true" aria-describedby="exampleSelectErrorMessage">
+      <select class="p-form-validation__input" id="exampleSelectInputError" name="exampleSelectInputError" aria-invalid="true" aria-describedby="exampleSelectErrorMessage">
         <option value="">--Select an option--</option>
         <option value="1">Cosmic Cuttlefish</option>
         <option value="2">Bionic Beaver</option>

--- a/templates/docs/examples/patterns/forms/form-validation-dark.html
+++ b/templates/docs/examples/patterns/forms/form-validation-dark.html
@@ -1,0 +1,47 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Forms / Validation Dark{% endblock %}
+
+{% block standalone_css %}patterns_forms{% endblock %}
+
+{% block style %}
+<style>
+  body {
+    background: #262626;
+    color: #fff;
+  }
+</style>
+{% endblock %}
+{% block content %}
+<form>
+  <div class="p-form-validation is-error">
+    <label for="exampleTextInputError">Email address</label>
+    <input class="p-form-validation__input is-dark" type="email" id="exampleTextInputError" placeholder="example@canonical.com" name="exampleTextInputError" autocomplete="email" aria-invalid="true" aria-describedby="exampleInputErrorMessage" />
+    <p class="p-form-validation__message" id="exampleInputErrorMessage">This field is required.</p>
+  </div>
+
+  <div class="p-form-validation is-caution">
+    <label for="exampleTextInputCaution">Mail configuration ID</label>
+    <input class="p-form-validation__input is-dark" type="text" id="exampleTextInputCaution" placeholder="14" name="exampleTextInputCaution" autocomplete="on" aria-describedby="exampleInputCautionMessage"/>
+    <p class="p-form-validation__message" id="exampleInputCautionMessage">No validation is performed in preview mode.</p>
+  </div>
+
+  <div class="p-form-validation is-success">
+    <label for="exampleTextInputSuccess">Card number</label>
+    <input class="p-form-validation__input is-dark" type="text" id="exampleTextInputSuccess" placeholder="**** **** **** ****" name="exampleTextInputSuccess" autocomplete="off" aria-describedby="exampleInputSuccessMessage"/>
+    <p class="p-form-validation__message" id="exampleInputSuccessMessage">Verified.</p>
+  </div>
+
+  <div class="p-form-validation is-error">
+    <label for="exampleSelectInputError">Ubuntu releases</label>
+    <div class="p-form-validation__select-wrapper">
+      <select class="p-form-validation__input is-dark" id="exampleSelectInputError" name="exampleSelectInputError" aria-invalid="true" aria-describedby="exampleSelectErrorMessage">
+        <option value="">--Select an option--</option>
+        <option value="1">Cosmic Cuttlefish</option>
+        <option value="2">Bionic Beaver</option>
+        <option value="3">Xenial Xerus</option>
+      </select>
+    </div>
+    <p class="p-form-validation__message" id="exampleSelectErrorMessage">You need to select an OS to complete your install.</p>
+  </div>
+</form>
+{% endblock %}

--- a/templates/docs/examples/patterns/forms/forms-dark.html
+++ b/templates/docs/examples/patterns/forms/forms-dark.html
@@ -17,7 +17,7 @@
 <form>
   <label for="exampleTextInputHelp">Email address</label>
   <input class="p-form-validation__input is-dark" type="email" id="exampleTextInputHelp" placeholder="example@canonical.com" name="exampleTextInputHelp" autocomplete="email" aria-describedby="exampleInputHelpMessage"/>
-  <p class="p-form-help-text" id="exampleInputHelpMessage">
+  <p class="p-form-help-text is-dark" id="exampleInputHelpMessage">
     A notification email will be sent to entered email address.
   </p>
 
@@ -36,6 +36,6 @@
     <input type="checkbox" aria-labelledby="checkboxLabel4" class="p-checkbox__input" aria-describedby="exampleTickHelpMessage">
     <span class="p-checkbox__label" id="checkboxLabel4">I agree to the Terms and Conditions</span>
   </label>
-  <p class="p-form-help-text is-tick-element" id="exampleTickHelpMessage">By checking this you confirm that you have read and agree to the Terms and Conditions.</p>
+  <p class="p-form-help-text is-tick-element is-dark" id="exampleTickHelpMessage">By checking this you confirm that you have read and agree to the Terms and Conditions.</p>
 </form>
 {% endblock %}

--- a/templates/docs/examples/patterns/forms/forms-dark.html
+++ b/templates/docs/examples/patterns/forms/forms-dark.html
@@ -1,0 +1,41 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Forms / Dark{% endblock %}
+
+{% block standalone_css %}patterns_forms{% endblock %}
+
+
+{% block style %}
+<style>
+  body {
+    background: #262626;
+    color: #fff;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<form>
+  <label for="exampleTextInputHelp">Email address</label>
+  <input class="p-form-validation__input is-dark" type="email" id="exampleTextInputHelp" placeholder="example@canonical.com" name="exampleTextInputHelp" autocomplete="email" aria-describedby="exampleInputHelpMessage"/>
+  <p class="p-form-help-text" id="exampleInputHelpMessage">
+    A notification email will be sent to entered email address.
+  </p>
+
+  <label for="exampleSelect">Ubuntu releases</label>
+  <select class="is-dark" name="exampleSelect" id="exampleSelect" name="exampleSelect" placeholder="Select an option">
+    <option value="" disabled="disabled" selected>Select an option</option>
+    <option value="1">Cosmic Cuttlefish</option>
+    <option value="2">Bionic Beaver</option>
+    <option value="3">Xenial Xerus</option>
+  </select>
+
+  <label for="exampleTextarea">Comment</label>
+  <textarea id="exampleTextarea" class="is-dark" placeholder="Type your comment here..."></textarea>
+
+  <label class="p-checkbox is-dark">
+    <input type="checkbox" aria-labelledby="checkboxLabel4" class="p-checkbox__input" aria-describedby="exampleTickHelpMessage">
+    <span class="p-checkbox__label" id="checkboxLabel4">I agree to the Terms and Conditions</span>
+  </label>
+  <p class="p-form-help-text is-tick-element" id="exampleTickHelpMessage">By checking this you confirm that you have read and agree to the Terms and Conditions.</p>
+</form>
+{% endblock %}

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -37,7 +37,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Identifiers per selectors',
       benchmark: 1.75,
-      threshold: 2.7,
+      threshold: 2.8,
       result: results['identifiers-per-selector'],
     },
     {


### PR DESCRIPTION
## Done

Adds dark theme to form inputs

Fixes [WD-5201](https://warthogs.atlassian.net/browse/WD-5201)

## QA

- Open [demo](https://vanilla-framework-4857.demos.haus/docs/base/forms#dark-theme)
- Check new examples
- https://vanilla-framework-4857.demos.haus/docs/examples/patterns/forms/forms-dark
- Review updated documentation:
  - https://vanilla-framework-4857.demos.haus/docs/base/forms#dark-theme
  - https://vanilla-framework-4857.demos.haus/docs/examples/patterns/forms/form-validation-dark


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1207" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/df45a771-ac88-4eb0-a389-791ed6da68d4">

<img width="1496" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/406df5d6-c075-4e68-9186-f604a4e6ac6e">






[WD-5201]: https://warthogs.atlassian.net/browse/WD-5201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ