### PR TITLE
Remove old Canonical logo from contribute page

### DIFF
--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -158,7 +158,7 @@
       <div class="col-6">
         <div class="p-heading-icon">
           <div class="p-heading-icon__header is-stacked">
-            <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/60d9b81e-picto-canonical.svg" alt=""/>
+            <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/ce518a18-CoF-2022_solid+O.svg" alt=""/>
             <h3 class="p-heading-icon__title">Licences</h3>
           </div>
         </div>


### PR DESCRIPTION
## Done

Fixes #4860

## QA

- Open [demo](https://vanilla-framework-4861.demos.haus/contribute)
- Make sure Licenses part at the bottom doesn't use old Canonical logo


## Screenshots

<img width="639" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/ce67c643-4fbf-4604-bb80-690c99a5b4d5">

