### PR TITLE
Use new documentation layout on Vanilla site

### DIFF
--- a/scss/_layouts_full-width.scss
+++ b/scss/_layouts_full-width.scss
@@ -47,26 +47,6 @@
       }
     }
 
-    // FIXME: quick hack for demo
-    .l-full-width .l-start .p-side-navigation {
-      background: $color-light;
-    }
-
-    // FIXME: quick hack for demo
-    .l-full-width .l-start .p-side-navigation__drawer {
-      background: transparent;
-
-      &::after {
-        background: linear-gradient(90deg, transparent, rgba($color-x-dark, 0.05));
-        bottom: 0;
-        content: '';
-        position: absolute;
-        right: 0;
-        top: 0;
-        width: 8px;
-      }
-    }
-
     .l-full-width {
       display: grid;
       grid-template-areas: 'start main end';

--- a/scss/_layouts_full-width.scss
+++ b/scss/_layouts_full-width.scss
@@ -47,6 +47,26 @@
       }
     }
 
+    // FIXME: quick hack for demo
+    .l-full-width .l-start .p-side-navigation {
+      background: $color-light;
+    }
+
+    // FIXME: quick hack for demo
+    .l-full-width .l-start .p-side-navigation__drawer {
+      background: transparent;
+
+      &::after {
+        background: linear-gradient(90deg, transparent, rgba($color-x-dark, 0.05));
+        bottom: 0;
+        content: '';
+        position: absolute;
+        right: 0;
+        top: 0;
+        width: 8px;
+      }
+    }
+
     .l-full-width {
       display: grid;
       grid-template-areas: 'start main end';

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -79,29 +79,31 @@
     .p-search-box__input {
       @include vf-search-box-dark-theme;
     }
-
-    .p-search-box.is-light {
-      .p-search-box__input {
-        @include vf-search-box-light-theme;
-      }
-    }
   } @else {
     .p-search-box {
       .p-search-box__input {
         @include vf-search-box-light-theme;
       }
     }
-
-    .p-search-box.is-dark {
-      .p-search-box__input {
-        @include vf-search-box-dark-theme;
-      }
-    }
   }
 
+  // beware that the order of the following classes is important
+  // as they are used to override the default theme
   .is-paper .p-search-box {
     .p-search-box__input {
       @include vf-search-box-paper-theme;
+    }
+  }
+
+  .p-search-box.is-light {
+    .p-search-box__input {
+      @include vf-search-box-light-theme;
+    }
+  }
+
+  .p-search-box.is-dark {
+    .p-search-box__input {
+      @include vf-search-box-dark-theme;
     }
   }
 }

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -544,6 +544,11 @@
       }
     }
   }
+
+  .is-paper .p-side-navigation__drawer,
+  .is-paper .p-side-navigation__drawer-header {
+    background: $color-paper;
+  }
 }
 
 // helper

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -292,6 +292,7 @@
     &[aria-expanded='false'] {
       height: 0;
       opacity: 0;
+      overflow: hidden;
       transform: translate3d(0, -0.5rem, 0);
       visibility: hidden;
     }

--- a/scss/docs/site.scss
+++ b/scss/docs/site.scss
@@ -5,3 +5,12 @@
 
 // import cookie policy
 @import '@canonical/cookie-policy/build/css/cookie-policy';
+
+// align navigation items with grid in docs layout
+// workaround for https://github.com/canonical/vanilla-framework/issues/4898
+// FIXME: remove this when the issue is fixed
+@media screen and (min-width: $breakpoint-navigation-threshold) {
+  .p-navigation__nav {
+    margin-left: 0.5rem;
+  }
+}

--- a/templates/_layouts/_class-reference.html
+++ b/templates/_layouts/_class-reference.html
@@ -1,5 +1,5 @@
 {%- for element, items in data.items() -%}
-<hr>
+<hr />
 <div class="row">
     <div class="col-2 col-medium-1"><h4 class="p-muted-heading">{{ element }}</h4></div>
     <div class="col-7 col-medium-5">

--- a/templates/_layouts/_footer.html
+++ b/templates/_layouts/_footer.html
@@ -9,16 +9,16 @@
         <nav class="col-3" aria-label="Footer">
           <ul class="p-list u-no-margin--bottom">
             <li class="p-list__item">
-              <a href="https://github.com/canonical/vanilla-framework/releases/latest">Vanilla framework v{{ version }}</a>
+              <a class="is-dark" href="https://github.com/canonical/vanilla-framework/releases/latest">Vanilla framework v{{ version }}</a>
             </li>
             <li class="p-list__item">
-              <a href="https://www.ubuntu.com/legal">Legal info</a>
+              <a class="is-dark" href="https://www.ubuntu.com/legal">Legal info</a>
             </li>
             <li class="p-list__item">
-              <a href="https://github.com/canonical/vanilla-framework/issues/new/choose">Report a bug</a>
+              <a class="is-dark" href="https://github.com/canonical/vanilla-framework/issues/new/choose">Report a bug</a>
             </li>
             <li class="p-list__item">
-              <a href="#tracker-settings" class="js-revoke-cookie-manager">Manage your tracker settings</a>
+              <a class="is-dark" href="#tracker-settings" class="js-revoke-cookie-manager">Manage your tracker settings</a>
             </li>
           </ul>
           <span class="u-off-screen">
@@ -41,16 +41,16 @@
     <nav class="col-3" aria-label="Footer">
       <ul class="p-list u-no-margin--bottom">
         <li class="p-list__item">
-          <a href="https://github.com/canonical/vanilla-framework/releases/latest">Vanilla framework v{{ version }}</a>
+          <a class="is-dark" href="https://github.com/canonical/vanilla-framework/releases/latest">Vanilla framework v{{ version }}</a>
         </li>
         <li class="p-list__item">
-          <a href="https://www.ubuntu.com/legal">Legal info</a>
+          <a class="is-dark" href="https://www.ubuntu.com/legal">Legal info</a>
         </li>
         <li class="p-list__item">
-          <a href="https://github.com/canonical/vanilla-framework/issues/new/choose">Report a bug</a>
+          <a class="is-dark" href="https://github.com/canonical/vanilla-framework/issues/new/choose">Report a bug</a>
         </li>
         <li class="p-list__item">
-          <a href="#tracker-settings" class="js-revoke-cookie-manager">Manage your tracker settings</a>
+          <a class="is-dark" href="#tracker-settings" class="js-revoke-cookie-manager">Manage your tracker settings</a>
         </li>
       </ul>
       <span class="u-off-screen">

--- a/templates/_layouts/_footer.html
+++ b/templates/_layouts/_footer.html
@@ -1,5 +1,4 @@
-<footer class="p-strip--light l-full-width">
-  <div class="l-main">
+<footer class="p-strip--light">
     <div class="u-fixed-width">
       <p class="u-no-margin--bottom">&copy; {{ now("%Y") }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
       <nav aria-label="Footer">
@@ -22,5 +21,4 @@
         </span>
       </nav>
     </div>
-  </div>
 </footer>

--- a/templates/_layouts/_footer.html
+++ b/templates/_layouts/_footer.html
@@ -1,24 +1,65 @@
-<footer class="p-strip--light">
-    <div class="u-fixed-width">
-      <p class="u-no-margin--bottom">&copy; {{ now("%Y") }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
-      <nav aria-label="Footer">
-        <ul class="p-inline-list--middot u-no-margin--bottom">
-          <li class="p-inline-list__item">
-            <a href="https://github.com/canonical/vanilla-framework/releases/latest">Vanilla framework v{{ version }}</a>
-          </li>
-          <li class="p-inline-list__item">
-            <a href="https://www.ubuntu.com/legal">Legal info</a>
-          </li>
-          <li class="p-inline-list__item">
-            <a href="https://github.com/canonical/vanilla-framework/issues/new/choose">Report a bug</a>
-          </li>
-          <li class="p-inline-list__item">
-            <a href="#tracker-settings" class="js-revoke-cookie-manager">Manage your tracker settings</a>
-          </li>
-        </ul>
-        <span class="u-off-screen">
-          <a href="#">Go to the top of the page</a>
-        </span>
-      </nav>
+{% if is_docs %}
+<footer class="l-footer--sticky p-strip--dark">
+  <div class="l-docs__subgrid">
+    <div class="l-docs__sidebar u-fixed-width">
+      <p class="u-no-margin--bottom">&copy; {{ now("%Y") }} Canonical Ltd.</p>
     </div>
+    <div class="l-docs__main">
+      <div class="row">
+        <nav class="col-3" aria-label="Footer">
+          <ul class="p-list u-no-margin--bottom">
+            <li class="p-list__item">
+              <a href="https://github.com/canonical/vanilla-framework/releases/latest">Vanilla framework v{{ version }}</a>
+            </li>
+            <li class="p-list__item">
+              <a href="https://www.ubuntu.com/legal">Legal info</a>
+            </li>
+            <li class="p-list__item">
+              <a href="https://github.com/canonical/vanilla-framework/issues/new/choose">Report a bug</a>
+            </li>
+            <li class="p-list__item">
+              <a href="#tracker-settings" class="js-revoke-cookie-manager">Manage your tracker settings</a>
+            </li>
+          </ul>
+          <span class="u-off-screen">
+            <a href="#">Go to the top of the page</a>
+          </span>
+        </nav>
+        <div class="col-9">
+          <p class="u-no-margin--bottom">Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+        </div>
+      </div>
+    </div>
+  </div>
 </footer>
+{% else %}
+<footer class="p-strip--dark">
+  <div class="row">
+    <div class="col-3">
+      <p class="u-no-margin--bottom">&copy; {{ now("%Y") }} Canonical Ltd.</p>
+    </div>
+    <nav class="col-3" aria-label="Footer">
+      <ul class="p-list u-no-margin--bottom">
+        <li class="p-list__item">
+          <a href="https://github.com/canonical/vanilla-framework/releases/latest">Vanilla framework v{{ version }}</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://www.ubuntu.com/legal">Legal info</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://github.com/canonical/vanilla-framework/issues/new/choose">Report a bug</a>
+        </li>
+        <li class="p-list__item">
+          <a href="#tracker-settings" class="js-revoke-cookie-manager">Manage your tracker settings</a>
+        </li>
+      </ul>
+      <span class="u-off-screen">
+        <a href="#">Go to the top of the page</a>
+      </span>
+    </nav>
+    <div class="col-6">
+      <p class="u-no-margin--bottom">Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+    </div>
+  </div>
+</footer>
+{% endif %}

--- a/templates/_layouts/_header.html
+++ b/templates/_layouts/_header.html
@@ -52,11 +52,11 @@
 <header id="navigation" class="p-navigation is-dark">
 
   {% if is_docs %}
-  <div class="l-full-width">
-    <div class="l-start">
+  <div class="l-docs__subgrid">
+    <div class="l-docs__sidebar">
       {{ nav_logo() }}
     </div>
-    <div class="l-main">
+    <div class="l-docs__main">
       <div class="p-navigation__row u-fixed-width">
         {{ nav_items() }}
       </div>

--- a/templates/_layouts/_header.html
+++ b/templates/_layouts/_header.html
@@ -1,57 +1,72 @@
+{% macro nav_logo() %}
+<div class="p-navigation__banner">
+  <div class="p-navigation__tagged-logo">
+    <a class="p-navigation__link" href="/">
+      <div class="p-navigation__logo-tag">
+        <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/b36b0862-Vanilla_icon_RGB_2022.svg" alt="Vanilla framework">
+      </div>
+      <span class="p-navigation__logo-title">Vanilla</span>
+    </a>
+  </div>
+  <ul class="p-navigation__items">
+    <li class="p-navigation__item">
+      <button class="js-search-button p-navigation__link--search-toggle">
+        <span class="p-navigation__search-label">Search</span>
+      </button>
+    </li>
+    <li class="p-navigation__item">
+      <button class="js-menu-button p-navigation__link">Menu</button>
+    </li>
+  </ul>
+</div>
+{% endmacro %}
+
+{% macro nav_items() %}
+<nav class="p-navigation__nav" aria-label="Main">
+  <ul class="p-navigation__items">
+    <li class="p-navigation__item {% if (path.startswith('/docs') or path.startswith('/design')) and not path.startswith('/docs/examples') %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs">Docs</a></li>
+    <li class="p-navigation__item {% if '/docs/examples' in path %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs/examples">Examples</a></li>
+    <li class="p-navigation__item{% if path == '/accessibility' %} is-selected{% endif %}"><a class="p-navigation__link" href="/accessibility">Accessibility</a></li>
+    <li class="p-navigation__item{% if path == '/browser-support' %} is-selected{% endif %}"><a class="p-navigation__link" href="/browser-support">Browser support</a></li>
+    <li class="p-navigation__item{% if path == '/contribute' %} is-selected{% endif %}"><a class="p-navigation__link" href="/contribute">Contribute</a></li>
+  </ul>
+  <ul class="p-navigation__items">
+    <li class="p-navigation__item">
+      <button class="js-search-button p-navigation__link--search-toggle">
+        <span class="p-navigation__search-label">Search</span>
+      </button>
+    </li>
+  </ul>
+  <div class="p-navigation__search">
+    <form class="p-search-box" action="/docs/search">
+      <input type="search" id="search-docs" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search the docs" title="Search the documentation"  autocomplete="on" aria-label="Search the docs" required />
+      <button type="reset" id="search-docs-reset" class="p-search-box__reset u-no-margin--right" name="close"><i class="p-icon--close">Clear input</i></button>
+      <button type="submit" class="p-search-box__button" name="submit"><i class="p-icon--search">Submit</i></button>
+    </form>
+  </div>
+</nav>
+{% endmacro %}
+
 <a href="#main-content" class="p-link--skip">Jump to main content</a>
 
 <header id="navigation" class="p-navigation is-dark">
-  <div class=" l-full-width">
-  <div class="l-start">
-    <div class="p-navigation__banner">
-      <div class="p-navigation__tagged-logo">
-        <a class="p-navigation__link" href="/">
-          <div class="p-navigation__logo-tag">
-            <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/b36b0862-Vanilla_icon_RGB_2022.svg" alt="Vanilla framework">
-          </div>
-          <span class="p-navigation__logo-title">Vanilla</span>
-        </a>
-      </div>
-      <ul class="p-navigation__items">
-        <li class="p-navigation__item">
-          <button class="js-search-button p-navigation__link--search-toggle">
-            <span class="p-navigation__search-label">Search</span>
-          </button>
-        </li>
-        <li class="p-navigation__item">
-          <button class="js-menu-button p-navigation__link">Menu</button>
-        </li>
-      </ul>
-    </div>
-  </div>
-  <div class="l-main">
-    <div class="p-navigation__row u-fixed-width">
-      <nav class="p-navigation__nav" aria-label="Main">
-        <ul class="p-navigation__items">
-          <li class="p-navigation__item {% if (path.startswith('/docs') or path.startswith('/design')) and not path.startswith('/docs/examples') %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs">Docs</a></li>
-          <li class="p-navigation__item {% if '/docs/examples' in path %}is-selected{% endif %}"><a class="p-navigation__link" href="/docs/examples">Examples</a></li>
-          <li class="p-navigation__item{% if path == '/accessibility' %} is-selected{% endif %}"><a class="p-navigation__link" href="/accessibility">Accessibility</a></li>
-          <li class="p-navigation__item{% if path == '/browser-support' %} is-selected{% endif %}"><a class="p-navigation__link" href="/browser-support">Browser support</a></li>
-          <li class="p-navigation__item{% if path == '/contribute' %} is-selected{% endif %}"><a class="p-navigation__link" href="/contribute">Contribute</a></li>
-        </ul>
-        <ul class="p-navigation__items">
-          <li class="p-navigation__item">
-            <button class="js-search-button p-navigation__link--search-toggle">
-              <span class="p-navigation__search-label">Search</span>
-            </button>
-          </li>
-        </ul>
-        <div class="p-navigation__search">
-          <form class="p-search-box is-dark" action="/docs/search">
-            <input type="search" id="search-docs" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search the docs" title="Search the documentation"  autocomplete="on" aria-label="Search the docs" required />
-            <button type="reset" id="search-docs-reset" class="p-search-box__reset u-no-margin--right" name="close"><i class="p-icon--close">Clear input</i></button>
-            <button type="submit" class="p-search-box__button" name="submit"><i class="p-icon--search">Submit</i></button>
-          </form>
-        </div>
-      </nav>
-    </div>
-  </div>
-  </div>
 
+  {% if is_docs %}
+  <div class="l-full-width">
+    <div class="l-start">
+      {{ nav_logo() }}
+    </div>
+    <div class="l-main">
+      <div class="p-navigation__row u-fixed-width">
+        {{ nav_items() }}
+      </div>
+    </div>
+  </div>
+  {% else %}
+  <div class="p-navigation__row">
+    {{ nav_logo() }}
+    {{ nav_items() }}
+  </div>
+  {% endif %}
   <div class="p-navigation__search-overlay"></div>
 </header>

--- a/templates/_layouts/_header.html
+++ b/templates/_layouts/_header.html
@@ -38,7 +38,7 @@
     </li>
   </ul>
   <div class="p-navigation__search">
-    <form class="p-search-box" action="/docs/search">
+    <form class="p-search-box is-light" action="/docs/search">
       <input type="search" id="search-docs" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search the docs" title="Search the documentation"  autocomplete="on" aria-label="Search the docs" required />
       <button type="reset" id="search-docs-reset" class="p-search-box__reset u-no-margin--right" name="close"><i class="p-icon--close">Clear input</i></button>
       <button type="submit" class="p-search-box__button" name="submit"><i class="p-icon--search">Submit</i></button>

--- a/templates/_layouts/_root.html
+++ b/templates/_layouts/_root.html
@@ -48,7 +48,7 @@
     {% endif %}
   </head>
 
-  <body class="is-paper">
+  <body class="l-site is-paper">
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K7ZB6FL"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/templates/_layouts/_root.html
+++ b/templates/_layouts/_root.html
@@ -48,7 +48,7 @@
     {% endif %}
   </head>
 
-  <body>
+  <body class="is-paper">
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K7ZB6FL"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/templates/_layouts/_root.html
+++ b/templates/_layouts/_root.html
@@ -56,7 +56,9 @@
 
     {% include "_layouts/_header.html" %}
     {% block body %}{% endblock %}
-    {% include "_layouts/_footer.html" %}
+    {% if not is_docs %}
+      {% include "_layouts/_footer.html" %}
+    {% endif %}
 
     <script src="{{ versioned_static('build/js/modules/cookie-policy.js') }}"></script>
     <script>

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -88,7 +88,7 @@
 
               {% include "_layouts/_component_tabs.html" %}
               {% if not page_tabs %}
-              <hr>
+              <hr />
               {% endif %}
 
             {% endblock content_title %}

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -108,7 +108,7 @@
 
       {# table of contents placeholder, to be filled by JS based on headings #}
       <div class="l-docs__meta u-hide">
-        <div class="p-strip is-shallow">
+        <div class="l-docs__sticky-container p-strip is-shallow">
           <aside class="p-table-of-contents">
             <div class="p-table-of-contents__section">
               <h4 class="p-table-of-contents__header">On this page:</h4>

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -13,11 +13,11 @@
 
 
 
-    <div class="l-full-width">
+    <div class="l-docs">
 
-      <aside class="l-start">
+      <aside class="l-docs__sidebar">
 
-        <nav class="p-side-navigation is-sticky is-drawer-hidden" id="side-navigation-drawer" aria-label="Side">
+        <nav class="p-side-navigation--accordion is-sticky is-drawer-hidden" id="side-navigation-drawer" aria-label="Side">
 
           <div class="u-hide--large p-strip--light is-shallow">
             <div class="u-fixed-width">
@@ -59,39 +59,63 @@
                     </li>
                 {%- endmacro %}
 
-                {% for item in sideNavigation %}
                 <ul class="p-side-navigation__list">
-                  <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">{{ item.heading | replace("{version}", version) }}</span></li>
-                  {% for subheading in item.subheadings %}
-                  {{ side_nav_item(subheading.url, subheading.title) }}
-                  {% endfor %}
-                </ul>
-                {% endfor %}
+                {% for item in sideNavigation %}
 
+                  <li class="p-side-navigation__item">
+                    <button class="p-side-navigation__accordion-button" aria-expanded="false">{{ item.heading | replace("{version}", version) }}</button>
+                    <ul class="p-side-navigation__list">
+                      {% for subheading in item.subheadings %}
+                      {{ side_nav_item(subheading.url, subheading.title) }}
+                      {% endfor %}
+                    </ul>
+                  </li>
+
+                {% endfor %}
+              </ul>
               </div>
             </div>
       </aside>
 
+      <div class="l-docs__title" id="main-content">
+        <div class="p-strip is-shallow u-no-padding--bottom">
+          <div class="u-fixed-width">
+            {% block content_title %}
 
-      <div class="l-main">
-        <div class="p-strip is-shallow">
-          <main class="u-fixed-width" id="main-content">
-            {% block content %}
-              {% if page_tabs %}
-              <div class="p-strip u-no-padding--top">
+              {% if title %}
                 <h1>{{ title.split('|')[0] }}</h1>
-              </div>
               {% endif %}
 
               {% include "_layouts/_component_tabs.html" %}
+              {% if not page_tabs %}
+              <hr>
+              {% endif %}
 
-              {{ content | safe }}
-            {% endblock content %}
-            </main>
+            {% endblock content_title %}
+          </div>
         </div>
-        {% include "_layouts/_footer.html" %}
+      </div>
+
+      <div class="l-docs__main">
+        <main class="u-fixed-width">
+          {% block content %}
+            {{ content | safe }}
+          {% endblock content %}
+          </main>
+      </div>
+
+      {# table of contents placeholder, to be filled by JS based on headings #}
+      <div class="l-docs__meta u-hide">
+        <aside class="p-table-of-contents">
+          <div class="p-table-of-contents__section">
+            <h4 class="p-table-of-contents__header">On this page:</h4>
+            <nav class="p-table-of-contents__nav" aria-label="Table of contents" id="toc">
+            </nav>
+          </div>
       </div>
     </div>
+
+    {% include "_layouts/_footer.html" %}
 
     <script>
       window.Prism = window.Prism || {};

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -1,5 +1,7 @@
 {% extends "_layouts/_root.html" %}
 
+{% set is_docs=True %}
+
 {% block custom_head %}
   <link rel="stylesheet" href="{{ versioned_static('build/css/docs/site.css') }}" />
 {% endblock %}
@@ -9,68 +11,71 @@
 
     {% block banner %}{% endblock %}
 
-    <aside class="l-full-width__sidebar">
 
-      <nav class="p-side-navigation is-sticky is-drawer-hidden" id="side-navigation-drawer" aria-label="Side">
 
-        <div class="u-hide--large p-strip--light is-shallow">
-          <div class="u-fixed-width">
-            <a href="#side-navigation-drawer" class="p-button has-icon u-no-margin js-drawer-toggle" aria-expanded="false"><i class="p-icon--menu"></i><span>Contents</span></a>
-          </div>
-        </div>
+    <div class="l-full-width">
 
-        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="side-navigation-drawer" aria-expanded="false"></div>
+      <aside class="l-start">
 
-          <div class="p-side-navigation__drawer">
-            <div class="p-strip is-shallow">
-              <div class="p-side-navigation__drawer-header">
-                <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="side-navigation-drawer">
-                  Toggle side navigation
-                </a>
-              </div>
+        <nav class="p-side-navigation is-sticky is-drawer-hidden" id="side-navigation-drawer" aria-label="Side">
 
-              {% macro side_nav_item(url, title) -%}
-                  <li class="p-side-navigation__item">
-                    <a class="p-side-navigation__link" href="{{ url }}" {% if (slug and slug in url) or (url == path) %}aria-current="page"{% endif %}>
-                      {{ title | replace("{version}", version) }}
-                      {% if url in updatedFeatures %}
-                        <span class="p-side-navigation__status">
-                          {% if updatedFeatures[url]=="New" %}
-                          <span class="p-status-label--positive">
-                          {% elif updatedFeatures[url]=="Updated" %}
-                          <span class="p-status-label--information">
-                          {% elif updatedFeatures[url]=="Removed" %}
-                          <span class="p-status-label--negative">
-                          {% elif updatedFeatures[url]=="Deprecated" %}
-                          <span class="p-status-label--negative">
-                          {% elif updatedFeatures[url]=="In Progress" %}
-                          <span class="p-status-label--caution">    
-                          {% endif %}
-                          {{ updatedFeatures[url] }}
-                          </span>
-                        {% endif %}
-                    </a>
-                  </li>
-              {%- endmacro %}
-              
-              {% for item in sideNavigation %}
-              <ul class="p-side-navigation__list">
-                <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">{{ item.heading | replace("{version}", version) }}</span></li>
-                {% for subheading in item.subheadings %}
-                {{ side_nav_item(subheading.url, subheading.title) }}
-                {% endfor %}
-              </ul>
-              {% endfor %}
-
+          <div class="u-hide--large p-strip--light is-shallow">
+            <div class="u-fixed-width">
+              <a href="#side-navigation-drawer" class="p-button has-icon u-no-margin js-drawer-toggle" aria-expanded="false"><i class="p-icon--menu"></i><span>Contents</span></a>
             </div>
           </div>
-      </div>
-    </aside>
-    
-    <div class="p-strip is-shallow l-full-width">
+
+          <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="side-navigation-drawer" aria-expanded="false"></div>
+
+            <div class="p-side-navigation__drawer">
+              <div class="p-strip is-shallow">
+                <div class="p-side-navigation__drawer-header">
+                  <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="side-navigation-drawer">
+                    Toggle side navigation
+                  </a>
+                </div>
+
+                {% macro side_nav_item(url, title) -%}
+                    <li class="p-side-navigation__item">
+                      <a class="p-side-navigation__link" href="{{ url }}" {% if (slug and slug in url) or (url == path) %}aria-current="page"{% endif %}>
+                        {{ title | replace("{version}", version) }}
+                        {% if url in updatedFeatures %}
+                          <span class="p-side-navigation__status">
+                            {% if updatedFeatures[url]=="New" %}
+                            <span class="p-status-label--positive">
+                            {% elif updatedFeatures[url]=="Updated" %}
+                            <span class="p-status-label--information">
+                            {% elif updatedFeatures[url]=="Removed" %}
+                            <span class="p-status-label--negative">
+                            {% elif updatedFeatures[url]=="Deprecated" %}
+                            <span class="p-status-label--negative">
+                            {% elif updatedFeatures[url]=="In Progress" %}
+                            <span class="p-status-label--caution">
+                            {% endif %}
+                            {{ updatedFeatures[url] }}
+                            </span>
+                          {% endif %}
+                      </a>
+                    </li>
+                {%- endmacro %}
+
+                {% for item in sideNavigation %}
+                <ul class="p-side-navigation__list">
+                  <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">{{ item.heading | replace("{version}", version) }}</span></li>
+                  {% for subheading in item.subheadings %}
+                  {{ side_nav_item(subheading.url, subheading.title) }}
+                  {% endfor %}
+                </ul>
+                {% endfor %}
+
+              </div>
+            </div>
+      </aside>
+
+
       <div class="l-main">
-        <div class="row">
-          <main class="col-12" id="main-content">
+        <div class="p-strip is-shallow">
+          <main class="u-fixed-width" id="main-content">
             {% block content %}
               {% if page_tabs %}
               <div class="p-strip u-no-padding--top">
@@ -82,8 +87,9 @@
 
               {{ content | safe }}
             {% endblock content %}
-          </main>
+            </main>
         </div>
+        {% include "_layouts/_footer.html" %}
       </div>
     </div>
 

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -108,12 +108,15 @@
 
       {# table of contents placeholder, to be filled by JS based on headings #}
       <div class="l-docs__meta u-hide">
-        <aside class="p-table-of-contents">
-          <div class="p-table-of-contents__section">
-            <h4 class="p-table-of-contents__header">On this page:</h4>
-            <nav class="p-table-of-contents__nav" aria-label="Table of contents" id="toc">
-            </nav>
-          </div>
+        <div class="p-strip is-shallow">
+          <aside class="p-table-of-contents">
+            <div class="p-table-of-contents__section">
+              <h4 class="p-table-of-contents__header">On this page:</h4>
+              <nav class="p-table-of-contents__nav" aria-label="Table of contents" id="toc">
+              </nav>
+            </div>
+          </aside>
+        </div>
       </div>
     </div>
 

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -97,11 +97,13 @@
       </div>
 
       <div class="l-docs__main">
-        <main class="u-fixed-width">
-          {% block content %}
-            {{ content | safe }}
-          {% endblock content %}
+        <div class="p-section">
+          <main class="u-fixed-width">
+            {% block content %}
+              {{ content | safe }}
+            {% endblock content %}
           </main>
+        </div>
       </div>
 
       {# table of contents placeholder, to be filled by JS based on headings #}

--- a/templates/accessibility.html
+++ b/templates/accessibility.html
@@ -5,27 +5,20 @@
 {% block copydoc %}https://docs.google.com/document/d/1_cCvuHSwS9i0pzD_4WHDFoTenVAfZVr9qGxG-rSHHGY/edit{% endblock %}
 
 {% block content %}
-<div id="main-content" class="p-strip l-full-width">
-  <div class="l-main">
+<div id="main-content" class="p-strip">
     <div class="row">
       <div class="col-12">
         <h1>Accessibility guidelines</h1>
         <p>Vanilla Framework aims for Level AA conformance with the <br><a href="https://www.w3.org/TR/WCAG21/">Web Content Accessibility Guidelines (WCAG) 2.1</a></p>
       </div>
     </div>
-  </div>
 </div>
 
-<div class="l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <hr>
-    </div>
-  </div>
+<div class="u-fixed-width">
+  <hr>
 </div>
 
-<div class="p-strip l-full-width">
-  <div class="l-main">
+<div class="p-strip">
     <div class="row">
       <div class="col-6">
         <h2>Ensuring conformance</h2>
@@ -40,19 +33,13 @@
         <p class="p-heading--5 u-no-margin--bottom"><a href="https://validator.w3.org/nu/">The W3 Markup Validation Service</a></p>
       </div>
     </div>
-  </div>
 </div>
 
-<div class="l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <hr>
-    </div>
-  </div>
+<div class="u-fixed-width">
+  <hr>
 </div>
 
-<div class="p-strip l-full-width">
-  <div class="l-main">
+<div class="p-strip">
     <div class="row">
       <div class="col-6">
         <h2>Curated criteria checklist</h2>
@@ -61,11 +48,9 @@
       <div class="col-6">
       </div>
     </div>
-  </div>
 </div>
 
-<div class="p-strip u-no-padding--top l-full-width">
-  <div class="l-main">
+<div class="p-strip u-no-padding--top">
     <div class="u-fixed-width">
       <ul class="p-list is-split">
         <li class="p-list__item is-ticked">Make sure there is enough contrast between text and its background color</li>
@@ -93,30 +78,22 @@
       </ul>
       <p>*Adapted from <a href="http://accessibility.voxmedia.com">Accessibility Guidelines</a> checklist and <a href="http://a11yproject.com/checklist.html">Web Accessibility Checklist</a></p>
     </div>
-  </div>
 </div>
 
-<div class="l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <hr>
-    </div>
-  </div>
+<div class="u-fixed-width">
+  <hr>
 </div>
 
-<div class="p-strip l-full-width">
-  <div class="l-main">
+<div class="p-strip">
     <div class="row">
       <div class="col-6">
         <h2>Key WCAG documents</h2>
         <p>The volume of information on the WCAG 2.0 website can be disorienting. <br>We keep the following links handy for quick reference:</p>
       </div>
     </div>
-  </div>
 </div>
 
-<div class="p-strip u-no-padding--top l-full-width">
-  <div class="l-main">
+<div class="p-strip u-no-padding--top">
     <div class="row">
       <ul class="p-list is-split">
         <li class="p-list__item"><a href="https://www.w3.org/TR/WCAG20/">WCAG 2.0</a>: the W3C standard, includes principles, guidelines and success criteria</li>
@@ -125,19 +102,13 @@
         <li class="p-list__item"><a href="https://www.w3.org/TR/WCAG20-TECHS/">Techniques for WCAG 2.0</a>: instructions for developers, includes browser and assistive technology support notes, examples, code, resources and test procedures</li>
       </ul>
     </div>
-  </div>
 </div>
 
-<div class="l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <hr>
-    </div>
-  </div>
+<div class="u-fixed-width">
+  <hr>
 </div>
 
-<div class="p-strip l-full-width">
-  <div class="l-main">
+<div class="p-strip">
     <div class="row">
       <div class="col-6">
         <h2>Useful tools</h2>
@@ -153,23 +124,16 @@
         </ul>
       </div>
     </div>
-  </div>
 </div>
 
-<div class="l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <hr>
-    </div>
-  </div>
+<div class="u-fixed-width">
+  <hr>
 </div>
 
-<div class="p-strip l-full-width">
-  <div class="l-main">
+<div class="p-strip">
     <div class="u-fixed-width">
       <h2>Noticed an issue?</h2>
       <p>If you spot an accessibility problem in Vanilla, let us know <br> by <a href="https://github.com/canonical/vanilla-framework/issues">filing&nbsp;an&nbsp;issue</a> on GitHub.</p>
     </div>
-  </div>
 </div>
 {% endblock %}

--- a/templates/accessibility.html
+++ b/templates/accessibility.html
@@ -15,7 +15,7 @@
 </div>
 
 <div class="u-fixed-width">
-  <hr>
+  <hr />
 </div>
 
 <div class="p-strip">
@@ -36,7 +36,7 @@
 </div>
 
 <div class="u-fixed-width">
-  <hr>
+  <hr />
 </div>
 
 <div class="p-strip">
@@ -81,7 +81,7 @@
 </div>
 
 <div class="u-fixed-width">
-  <hr>
+  <hr />
 </div>
 
 <div class="p-strip">
@@ -105,7 +105,7 @@
 </div>
 
 <div class="u-fixed-width">
-  <hr>
+  <hr />
 </div>
 
 <div class="p-strip">
@@ -127,7 +127,7 @@
 </div>
 
 <div class="u-fixed-width">
-  <hr>
+  <hr />
 </div>
 
 <div class="p-strip">

--- a/templates/browser-support.html
+++ b/templates/browser-support.html
@@ -18,7 +18,7 @@
 </div>
 
 <div class="u-fixed-width">
-  <hr>
+  <hr />
 </div>
 
 <div class="p-strip">
@@ -38,7 +38,7 @@
 </div>
 
 <div class="u-fixed-width">
-  <hr>
+  <hr />
 </div>
 
 <div class="p-strip">

--- a/templates/browser-support.html
+++ b/templates/browser-support.html
@@ -6,8 +6,7 @@
 
 
 {% block content %}
-<div id="main-content" class="p-strip l-full-width">
-  <div class="l-main">
+<div id="main-content" class="p-strip">
     <div class="row">
       <div class="col-6">
         <h1 class="u-no-margin--bottom">Browser support</h1>
@@ -16,19 +15,13 @@
         <p>Vanilla framework follows the principles of progressive enhancement and web standards. Users should be able to access core content and functionality from any browser or operating system, with varying degrees of access to visual and other enhancements — design components do not have to look exactly the same on every browser.</p>
       </div>
     </div>
-  </div>
 </div>
 
-<div class="l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <hr class="u-no-margin--bottom">
-    </div>
-  </div>
+<div class="u-fixed-width">
+  <hr>
 </div>
 
-<div class="p-strip l-full-width">
-  <div class="l-main">
+<div class="p-strip">
     <div class="row">
       <div class="col-6">
         <h2>Bugs and prioritisation</h2>
@@ -42,19 +35,13 @@
         </ul>
       </div>
     </div>
-  </div>
 </div>
 
-<div class="l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <hr class="u-no-margin--bottom">
-    </div>
-  </div>
+<div class="u-fixed-width">
+  <hr>
 </div>
 
-<div class="p-strip l-full-width">
-  <div class="l-main">
+<div class="p-strip">
     <div class="row">
       <div class="col-6">
         <h2>Supported browsers</h2>
@@ -105,6 +92,5 @@
         </ul>
       </div>
     </div>
-  </div>
 </div>
 {% endblock %}

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -5,26 +5,19 @@
 {% block copydoc %}https://docs.google.com/document/d/1FIYkjR9Xu6Or0WUCi6EQGaZsiTq8ESk8Kv39CW4kkwo/edit{% endblock %}
 
 {% block content %}
-<div id="main-content" class="p-strip l-full-width">
-  <div class="l-main">
+<div id="main-content" class="p-strip">
     <div class="row">
       <div class="col-12">
         <h1 class="u-no-margin--bottom">Contribute</h1>
       </div>
     </div>
-  </div>
 </div>
 
-<div class="l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <hr>
-    </div>
-  </div>
+<div class="u-fixed-width">
+  <hr>
 </div>
 
-<div class="p-strip l-full-width">
-  <div class="l-main">
+<div class="p-strip">
     <div class="row">
       <div class="p-strip u-no-padding--top"><h2>Meet the team</h2></div>
       {% for team_member in team_members %}
@@ -45,20 +38,14 @@
         </div>
       {% endfor %}
     </div>
-  </div>
 </div>
 
 {% if contributors %}
-  <div class="l-full-width">
-    <div class="l-main">
-      <div class="u-fixed-width">
-        <hr>
-      </div>
-    </div>
+  <div class="u-fixed-width">
+    <hr>
   </div>
 
-  <div class="p-strip l-full-width">
-    <div class="l-main">
+  <div class="p-strip">
       <div class="row">
         <div class="p-strip u-no-padding--top"><h2>Contributors</h2></div>
       </div>
@@ -79,20 +66,14 @@
           </div>
         {% endfor %}
       </div>
-    </div>
   </div>
 {% endif %}
 
-<div class="l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <hr>
-    </div>
-  </div>
+<div class="u-fixed-width">
+  <hr>
 </div>
 
-<div class="p-strip l-full-width">
-  <div class="l-main">
+<div class="p-strip">
     <div class="row">
       <div class="p-strip u-no-padding--top"><h2>Contribute</h2></div>
     </div>
@@ -126,19 +107,13 @@
         </div>
       </div>
     </div>
-  </div>
 </div>
 
-<div class="l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <hr>
-    </div>
-  </div>
+<div class="u-fixed-width">
+  <hr>
 </div>
 
-<div class="p-strip l-full-width">
-  <div class="l-main">
+<div class="p-strip">
     <div class="row">
       <div class="col-6">
         <div class="p-heading-icon">
@@ -165,6 +140,5 @@
         <p>The content of this project is licensed under the <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International license</a>, and the underlying code used to format and display that content is licensed under the <a href="https://opensource.org/licenses/lgpl-3.0.html">LGPLv3</a> by <a href="https://canonical.com">Canonical Ltd</a>.</p>
       </div>
     </div>
-  </div>
 </div>
 {% endblock %}

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -14,7 +14,7 @@
 </div>
 
 <div class="u-fixed-width">
-  <hr>
+  <hr />
 </div>
 
 <div class="p-strip">
@@ -42,7 +42,7 @@
 
 {% if contributors %}
   <div class="u-fixed-width">
-    <hr>
+    <hr />
   </div>
 
   <div class="p-strip">
@@ -70,7 +70,7 @@
 {% endif %}
 
 <div class="u-fixed-width">
-  <hr>
+  <hr />
 </div>
 
 <div class="p-strip">
@@ -110,7 +110,7 @@
 </div>
 
 <div class="u-fixed-width">
-  <hr>
+  <hr />
 </div>
 
 <div class="p-strip">

--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -4,10 +4,6 @@ context:
   title: Code | Base elements
 ---
 
-# Code
-
-<hr>
-
 Vanilla gives you multiple ways to display code using the standard HTML elements.
 
 ## Inline

--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -4,10 +4,6 @@ context:
   title: Forms | Base elements
 ---
 
-# Forms
-
-<hr>
-
 Form controls have global styling defined at the HTML element level.
 
 Most labels and controls are 100% the width of the `<form>` parent element, unless you [specify inline layout](#inline).

--- a/templates/docs/base/paper.md
+++ b/templates/docs/base/paper.md
@@ -4,10 +4,6 @@ context:
   title: Paper background | Base elements
 ---
 
-# Paper background
-
-<hr>
-
 In Vanilla 4.0 we are introducing a new option for the background colour of brochure site pages that we call a paper background.
 
 It replaces the default white page background with a light grey `#f3f3f3` colour.

--- a/templates/docs/base/reset.md
+++ b/templates/docs/base/reset.md
@@ -4,8 +4,4 @@ context:
   title: Reset | Base elements
 ---
 
-# Reset
-
-<hr>
-
 Vanilla uses [Normalize](https://necolas.github.io/normalize.css/) to reset default browser styling on page elements. This helps remove any quirks or nuances specific to certain browsers before further styling is layered on top.

--- a/templates/docs/base/separators.md
+++ b/templates/docs/base/separators.md
@@ -4,10 +4,6 @@ context:
   title: Separators | Base elements
 ---
 
-# Separators
-
-<hr>
-
 Vanilla gives you multiple ways to separate parts of the content with a horizontal line.
 
 ## Horizontal rule

--- a/templates/docs/base/separators.md
+++ b/templates/docs/base/separators.md
@@ -8,7 +8,7 @@ Vanilla gives you multiple ways to separate parts of the content with a horizont
 
 ## Horizontal rule
 
-Use the standard `<hr>` element to introduce section breaks.
+Use the standard `<hr />` element to introduce section breaks.
 
 <div class="embedded-example"><a href="/docs/examples/base/hr/" class="js-example">
 View example of the horizontal line
@@ -16,7 +16,7 @@ View example of the horizontal line
 
 ### Muted horizontal rule
 
-Add the `is-muted` class to an `<hr>` to make the horizontal rule lighter in colour.
+Add the `is-muted` class to an `<hr />` to make the horizontal rule lighter in colour.
 This can be useful when trying to create a more subtle partitioning within a section within a container, or between standard horizontal rules.
 
 <div class="embedded-example"><a href="/docs/examples/base/hr-muted/" class="js-example">
@@ -25,7 +25,7 @@ View example of the muted horizontal line
 
 ### Fixed width horizontal rule
 
-Often it is useful to add a rule that aligns with content placed in a grid `row` class. One way to do that is to wrap an `<hr>` in a `div` with class `row`. To avoid the need for a wrapping element, add the class `is-fixed-width` directly on the `<hr>`.
+Often it is useful to add a rule that aligns with content placed in a grid `row` class. One way to do that is to wrap an `<hr />` in a `div` with class `row`. To avoid the need for a wrapping element, add the class `is-fixed-width` directly on the `<hr />`.
 
 <div class="embedded-example"><a href="/docs/examples/base/hr-fixed-width/" class="js-example">
 View example of the fixed-width horizontal line

--- a/templates/docs/base/tables.md
+++ b/templates/docs/base/tables.md
@@ -4,10 +4,6 @@ context:
   title: Tables | Base elements
 ---
 
-# Tables
-
-<hr>
-
 Data tables are used to organize and display all information from a data set.
 
 <div class="embedded-example"><a href="/docs/examples/base/table/" class="js-example">

--- a/templates/docs/base/typography.md
+++ b/templates/docs/base/typography.md
@@ -4,10 +4,6 @@ context:
   title: Typography | Base elements
 ---
 
-# Typography
-
-<hr>
-
 ## The Ubuntu typeface
 
 We use the [Ubuntu typeface](https://design.ubuntu.com/font/) exclusively. It was recently upgraded to a variable font, which features a weight and a width axis. It now also includes true small caps. Number figures to accompany the small caps are currently being finalised and will be available soon.

--- a/templates/docs/building-vanilla.md
+++ b/templates/docs/building-vanilla.md
@@ -4,10 +4,6 @@ context:
   title: Building with Vanilla
 ---
 
-# Building with Vanilla
-
-<hr>
-
 Here you will find information on how you can use different tools to build Vanilla into production CSS.
 
 ## Sass

--- a/templates/docs/changelog-v2.md
+++ b/templates/docs/changelog-v2.md
@@ -4,8 +4,6 @@ context:
   title: Vanilla v2 Changelog
 ---
 
-# Vanilla v2 Changelog
-
 <table>
   <thead>
     <tr>

--- a/templates/docs/changelog-v3.html
+++ b/templates/docs/changelog-v3.html
@@ -1,9 +1,11 @@
 {% extends "_layouts/docs.html" %}
 
-{% block content %}
-
+{% block content_title %}
 <h1>Vanilla v3 changelog</h1>
+<hr>
+{% endblock %}
 
+{% block content %}
 <table aria-label="Vanilla v3 changelog">
   <thead>
     <tr>

--- a/templates/docs/changelog-v3.html
+++ b/templates/docs/changelog-v3.html
@@ -2,7 +2,7 @@
 
 {% block content_title %}
 <h1>Vanilla v3 changelog</h1>
-<hr>
+<hr />
 {% endblock %}
 
 {% block content %}

--- a/templates/docs/customising-vanilla.md
+++ b/templates/docs/customising-vanilla.md
@@ -1,12 +1,8 @@
 ---
 wrapper_template: '_layouts/docs.html'
 context:
-  title: Customising Vanilla
+  title: Customising Vanilla | test
 ---
-
-# Customising Vanilla
-
-<hr>
 
 Here you will find information on customising Vanilla to suit your project.
 

--- a/templates/docs/examples/base/hr.html
+++ b/templates/docs/examples/base/hr.html
@@ -12,5 +12,5 @@
 {% endblock %}
 
 {% block content %}
-<hr>
+<hr />
 {% endblock %}

--- a/templates/docs/examples/brochure/hero-25-75.html
+++ b/templates/docs/examples/brochure/hero-25-75.html
@@ -30,7 +30,7 @@
     </div>
     <div class="row--25-75 is-split-on-medium">
         <div class="col">
-            <hr>
+            <hr />
             <a href="#" class="p-button--positive">CTA up to 3 words</a>
             <a href="#" class="p-button">Optional button</a>
             <a href="#">Link CTA up to 5 words</a>

--- a/templates/docs/examples/brochure/hero-50-50.html
+++ b/templates/docs/examples/brochure/hero-50-50.html
@@ -20,7 +20,7 @@
                 <p>In conjunction with a hybrid cloud architecture, the multi-cloud approach enables organisations to optimise their infrastructure costs. Multi-cloud reflects the reality of most organisations today and is expected to become the standard for cloud infrastructure in the coming years.</p>
             </div>
             <div class="p-section">
-                <hr>
+                <hr />
                 <a href="#" class="p-button--positive">CTA up to 3 words</a>
                 <a href="#" class="p-button">CTA up to 3 words</a>
             </div>

--- a/templates/docs/examples/brochure/hero-75-offset.html
+++ b/templates/docs/examples/brochure/hero-75-offset.html
@@ -18,7 +18,7 @@
                 <p>Multi-cloud (also referred to as multi cloud or multicloud) is a concept that refers to using multiple clouds from more than one cloud service provider at the same time. The term is also used to refer to the simultaneous running of bare metal, virtualised and containerised workloads.</p>
                 <p>In conjunction with a hybrid cloud architecture, the multi-cloud approach enables organisations to optimise their infrastructure costs. Multi-cloud reflects the reality of most organisations today and is expected to become the standard for cloud infrastructure in the coming years.</p>
             </div>
-            <hr>
+            <hr />
             <a href="#" class="p-button--positive">CTA up to 3 words</a>
             <a href="#" class="p-button">Optional button</a>
             <a href="#">Link CTA up to 5 words</a>

--- a/templates/docs/examples/index.html
+++ b/templates/docs/examples/index.html
@@ -7,8 +7,7 @@
 {% block title %}Component examples{% endblock %}
 
 {% block body %}
-<main id="main-content" class="p-strip l-full-width">
-  <div class="l-main">
+<main id="main-content" class="p-strip">
     <div class="u-fixed-width">
       <h1>Component examples</h1>
       <hr>
@@ -88,6 +87,5 @@
     <div class="u-fixed-width">
       <p><a href="/docs/examples/standalone">Examples using standalone component CSS for testing/debugging</a></p>
     </div>
-  </div>
 </main>
 {% endblock %}

--- a/templates/docs/examples/index.html
+++ b/templates/docs/examples/index.html
@@ -10,7 +10,7 @@
 <main id="main-content" class="p-strip">
     <div class="u-fixed-width">
       <h1>Component examples</h1>
-      <hr>
+      <hr />
     </div>
 
     <div class="row">

--- a/templates/docs/examples/layouts/full-width/default.html
+++ b/templates/docs/examples/layouts/full-width/default.html
@@ -141,7 +141,7 @@
   </div>
 </div>
 
-<hr>
+<hr />
 
 <div class="p-strip is-shallow l-full-width">
   <div class="l-main">
@@ -173,7 +173,7 @@
 <div class="l-full-width">
   <div class="l-main">
     <div class="u-fixed-width">
-      <hr>
+      <hr />
     </div>
   </div>
 </div>

--- a/templates/docs/examples/layouts/full-width/no-sidebar.html
+++ b/templates/docs/examples/layouts/full-width/no-sidebar.html
@@ -84,7 +84,7 @@
   </div>
 </div>
 
-<hr>
+<hr />
 
 <div class="p-strip is-shallow l-full-width">
   <div class="l-main">
@@ -116,7 +116,7 @@
 <div class="l-full-width">
   <div class="l-main">
     <div class="u-fixed-width">
-      <hr>
+      <hr />
     </div>
   </div>
 </div>

--- a/templates/docs/examples/patterns/empty-state/user-triggered.html
+++ b/templates/docs/examples/patterns/empty-state/user-triggered.html
@@ -32,7 +32,7 @@
     </div>
   </div>
   <div class="u-fixed-width">
-    <hr>
+    <hr />
   </div>
   <div class="row">
     <div class="col-4 col-medium-3">

--- a/templates/docs/examples/standalone.html
+++ b/templates/docs/examples/standalone.html
@@ -7,8 +7,7 @@
 {% block title %}Standalone component examples{% endblock %}
 
 {% block body %}
-<main id="main-content" class="p-strip l-full-width">
-  <div class="l-main">
+<main id="main-content" class="p-strip">
     <div class="row">
       <div class="col-12">
         <h1>Standalone component examples</h1>
@@ -42,6 +41,5 @@
         </nav>
       </div>
     </div>
-  </div>
 </main>
 {% endblock %}

--- a/templates/docs/examples/standalone.html
+++ b/templates/docs/examples/standalone.html
@@ -11,7 +11,7 @@
     <div class="row">
       <div class="col-12">
         <h1>Standalone component examples</h1>
-        <hr>
+        <hr />
         <p>Examples below use CSS built with single pattern included with base styles instead of the whole Vanilla framework CSS file.</p>
       </div>
     </div>

--- a/templates/docs/examples/templates/maas-layout.html
+++ b/templates/docs/examples/templates/maas-layout.html
@@ -205,7 +205,7 @@
     </div>
   </div>
 </div>
-<hr>
+<hr />
 <footer class="p-strip">
   <div class="row">
     <p>© 2017 Company name and logo are registered trademarks of Company Ltd.</p>

--- a/templates/docs/examples/templates/responsive.html
+++ b/templates/docs/examples/templates/responsive.html
@@ -75,27 +75,27 @@
       <p class="u-float-left--small"><code>u-float-left--small</code></p>
       <p>This text floats next to previous element when grid is 4 cols.</p>
     </div>
-    <hr>
+    <hr />
     <div class="u-clearfix">
       <p class="u-float-left--medium"><code>u-float-left--medium</code></p>
       <p>This text floats next to previous element when grid is 6 cols.</p>
     </div>
-    <hr>
+    <hr />
     <div class="u-clearfix">
       <p class="u-float-left--large"><code>u-float-left--large</code></p>
       <p>This text floats next to previous element when grid is 12 cols.</p>
     </div>
-    <hr>
+    <hr />
     <div class="u-clearfix">
       <p class="u-float-right--small"><code>u-float-right--small</code></p>
       <p>This text floats next to previous element when grid is 4 cols.</p>
     </div>
-    <hr>
+    <hr />
     <div class="u-clearfix">
       <p class="u-float-right--medium"><code>u-float-right--medium</code></p>
       <p>This text floats next to previous element when grid is 6 cols.</p>
     </div>
-    <hr>
+    <hr />
     <div class="u-clearfix">
       <p class="u-float-right--large"><code>u-float-right--large</code></p>
       <p>This text floats next to previous element when grid is 12 cols.</p>

--- a/templates/docs/examples/templates/snapcraft-publicise.html
+++ b/templates/docs/examples/templates/snapcraft-publicise.html
@@ -195,7 +195,7 @@
         </div>
 
         <div class="row">
-          <hr>
+          <hr />
         </div>
 
         <div id="en_content" class="js-language-content">
@@ -237,7 +237,7 @@
           </div>
 
           <div class="row">
-            <hr>
+            <hr />
           </div>
 
           <div class="row">
@@ -279,7 +279,7 @@
         </div>
 
         <div class="row">
-          <hr>
+          <hr />
         </div>
 
         <div class="row">

--- a/templates/docs/examples/templates/tick-elements.html
+++ b/templates/docs/examples/templates/tick-elements.html
@@ -55,7 +55,7 @@
           <input type="checkbox" aria-labelledby="checkboxExample2" class="p-checkbox__input">
           <span class="p-checkbox__label" id="checkboxExample2">Checkbox option 2</span>
         </label>
-        
+
         <label class="p-radio">
           <input type="radio" aria-labelledby="radioExample1" class="p-radio__input" checked>
           <span class="p-radio__label" id="radioExample1">Radio option 1</span>
@@ -91,7 +91,7 @@
   </div>
   <div class="p-strip is-shallow u-no-padding--top">
     <div class="row">
-      <hr>
+      <hr />
       <p>In padded containers (table cells, some list items), checkboxes and labels need to align with text not wrapped in a tag. Use <code>.p-checkbox--inline</code> or <code>.p-radio--inline</code> elements to achieve that.</p>
     </div>
   </div>

--- a/templates/docs/examples/templates/typographic-spacing.html
+++ b/templates/docs/examples/templates/typographic-spacing.html
@@ -325,7 +325,7 @@
     <h1>h1</h1>
   </div>
 </div>
-<hr>
+<hr />
 <!-- h1 -->
 <div class="flex-container">
   <div class="flex-col">
@@ -386,7 +386,7 @@
     <h1>h1</h1>
   </div>
 </div>
-<hr>
+<hr />
 <!-- h2 -->
 <div class="flex-container">
   <div class="flex-col">
@@ -447,7 +447,7 @@
     <h1>h1</h1>
   </div>
 </div>
-<hr>
+<hr />
 <!-- h3 -->
 <div class="flex-container">
   <div class="flex-col">
@@ -508,7 +508,7 @@
     <h1>h1</h1>
   </div>
 </div>
-<hr>
+<hr />
 <!-- h4 -->
 <div class="flex-container">
   <div class="flex-col">
@@ -569,7 +569,7 @@
     <h1>h1</h1>
   </div>
 </div>
-<hr>
+<hr />
 <!-- h5 -->
 <div class="flex-container">
   <div class="flex-col">
@@ -630,7 +630,7 @@
     <h1>h1</h1>
   </div>
 </div>
-<hr>
+<hr />
 <!-- muted -->
 <div class="flex-container">
   <div class="flex-col">
@@ -691,14 +691,14 @@
     <h1>h1</h1>
   </div>
 </div>
-<hr>
+<hr />
 <!-- <p>Headings preceding block level element</p> -->
 <div class="p-strip--light is-shallow">
   <div class="row" style="max-width: 100%">
     <p>Headings preceding block level element</p>
   </div>
   <div class="row" style="max-width: 100%">
-    <hr>
+    <hr />
   </div>
   <div class="row" style="max-width: 100%">
     <div class="col-2">
@@ -753,7 +753,7 @@
 <!-- blog text -->
 <div class="p-strip is-shallow">
   <div class="row" style="max-width: 100%">
-    <hr>
+    <hr />
   </div>
   <div class="row">
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.
@@ -930,7 +930,7 @@
     <p>This is a paragraph</p>
   </div>
 </div>
-<hr>
+<hr />
 <div class="row">
   <div class="col-6 p-strip is-shallow">
     <h1>
@@ -1035,7 +1035,7 @@
     </p>
   </div>
 </div>
-<hr>
+<hr />
 <div class="row">
   <div class="col-6">
     <h3>List styles and spacing</h3>
@@ -1064,7 +1064,7 @@
     <p>This is just a line of text after the lists.</p>
   </div>
 </div>
-<hr>
+<hr />
 <div class="row">
   <a target="_blank" rel="noopener noreferrer"
     href="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg">

--- a/templates/docs/examples/utilities/margin-collapse.html
+++ b/templates/docs/examples/utilities/margin-collapse.html
@@ -18,22 +18,22 @@
   This div has no left margin
 </div>
 <h1 class="u-no-margin--bottom">&lt;h1&gt; heading with u-no-margin--bottom</h1>
-<hr>
+<hr />
 <h2 class="u-no-margin--bottom">&lt;h2&gt; heading with u-no-margin--bottom</h2>
-<hr>
+<hr />
 <h3 class="u-no-margin--bottom">&lt;h3&gt; heading with u-no-margin--bottom</h3>
-<hr>
+<hr />
 <h4 class="u-no-margin--bottom">&lt;h4&gt; heading with u-no-margin--bottom</h4>
-<hr>
+<hr />
 <h5 class="u-no-margin--bottom">&lt;h5&gt; heading with u-no-margin--bottom</h5>
-<hr>
+<hr />
 <h6 class="u-no-margin--bottom">&lt;h6&gt; heading with u-no-margin--bottom</h6>
-<hr>
+<hr />
 <p class="u-no-margin--bottom">&lt;p&gt; with u-no-margin--bottom</p>
-<hr>
+<hr />
 <p class="p-muted-heading u-no-margin--bottom">&lt;p&gt; p-muted-heading with u-no-margin--bottom</p>
-<hr>
+<hr />
 <p class="p-text--default u-no-margin--bottom">&lt;p&gt; p-text--default with u-no-margin--bottom</p>
-<hr>
+<hr />
 <p class="p-text--small u-no-margin--bottom">&lt;p&gt; small-text with u-no-margin--bottom</p>
 {% endblock %}

--- a/templates/docs/index.html
+++ b/templates/docs/index.html
@@ -4,7 +4,7 @@
 
 {% block content_title %}
 <h1>Get started</h1>
-<hr>
+<hr />
 {% endblock %}
 
 {% block content %}

--- a/templates/docs/index.html
+++ b/templates/docs/index.html
@@ -2,10 +2,12 @@
 
 {% block title %}Get started{% endblock %}
 
-{% block content %}
+{% block content_title %}
 <h1>Get started</h1>
-
 <hr>
+{% endblock %}
+
+{% block content %}
 
 <p>You can use Vanilla in your projects in a few different ways. See <a href="/docs/building-vanilla">Building with Vanilla</a> and <a href="/docs/customising-vanilla">Customising Vanilla</a> for more in-depth setup instructions.</p>
 

--- a/templates/docs/layouts/application.md
+++ b/templates/docs/layouts/application.md
@@ -1,12 +1,8 @@
 ---
 wrapper_template: '_layouts/docs.html'
 context:
-  title: Application | Layouts
+  title: Application layout | Layouts
 ---
-
-# Application layout
-
-<hr>
 
 ## Structure
 

--- a/templates/docs/layouts/brochure.html
+++ b/templates/docs/layouts/brochure.html
@@ -1,9 +1,11 @@
----
-wrapper_template: '_layouts/docs.html'
-context:
-  title: Brochure site | Layouts
----
+{% extends "_layouts/docs.html" %}
 
+{% block title %}Brochure site | Layouts{% endblock %}
+
+{% block content_title %}
+{% endblock %}
+
+{% block content %}
 <div class="p-notification--caution">
   <div class="p-notification__content">
     <h5 class="p-notification__title">Work in progress</h5>
@@ -249,3 +251,4 @@ it is very compact - as the headings do not push the body text down.</li>
     <p class="p-notification__message">Please note that this documentation is still a work in progress. If you have any suggestions on how to improve it feel free to <a href="https://github.com/canonical/vanilla-framework/issues/new">open an issue</a>.</p>
   </div>
 </div>
+{% endblock %}

--- a/templates/docs/layouts/documentation-brochure.md
+++ b/templates/docs/layouts/documentation-brochure.md
@@ -1,12 +1,8 @@
 ---
 wrapper_template: '_layouts/docs.html'
 context:
-  title: Documentation | Layouts
+  title: Documentation brochure layout | Layouts
 ---
-
-# Documentation layout
-
-<hr>
 
 <div class="p-notification--caution">
   <div class="p-notification__content">

--- a/templates/docs/layouts/documentation.md
+++ b/templates/docs/layouts/documentation.md
@@ -1,12 +1,8 @@
 ---
 wrapper_template: '_layouts/docs.html'
 context:
-  title: Documentation | Layouts
+  title: Documentation layout | Layouts
 ---
-
-# Documentation layout
-
-<hr>
 
 ## Structure
 

--- a/templates/docs/layouts/fluid-breakout.md
+++ b/templates/docs/layouts/fluid-breakout.md
@@ -4,10 +4,6 @@ context:
   title: Breaking out of the grid | Layouts
 ---
 
-# Breaking out of the grid
-
-<hr>
-
 In some cases, there might be a good reason to break out of the constraints of a 12 column grid and allow content to bleed into the page margins - for example, tables with many columns that would otherwise result in heavy truncation or wrapping, charts with a lot of detail along the x axis, or card layouts that aim to impress with the abundance of available content. The fluid breakout layout allows you to do this.
 
 ## Anatomy of the fluid breakout layout

--- a/templates/docs/layouts/full-width.md
+++ b/templates/docs/layouts/full-width.md
@@ -4,8 +4,6 @@ context:
   title: Full-width site layout | Layouts
 ---
 
-# Full-width site layout
-
 <div class="p-notification--negative">
   <div class="p-notification__content">
     <h5 class="p-notification__title">Deprecated</h5>

--- a/templates/docs/layouts/sticky-footer.md
+++ b/templates/docs/layouts/sticky-footer.md
@@ -4,10 +4,6 @@ context:
   title: Sticky footer | Layouts
 ---
 
-# Sticky footer
-
-<hr>
-
 To implement a footer that sticks to the bottom of the viewport even when there is little content on the page use the `l-site` element (that should be a wrapper around whole contents of the page and direct child of the `<body>` element) with `l-footer--sticky` inside it.
 
 <div class="embedded-example"><a href="/docs/examples/layouts/sticky-footer/" class="js-example" data-height="400">

--- a/templates/docs/migration-guide-to-v3.md
+++ b/templates/docs/migration-guide-to-v3.md
@@ -4,10 +4,6 @@ context:
   title: Migrating to Vanilla 3.0
 ---
 
-# Migrating to Vanilla 3.0
-
-<hr>
-
 Vanilla 3.0 introduces a number of breaking changes, and this upgrade guide provides detailed instructions on the actions needed to make the transition a smooth one.
 
 ## Building and importing
@@ -442,7 +438,7 @@ The individual mixins for label variants have been removed. All necessary styles
 
 <div class="p-notification--information">
   <div class="p-notification__content">
-    <p class="p-notification__message">Since Vanilla 3.2 the label component has been renamed to status label. Refer to the <a href="/docs/patterns/status-labels">status label component</a> page for more details and code examples. 
+    <p class="p-notification__message">Since Vanilla 3.2 the label component has been renamed to status label. Refer to the <a href="/docs/patterns/status-labels">status label component</a> page for more details and code examples.
   </div>
 </div>
 

--- a/templates/docs/migration-guide-to-v4.md
+++ b/templates/docs/migration-guide-to-v4.md
@@ -174,7 +174,7 @@ For more information see [the grid documentation](/docs/patterns/grid) or [broch
 White strip was introduced in Vanilla 4.0 as a way to highlight sections on top of a new paper background. See [“Paper background”](#paper-background) section above for more information.
 
 <div class="p-strip">
-<hr>
+<hr />
 
 If you want to learn about migration to Vanilla 3.0, see [Vanilla 3.0 migration guide](/docs/migration-guide-to-v3).
 

--- a/templates/docs/migration-guide-to-v4.md
+++ b/templates/docs/migration-guide-to-v4.md
@@ -4,10 +4,6 @@ context:
   title: Migrating to Vanilla 4
 ---
 
-# Vanilla 4 migration
-
-<hr>
-
 Vanilla 4.0 doesn’t introduce any breaking changes on SCSS code level, or in terms of removed components. It is still a major version update because it introduces new heading typography and increases the grid width. These changes may lead to visual differences and bugs.
 
 This migration guide explains what changes are introduced in Vanilla 4.0 and how to QA them in your projects.

--- a/templates/docs/patterns/chip.md
+++ b/templates/docs/patterns/chip.md
@@ -4,10 +4,6 @@ context:
   title: Chips | Components
 ---
 
-# Chips
-
-<hr>
-
 Use the chip component to display small actionable pieces of information.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/chip/default" class="js-example">

--- a/templates/docs/patterns/divider.md
+++ b/templates/docs/patterns/divider.md
@@ -4,10 +4,6 @@ context:
   title: Divider | Components
 ---
 
-# Divider
-
-<hr>
-
 ## Responsive divider
 
 A responsive divider inserts divider lines between sections of content. On small screens (up to `$breakpoint-large`), the divider lines appear horizontally. On screens bigger than `$breakpoint-large`, the divider lines appear vertically, centered in the column gutters. This behaviour can be overridden for medium screens by applying `col-medium-...` to each column which will cause the divider lines to remain vertical for medium and large screens.

--- a/templates/docs/patterns/empty-state.md
+++ b/templates/docs/patterns/empty-state.md
@@ -4,10 +4,6 @@ context:
   title: Empty states | Components
 ---
 
-# Empty states
-
-<hr>
-
 State zero or the empty state is a state where there is no data to display in the UI. It is most commonly used when a new feature is developed or a user interacts with the page for the first time. It can also be used when all data is deleted or unavailable. Empty states inform, support, and provide constructive guidance about the next steps when there is nothing to display.
 
 ## No content

--- a/templates/docs/patterns/images.md
+++ b/templates/docs/patterns/images.md
@@ -4,10 +4,6 @@ context:
   title: Images | Components
 ---
 
-# Images
-
-<hr>
-
 Enhance images by adding a variant style with a border or drop shadow.
 
 ## Image with border

--- a/templates/docs/patterns/list-tree.md
+++ b/templates/docs/patterns/list-tree.md
@@ -4,10 +4,6 @@ context:
   title: List tree | Components
 ---
 
-# List tree
-
-<hr>
-
 The list tree pattern can be used to show a directory style listing, such as a list of files and folders within a directory.
 
 Each directory can be opened or collapse using `aria-hidden`, set `true` for open and `false` to close on the nested list. Using JS this can be changed and should also update the `aria-expanded` attribute on the folder element.

--- a/templates/docs/patterns/matrix.md
+++ b/templates/docs/patterns/matrix.md
@@ -4,10 +4,6 @@ context:
   title: Matrix | Components
 ---
 
-# Matrix
-
-<hr>
-
 The matrix component can be useful to display a selection of items in a format that is less linear than a normal list, using an image to describe each item.
 
 Items will display in one column on small screens. At resolutions above `$breakpoint-small`, items will display three per row.

--- a/templates/docs/patterns/media-object.md
+++ b/templates/docs/patterns/media-object.md
@@ -5,10 +5,6 @@ context:
   title: Media object | Components
 ---
 
-# Media object
-
-<hr>
-
 A media object should be used to display events or articles.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/media-object/media-object/" class="js-example">

--- a/templates/docs/patterns/muted-heading.md
+++ b/templates/docs/patterns/muted-heading.md
@@ -5,10 +5,6 @@ context:
   title: Muted heading | Components
 ---
 
-# Muted heading
-
-<hr>
-
 A muted heading can be used to subtly provide context to content without the heading itself being too prominent.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/headings/muted/" class="js-example">

--- a/templates/docs/patterns/rule.md
+++ b/templates/docs/patterns/rule.md
@@ -4,10 +4,6 @@ context:
   title: Rule | Components
 ---
 
-# Rule
-
-<hr>
-
 The rule component indicates the beginning of a new group of elements. This might be at the section level, or between more granular elements, like paragraphs.
 
 It "anchors" elements that are far apart, and at risk of appearing floating in space.

--- a/templates/docs/patterns/search-and-filter.md
+++ b/templates/docs/patterns/search-and-filter.md
@@ -4,10 +4,6 @@ context:
   title: Search and filter | Components
 ---
 
-# Search and filter
-
-<hr>
-
 This pattern provides the ability to search and apply filter chips with a panel listing available options.
 
 This pattern requires JavaScript to provide the full functionality.

--- a/templates/docs/patterns/section.md
+++ b/templates/docs/patterns/section.md
@@ -4,10 +4,6 @@ context:
   title: Section | Components
 ---
 
-# Sections
-
-<hr>
-
 Use section components to wrap around parts of content on the page. They are used for managing the bottom space after each element.
 
 ## Regular sections

--- a/templates/docs/patterns/segmented-control.md
+++ b/templates/docs/patterns/segmented-control.md
@@ -4,10 +4,6 @@ context:
   title: Segmented control | Components
 ---
 
-# Segmented control
-
-<hr>
-
 Segmented control can be used in two ways:
 
 **Secondary tabs:** if the page already has a set of primary tabs used as navigation, this can be used as a sub-navigation of those primary tabs.

--- a/templates/docs/patterns/slider.md
+++ b/templates/docs/patterns/slider.md
@@ -4,10 +4,6 @@ context:
   title: Slider | Components
 ---
 
-# Slider
-
-<hr>
-
 The `p-slider__wrapper` and `p-slider__input` classes should be used with `<input type="range">` elements
 when you want to provide a numeric representation of the slider value, as well as allow the user to specify a value.
 

--- a/templates/docs/patterns/suru.md
+++ b/templates/docs/patterns/suru.md
@@ -4,10 +4,6 @@ context:
   title: Suru | Components
 ---
 
-# Suru
-
-<hr>
-
 The Suru component can be used to display a visual separation between two sections of content.
 
 By default, Suru should be used on the paper background. When used on dark background, add `is-dark` modifier class.

--- a/templates/docs/patterns/table-of-contents.md
+++ b/templates/docs/patterns/table-of-contents.md
@@ -4,10 +4,6 @@ context:
   title: Table of contents | Components
 ---
 
-# Table of contents
-
-<hr>
-
 A table of contents can be used to display supplementary links to a page.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/table-of-contents/default" class="js-example">

--- a/templates/docs/search.html
+++ b/templates/docs/search.html
@@ -2,13 +2,15 @@
 
 {% block title %}Search results{% if query %} for "{{query}}"{% endif %}{% endblock %}
 
-{% block content %}
+{% block content_title %}
   {% if results and results.entries %}
     <h1 class="p-heading--2">We've found these results for your search <strong>"{{ query }}"</strong></h1>
   {% else %}
     <h1 class="p-heading--2">We haven't found any results for your search <strong>"{{ query }}"</strong>.</h1>
   {% endif %}
+{% endblock %}
 
+{% block content %}
   {% if  results and results.entries %}
   <div class="p-strip is-shallow">
     {% for item in results.entries %}
@@ -38,6 +40,5 @@
       </a>
     {% endif %}
   </div>
-
   {% endif %}
 {% endblock %}

--- a/templates/docs/settings/animation-settings.md
+++ b/templates/docs/settings/animation-settings.md
@@ -4,10 +4,6 @@ context:
   title: Animations | Settings
 ---
 
-# Animations
-
-<hr>
-
 Vanilla provides a choice of duration and easing for animating components.
 
 ## Duration

--- a/templates/docs/settings/animation-settings.md
+++ b/templates/docs/settings/animation-settings.md
@@ -22,7 +22,7 @@ animation.
 | `slow`   | `.5s`         |
 | `sleepy` | `1s`          |
 
-<hr>
+<hr />
 
 ## Easing
 
@@ -33,7 +33,7 @@ Recommended durations for easing can be `easeInCubic` or `easeOutCubic`.
 | `out`   | `cubic-bezier(.215, .61, .355, 1)`   |
 | `in`    | `cubic-bezier(.55, .055, .675, .19)` |
 
-<hr>
+<hr />
 
 ## Spin
 

--- a/templates/docs/settings/assets-settings.md
+++ b/templates/docs/settings/assets-settings.md
@@ -4,10 +4,6 @@ context:
   title: Assets | Settings
 ---
 
-# Assets
-
-<hr>
-
 Assets might include images, icons or font files. If you wish to load these via a content delivery network (CDN), you can specify the CDN host using this variable.
 
 | Setting        | Default value                 |

--- a/templates/docs/settings/breakpoint-settings.md
+++ b/templates/docs/settings/breakpoint-settings.md
@@ -4,10 +4,6 @@ context:
   title: Breakpoints | Settings
 ---
 
-# Breakpoints
-
-<hr>
-
 Vanilla uses three main breakpoints for screen sizes, below you can see the setting, default width and device examples at which the content will scale.
 
 | Setting                            | Default value       | Device example    |

--- a/templates/docs/settings/color-settings.md
+++ b/templates/docs/settings/color-settings.md
@@ -4,10 +4,6 @@ context:
   title: Color | Settings
 ---
 
-# Color
-
-<hr>
-
 These guidelines are the framework upon which we have built our system for how color is used in Vanilla, we use a fairly neutral color palette along with a traffic light palette.
 
 <div class="p-strip is-shallow">

--- a/templates/docs/settings/font-settings.md
+++ b/templates/docs/settings/font-settings.md
@@ -4,10 +4,6 @@ context:
   title: Font | Settings
 ---
 
-# Font
-
-<hr>
-
 Vanilla uses the Ubuntu font family by default, but you can specify any other font family to better suit your project.
 
 All Ubuntu sites and applications should use the Ubuntu font, as it has been specially created to complement the Ubuntu tone of voice. It has a contemporary style and contains characteristics unique to the Ubuntu brand that convey a precise, reliable and free attitude.

--- a/templates/docs/settings/font-settings.md
+++ b/templates/docs/settings/font-settings.md
@@ -28,7 +28,7 @@ Vanilla uses three font weight settings in tandem with the Ubuntu font, which ca
 | `$font-weight-bold`            | `550`         | Most often used on elements with very small text to make them stand out |
 
 <br>
-<hr>
+<hr />
 
 ## Related
 

--- a/templates/docs/settings/layout-settings.md
+++ b/templates/docs/settings/layout-settings.md
@@ -4,10 +4,6 @@ context:
   title: Layout | Settings
 ---
 
-# Layout
-
-<hr>
-
 These settings are used specifically to configure the grid which will determine your overall site layout. Patterns placed within the grid structure will then adapt to fill the space available to them.
 
 | Setting              | Default value |

--- a/templates/docs/settings/placeholder-settings.md
+++ b/templates/docs/settings/placeholder-settings.md
@@ -4,10 +4,6 @@ context:
   title: Placeholders | Settings
 ---
 
-# Placeholders
-
-<hr>
-
 Vanilla uses several global placeholders to share common styles between components. These placeholders can be edited via the following placeholder variables, assuming a `$sp-unit` of `0.5rem`.
 
 <table>

--- a/templates/docs/settings/spacing-settings.md
+++ b/templates/docs/settings/spacing-settings.md
@@ -4,9 +4,6 @@ context:
   title: Spacing | Settings
 ---
 
-# Spacing
-
-<hr>
 Spacing in Vanilla is controlled via a set of variables. There are two kinds of variables - nudges, which keep text aligned to the baseline grid, and multiples of the spacing unit, which define vertical and horizontal spacing.
 
 ## The baseline grid

--- a/templates/docs/settings/table-layout.md
+++ b/templates/docs/settings/table-layout.md
@@ -4,10 +4,6 @@ context:
   title: Table layout | Settings
 ---
 
-# Table layout
-
-<hr>
-
 By default, tables in Vanilla use `table-layout: fixed`.
 
 There are cases where you might want to use `table-layout: auto` - e.g. in automatically generated tables. To do this, you need to set the `$table-layout-fixed` variable to `true`.

--- a/templates/docs/utilities/align.md
+++ b/templates/docs/utilities/align.md
@@ -4,10 +4,6 @@ context:
   title: Align | Utilities
 ---
 
-# Align
-
-<hr>
-
 ## Content
 
 When you need to align elements within a container, you can use the `u-align` utilities to force them to align center, left or right.

--- a/templates/docs/utilities/baseline-grid.md
+++ b/templates/docs/utilities/baseline-grid.md
@@ -4,10 +4,6 @@ context:
   title: Font metrics | Utilities
 ---
 
-# Font metrics
-
-<hr>
-
 You can apply this utility to an element (such as `<body>`) to visualise the `.5rem` baseline grid to which text elements adhere.
 
 <div class="embedded-example"><a href="/docs/examples/utilities/baseline-grid/" class="js-example">

--- a/templates/docs/utilities/clearfix.md
+++ b/templates/docs/utilities/clearfix.md
@@ -4,10 +4,6 @@ context:
   title: Clearfix | Utilities
 ---
 
-# Clearfix
-
-<hr>
-
 A clearfix is a way for an element to automatically clear its child elements, so that you don't need to add additional markup. It's generally used in float layouts where elements are floated to be stacked horizontally.
 
 The clearfix is a way to combat the zero-height container problem for floated elements.

--- a/templates/docs/utilities/embedded-media.md
+++ b/templates/docs/utilities/embedded-media.md
@@ -4,10 +4,6 @@ context:
   title: Embedded media | Utilities
 ---
 
-# Embedded media
-
-<hr>
-
 Embed media objects such as videos, maps and calendars.
 
 <div class="embedded-example"><a href="/docs/examples/utilities/embedded-media/" class="js-example" data-height="600">

--- a/templates/docs/utilities/equal-height.md
+++ b/templates/docs/utilities/equal-height.md
@@ -4,10 +4,6 @@ context:
   title: Equal height | Utilities
 ---
 
-# Equal height
-
-<hr>
-
 To ensure two or more elements have an equal height regardless of their content, add the class `.u-equal-height` to their wrapping parent element.
 
 <div class="embedded-example"><a href="/docs/examples/utilities/equal-height/" class="js-example">

--- a/templates/docs/utilities/floats.md
+++ b/templates/docs/utilities/floats.md
@@ -4,10 +4,6 @@ context:
   title: Floats | Utilities
 ---
 
-# Floats
-
-<hr>
-
 The float utilities allow you to float an element left or right.
 
 ## All screens

--- a/templates/docs/utilities/font-metrics.md
+++ b/templates/docs/utilities/font-metrics.md
@@ -4,10 +4,6 @@ context:
   title: Font metrics | Utilities
 ---
 
-# Font metrics
-
-<hr>
-
 Being able to visualise the <a target="_blank" href="https://en.wikipedia.org/wiki/Baseline_(typography)">baseline</a> position, <a target="_blank" href="https://en.wikipedia.org/wiki/Cap_height">cap-height</a> and <a target="_blank" href="https://en.wikipedia.org/wiki/X-height">x-height</a> of a typeface can be helpful, for example when trying to precisely align inline-block elements (like icons) to text.
 
 These properties are not directly accessible via css, but can be obtained from font-editing software like <a target="_blank" href="https://fontforge.github.io/">FontForge</a>. The values are stored in `_settings_font.scss` (the defaults apply to the Ubuntu font family). If you want to use this utility with another font, you will need to change the default values to match your font.

--- a/templates/docs/utilities/functions.md
+++ b/templates/docs/utilities/functions.md
@@ -4,10 +4,6 @@ context:
   title: Functions | Utilities
 ---
 
-# Functions
-
-<hr>
-
 Vanilla has several global functions used across multiple components or utilities, which can be also be used when building custom components.
 
 ## URL-friendly color

--- a/templates/docs/utilities/has-icon.md
+++ b/templates/docs/utilities/has-icon.md
@@ -4,10 +4,6 @@ context:
   title: Text with icon | Utilities
 ---
 
-# Text with icon
-
-<hr>
-
 To place an icon next to some text with correct spacing, use the class `u-has-icon` on the parent element.
 
 <div class="embedded-example"><a href="/docs/examples/utilities/text-with-icon" class="js-example">

--- a/templates/docs/utilities/hide.md
+++ b/templates/docs/utilities/hide.md
@@ -4,10 +4,6 @@ context:
   title: Hide | Utilities
 ---
 
-# Hide
-
-<hr>
-
 To hide an element from the user, use the class `u-hide`.
 
 ## Viewports

--- a/templates/docs/utilities/image-position.md
+++ b/templates/docs/utilities/image-position.md
@@ -5,10 +5,6 @@ context:
   title: Image position | Utilities
 ---
 
-# Image position
-
-<hr>
-
 Image position is a utility to position an image within a parent container, in
 most cases it would be a strip.
 

--- a/templates/docs/utilities/margin-collapse.md
+++ b/templates/docs/utilities/margin-collapse.md
@@ -4,10 +4,6 @@ context:
   title: Margin collapse | Utilities
 ---
 
-# Margin collapse
-
-<hr>
-
 Remove one or more margins of an element.
 
 <div class="embedded-example"><a href="/docs/examples/utilities/margin-collapse/" class="js-example">

--- a/templates/docs/utilities/no-print.md
+++ b/templates/docs/utilities/no-print.md
@@ -5,10 +5,6 @@ context:
   title: No print | Utilities
 ---
 
-# No print
-
-<hr>
-
 Add the class `u-no-print` to elements you want to hide when the page is printed.
 
 Use your browser's print preview to see the following example working.

--- a/templates/docs/utilities/off-screen.md
+++ b/templates/docs/utilities/off-screen.md
@@ -4,10 +4,6 @@ context:
   title: Off screen | Utilities
 ---
 
-# Off screen
-
-<hr>
-
 The `.u-off-screen` class will position an element out of the page flow and off-screen, while still making it available to screen readers.
 
 <div class="embedded-example"><a href="/docs/examples/utilities/off-screen/" class="js-example">

--- a/templates/docs/utilities/padding-collapse.md
+++ b/templates/docs/utilities/padding-collapse.md
@@ -4,10 +4,6 @@ context:
   title: Padding collapse | Utilities
 ---
 
-# Padding collapse
-
-<hr>
-
 Remove one or more paddings on an element.
 
 <div class="embedded-example"><a href="/docs/examples/utilities/padding-collapse/" class="js-example">

--- a/templates/docs/utilities/show.md
+++ b/templates/docs/utilities/show.md
@@ -4,10 +4,6 @@ context:
   title: Show | Utilities
 ---
 
-# Show
-
-<hr>
-
 Show an element within a certain breakpoint.
 
 <div class="embedded-example"><a href="/docs/examples/utilities/show/" class="js-example">

--- a/templates/docs/utilities/table-cell-padding-overlap.md
+++ b/templates/docs/utilities/table-cell-padding-overlap.md
@@ -4,10 +4,6 @@ context:
   title: Table cell padding overlap | Utilities
 ---
 
-# Table cell padding overlap
-
-<hr>
-
 Vanilla applies padding-top and padding bottom to table cells. This is done to prevent row borders from getting too close to text that is not wrapped in a `<p>` or other text element.
 
 In some cases it can be helpful to override this behaviour for specific children of the table cell, e.g. a `button`:

--- a/templates/docs/utilities/text-max-width.md
+++ b/templates/docs/utilities/text-max-width.md
@@ -4,10 +4,6 @@ context:
   title: Text max width | Utilities
 ---
 
-# Text max width
-
-<hr>
-
 We aim to limit text to a measure (line width) of around 90 characters. This is done for readability purposes, and is already applied to paragraphs and headings.
 
 To limit the width of text lists to match the line width of paragraphs use the `.u-text-max-width` utility class on the list element itself, or on a parent element.

--- a/templates/docs/utilities/truncate.md
+++ b/templates/docs/utilities/truncate.md
@@ -4,10 +4,6 @@ context:
   title: Truncation | Utilities
 ---
 
-# Truncation
-
-<hr>
-
 To truncate text, use the class `u-truncate`.
 
 When applied to a parent container, it will truncate any elements placed inside, so long as the parent's width is set.

--- a/templates/docs/utilities/vertical-spacing.md
+++ b/templates/docs/utilities/vertical-spacing.md
@@ -4,10 +4,6 @@ context:
   title: Vertical spacing | Utilities
 ---
 
-# Vertical spacing
-
-<hr>
-
 The `.u-sv` set of utility classes adjusts the space after an element in positive or negative multiples of the baseline grid unit. A baseline grid unit is equivalent to `.5rem`.
 
 For example, to pull the next element `1rem` closer, apply `.u-sv-2`. To push it `.5rem` away from the current element, apply `u-sv1`.

--- a/templates/docs/utilities/vertically-center.md
+++ b/templates/docs/utilities/vertically-center.md
@@ -4,10 +4,6 @@ context:
   title: Vertically center | Utilities
 ---
 
-# Vertically center
-
-<hr>
-
 The `.u-vertically-center` class will vertically center the direct child of the element it is placed on.
 
 Note: only affects medium and large screens.

--- a/templates/docs/whats-new.html
+++ b/templates/docs/whats-new.html
@@ -8,7 +8,7 @@
 {% block content %}
 <section class="p-section">
 
-When we add, make significant updates, or deprecate a component we update their status so that it’s clear what’s available to use. Check back here anytime to see current status information.
+<p>When we add, make significant updates, or deprecate a component we update their status so that it’s clear what’s available to use. Check back here anytime to see current status information.</p>
 
 <table aria-label="What's new in Vanilla {{versionMinor}}">
   <thead>

--- a/templates/docs/whats-new.html
+++ b/templates/docs/whats-new.html
@@ -2,7 +2,7 @@
 
 {% block content_title %}
 <h1>  What's new in Vanilla {{versionMinor}} </h1>
-<hr>
+<hr />
 {% endblock %}
 
 {% block content %}

--- a/templates/docs/whats-new.html
+++ b/templates/docs/whats-new.html
@@ -1,10 +1,12 @@
 {% extends "_layouts/docs.html" %}
 
+{% block content_title %}
+<h1>  What's new in Vanilla {{versionMinor}} </h1>
+<hr>
+{% endblock %}
+
 {% block content %}
 <section class="p-section">
-<h1>  What's new in Vanilla {{versionMinor}} </h1>
-
-<hr>
 
 When we add, make significant updates, or deprecate a component we update their status so that it’s clear what’s available to use. Check back here anytime to see current status information.
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -82,7 +82,7 @@
 </div>
 
 <div class="u-fixed-width">
-  <hr>
+  <hr />
 </div>
 
 <div id="quick-start" class="p-strip">
@@ -104,7 +104,7 @@
 </div>
 
 <div class="u-fixed-width">
-  <hr>
+  <hr />
 </div>
 
 <div class="p-strip">
@@ -136,7 +136,7 @@
 </div>
 
 <div class="u-fixed-width">
-  <hr>
+  <hr />
 </div>
 
 <div class="p-strip">
@@ -170,7 +170,7 @@
 </div>
 
 <div class="u-fixed-width">
-  <hr>
+  <hr />
 </div>
 
 <div class="p-strip">
@@ -196,7 +196,7 @@
 </template>
 
 <div class="u-fixed-width">
-  <hr>
+  <hr />
 </div>
 
 <div class="p-strip">
@@ -266,7 +266,7 @@
 </div>
 
 <div class="u-fixed-width">
-  <hr>
+  <hr />
 </div>
 
 <div class="p-strip">

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,211 +6,183 @@
 {% block content %}
 <script defer src="https://buttons.github.io/buttons.js"></script>
 
-<div id="main-content" class="p-strip is-deep l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <h1>A simple, extensible CSS framework</h1>
-      <p>Backed by open-source code and written in Sass by the Canonical Web Team.</p>
-      <ul class="p-inline-list u-no-margin--bottom">
-        <li class="p-inline-list__item">
-          <a href="/docs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Get started</a>
+<div id="main-content" class="p-strip is-deep">
+  <div class="u-fixed-width">
+    <h1>A simple, extensible CSS framework</h1>
+    <p>Backed by open-source code and written in Sass by the Canonical Web Team.</p>
+    <ul class="p-inline-list u-no-margin--bottom">
+      <li class="p-inline-list__item">
+        <a href="/docs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Get started</a>
+      </li>
+      <li class="p-inline-list__item">
+        <a href="https://github.com/canonical/vanilla-framework/releases/latest" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download latest', 'eventValue' : undefined });" class="p-button u-no-margin--bottom">Download Vanilla v{{version}}</a>
+      </li>
+    </ul>
+  </div>
+</div>
+
+<div class="p-section">
+  <div class="row">
+    <hr />
+    <div class="col-4 col-medium-2">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header is-stacked">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/1958451f-pictogram_lightweight01b-dark.svg",
+            alt="",
+            width="96",
+            height="96",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img"}
+            ) | safe
+          }}
+          <h2 class="p-heading-icon__title">Lightweight</h2>
+        </div>
+        <p>Vanilla contains a responsive CSS grid, basic style for HTML elements and a selection of key useful patterns and utility classes that you can extend.</p>
+      </div>
+    </div>
+    <div class="col-4 col-medium-2">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header is-stacked">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/730b14b9-pictogram_extension01-dark.svg",
+            alt="",
+            width="96",
+            height="96",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img"}
+            ) | safe
+          }}
+          <h2 class="p-heading-icon__title">Composable</h2>
+        </div>
+        <p>Designed to be composable — you can include the whole framework to avail of all styles or you can use only what you need for your project.</p>
+      </div>
+    </div>
+    <div class="col-4 col-medium-2">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header is-stacked">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/ff78e55c-pictogram_opensource01-dark.svg",
+            alt="",
+            width="96",
+            height="96",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img"}
+            ) | safe
+          }}
+          <h2 class="p-heading-icon__title">Open source</h2>
+        </div>
+        <p>Anyone can contribute to Vanilla, improve it and extend it. All the code is available on GitHub and is licensed under LGPLv3 by Canonical.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="u-fixed-width">
+  <hr>
+</div>
+
+<div id="quick-start" class="p-strip">
+  <div class="row">
+    <div class="col-12">
+      <h2>Quick start</h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6 col-medium-3">
+      <p>The recommended method of including Vanilla Framework in your project is via <a href="https://www.npmjs.com/package/vanilla-framework">npm</a> or <a href="https://yarnpkg.com/package/vanilla-framework">yarn</a>. You can then simply include the framework in your SCSS files and compile.</p>
+      <p>For other methods, please see the <a href="/docs">advanced usage docs.</a></p>
+    </div>
+    <div class="col-6 col-medium-3">
+      <pre><code>yarn add sass vanilla-framework</code></pre>
+      <pre><code><span class="token keyword">@import</span> <span class="token string">"vanilla-framework"</span><span class="token punctuation">;</span><br><span class="token keyword">@include</span> vanilla<span class="token punctuation">;</span></code></pre>
+    </div>
+  </div>
+</div>
+
+<div class="u-fixed-width">
+  <hr>
+</div>
+
+<div class="p-strip">
+  <div class="row u-equal-height">
+    <div class="col-6 col-medium-3">
+      <h2>Guidelines</h2>
+      <p>If you are <a href="https://vanillaframework.io/contribute">contributing to Vanilla</a>, make sure to read and follow these guidelines.</p>
+      <ul class="p-list--divided">
+        <li class="p-list__item">
+          <a href="/accessibility" class="p-link">Accessibility</a>
         </li>
-        <li class="p-inline-list__item">
-          <a href="https://github.com/canonical/vanilla-framework/releases/latest" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download latest', 'eventValue' : undefined });" class="p-button u-no-margin--bottom">Download Vanilla v{{version}}</a>
+        <li class="p-list__item">
+          <a href="/browser-support" class="p-link">Browser support</a>
         </li>
       </ul>
     </div>
+    <div class="col-6 col-medium-3 u-vertically-center u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/af1e0f04-guidelines-illustration.svg",
+        alt="",
+        width="378",
+        height="200",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
   </div>
 </div>
 
-<div class="p-section l-full-width">
-  <div class="l-main">
-    <div class="row">
-      <hr />
-      <div class="col-4 col-medium-2">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header is-stacked">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/1958451f-pictogram_lightweight01b-dark.svg",
-              alt="",
-              width="96",
-              height="96",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img"}
-              ) | safe
-            }}
-            <h2 class="p-heading-icon__title">Lightweight</h2>
-          </div>
-          <p>Vanilla contains a responsive CSS grid, basic style for HTML elements and a selection of key useful patterns and utility classes that you can extend.</p>
+<div class="u-fixed-width">
+  <hr>
+</div>
+
+<div class="p-strip">
+  <div class="row">
+    <div class="col-4 col-medium-2">
+      <h2>Downloads</h2>
+    </div>
+    <div class="p-card--highlighted col-4 col-medium-2">
+      <div class="p-heading-icon--small">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/0276b842-github-icon.svg" alt="GitHub repo:" />
+          <h3 class="p-heading-icon__title">Vanilla Framework</h3>
         </div>
+        <p>Use our CSS framework to start building&nbsp;your project.</p>
+        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button" href="https://github.com/canonical/vanilla-framework/releases/latest">Download latest Vanilla v{{version}}</a></p>
+        <small>See the <a href="https://github.com/canonical/vanilla-framework/releases">release notes</a> for details on the latest&nbsp;updates.</small>
       </div>
-      <div class="col-4 col-medium-2">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header is-stacked">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/730b14b9-pictogram_extension01-dark.svg",
-              alt="",
-              width="96",
-              height="96",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img"}
-              ) | safe
-            }}
-            <h2 class="p-heading-icon__title">Composable</h2>
-          </div>
-          <p>Designed to be composable — you can include the whole framework to avail of all styles or you can use only what you need for your project.</p>
+    </div>
+    <div class="p-card--highlighted col-4 col-medium-2">
+      <div class="p-heading-icon--small">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9a5b9c51-sketch-icon.svg" alt="Sketch library:" />
+          <h3 class="p-heading-icon__title">Vanilla Design</h3>
         </div>
-      </div>
-      <div class="col-4 col-medium-2">
-        <div class="p-heading-icon">
-          <div class="p-heading-icon__header is-stacked">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/ff78e55c-pictogram_opensource01-dark.svg",
-              alt="",
-              width="96",
-              height="96",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img"}
-              ) | safe
-            }}
-            <h2 class="p-heading-icon__title">Open source</h2>
-          </div>
-          <p>Anyone can contribute to Vanilla, improve it and extend it. All the code is available on GitHub and is licensed under LGPLv3 by Canonical.</p>
-        </div>
+        <p>Get our Sketch library of common design components.</p>
+        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla Design UI Kit', 'eventValue' : undefined });" class="p-button" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download the Sketch UI Kit</a></p>
+        <small><i class="p-icon--warning"></i> The Sketch UI Kit is no longer maintained. Current version is compatible with Vanilla v2.25.</small>
       </div>
     </div>
   </div>
 </div>
 
-<div class="l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <hr>
-    </div>
-  </div>
+<div class="u-fixed-width">
+  <hr>
 </div>
 
-<div id="quick-start" class="p-strip l-full-width">
-  <div class="l-main">
-    <div class="row">
-      <div class="col-12">
-        <h2>Quick start</h2>
-      </div>
+<div class="p-strip">
+  <div class="row">
+    <div class="col-4">
+      <h2>Latest news from our blog</h2>
     </div>
-    <div class="row">
-      <div class="col-6 col-medium-3">
-        <p>The recommended method of including Vanilla Framework in your project is via <a href="https://www.npmjs.com/package/vanilla-framework">npm</a> or <a href="https://yarnpkg.com/package/vanilla-framework">yarn</a>. You can then simply include the framework in your SCSS files and compile.</p>
-        <p>For other methods, please see the <a href="/docs">advanced usage docs.</a></p>
+    <div class="col-8">
+      <div id="articles" class="row">
+        <p><i class="p-icon--spinner u-animation--spin"></i> Loading...</p>
       </div>
-      <div class="col-6 col-medium-3">
-        <pre><code>yarn add sass vanilla-framework</code></pre>
-        <pre><code><span class="token keyword">@import</span> <span class="token string">"vanilla-framework"</span><span class="token punctuation">;</span><br><span class="token keyword">@include</span> vanilla<span class="token punctuation">;</span></code></pre>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <hr>
-    </div>
-  </div>
-</div>
-
-<div class="p-strip l-full-width">
-  <div class="l-main">
-    <div class="row u-equal-height">
-      <div class="col-6 col-medium-3">
-        <h2>Guidelines</h2>
-        <p>If you are <a href="https://vanillaframework.io/contribute">contributing to Vanilla</a>, make sure to read and follow these guidelines.</p>
-        <ul class="p-list--divided">
-          <li class="p-list__item">
-            <a href="/accessibility" class="p-link">Accessibility</a>
-          </li>
-          <li class="p-list__item">
-            <a href="/browser-support" class="p-link">Browser support</a>
-          </li>
-        </ul>
-      </div>
-      <div class="col-6 col-medium-3 u-vertically-center u-align--center">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/af1e0f04-guidelines-illustration.svg",
-          alt="",
-          width="378",
-          height="200",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <hr>
-    </div>
-  </div>
-</div>
-
-<div class="p-strip l-full-width">
-  <div class="l-main">
-    <div class="row">
-      <div class="col-4 col-medium-2">
-        <h2>Downloads</h2>
-      </div>
-      <div class="p-card--highlighted col-4 col-medium-2">
-        <div class="p-heading-icon--small">
-          <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/0276b842-github-icon.svg" alt="GitHub repo:" />
-            <h3 class="p-heading-icon__title">Vanilla Framework</h3>
-          </div>
-          <p>Use our CSS framework to start building&nbsp;your project.</p>
-          <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-button" href="https://github.com/canonical/vanilla-framework/releases/latest">Download latest Vanilla v{{version}}</a></p>
-          <small>See the <a href="https://github.com/canonical/vanilla-framework/releases">release notes</a> for details on the latest&nbsp;updates.</small>
-        </div>
-      </div>
-      <div class="p-card--highlighted col-4 col-medium-2">
-        <div class="p-heading-icon--small">
-          <div class="p-heading-icon__header">
-            <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9a5b9c51-sketch-icon.svg" alt="Sketch library:" />
-            <h3 class="p-heading-icon__title">Vanilla Design</h3>
-          </div>
-          <p>Get our Sketch library of common design components.</p>
-          <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla Design UI Kit', 'eventValue' : undefined });" class="p-button" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download the Sketch UI Kit</a></p>
-          <small><i class="p-icon--warning"></i> The Sketch UI Kit is no longer maintained. Current version is compatible with Vanilla v2.25.</small>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <hr>
-    </div>
-  </div>
-</div>
-
-<div class="p-strip l-full-width">
-  <div class="l-main">
-    <div class="row">
-      <div class="col-4">
-        <h2>Latest news from our blog</h2>
-      </div>
-      <div class="col-8">
-        <div id="articles" class="row">
-          <p><i class="p-icon--spinner u-animation--spin"></i> Loading...</p>
-        </div>
-        <div class="u-fixed-width"><a href="https://ubuntu.com/blog/topics/design" class="p-button">View more from our blog</a></div>
-      </div>
+      <div class="u-fixed-width"><a href="https://ubuntu.com/blog/topics/design" class="p-button">View more from our blog</a></div>
     </div>
   </div>
 </div>
@@ -223,121 +195,109 @@
   </article>
 </template>
 
-<div class="l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <hr>
-    </div>
-  </div>
+<div class="u-fixed-width">
+  <hr>
 </div>
 
-<div class="p-strip l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <div class="p-logo-section">
-        <p class="p-logo-section__title u-align-text--center">Who&rsquo;s using Vanilla</p>
-        <div class="p-logo-section__items">
-          <div class="p-logo-section__item">
-            <a href="https://ubuntu.com/">
-              {{ image (
-                url="https://assets.ubuntu.com/v1/89680bdf-logo-ubuntu.svg",
-                alt="",
-                width="144",
-                height="144",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-                ) | safe
-              }}
-            </a>
-          </div>
-          <div class="p-logo-section__item">
-            <a href="https://jaas.ai/">
-              {{ image (
-                url="https://assets.ubuntu.com/v1/7fe3f290-2019-logo-jaas.svg",
-                alt="",
-                width="145",
-                height="145",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-                ) | safe
-              }}
-            </a>
-          </div>
-          <div class="p-logo-section__item">
-            <a href="https://stmargarets.london/">
-              {{ image (
-                url="https://assets.ubuntu.com/v1/b7c9c8ce-2019-st-margarets-logo.svg",
-                alt="",
-                width="145",
-                height="145",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-                ) | safe
-              }}
-            </a>
-          </div>
-          <div class="p-logo-section__item">
-            <a href="https://snapcraft.io/">
-              {{ image (
-                url="https://assets.ubuntu.com/v1/e635d1ef-snapcraft_green-red_hex.png",
-                alt="",
-                width="170",
-                height="120",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-                ) | safe
-              }}
-            </a>
-          </div>
+<div class="p-strip">
+  <div class="u-fixed-width">
+    <div class="p-logo-section">
+      <p class="p-logo-section__title u-align-text--center">Who&rsquo;s using Vanilla</p>
+      <div class="p-logo-section__items">
+        <div class="p-logo-section__item">
+          <a href="https://ubuntu.com/">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/89680bdf-logo-ubuntu.svg",
+              alt="",
+              width="144",
+              height="144",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </a>
+        </div>
+        <div class="p-logo-section__item">
+          <a href="https://jaas.ai/">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/7fe3f290-2019-logo-jaas.svg",
+              alt="",
+              width="145",
+              height="145",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </a>
+        </div>
+        <div class="p-logo-section__item">
+          <a href="https://stmargarets.london/">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/b7c9c8ce-2019-st-margarets-logo.svg",
+              alt="",
+              width="145",
+              height="145",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </a>
+        </div>
+        <div class="p-logo-section__item">
+          <a href="https://snapcraft.io/">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/e635d1ef-snapcraft_green-red_hex.png",
+              alt="",
+              width="170",
+              height="120",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </a>
         </div>
       </div>
     </div>
   </div>
 </div>
 
-<div class="l-full-width">
-  <div class="l-main">
-    <div class="u-fixed-width">
-      <hr>
-    </div>
-  </div>
+<div class="u-fixed-width">
+  <hr>
 </div>
 
-<div class="p-strip l-full-width">
-  <div class="l-main">
-    <div class="row">
-      <div class="col-3">
-        <h2>Contribute</h2>
-        <p><a class="github-button" href="https://github.com/canonical/vanilla-framework" data-size="large" data-show-count="true" aria-label="Follow @vanilla-framework on GitHub">Follow @vanilla-framework</a></p>
-        <p><a class="github-button" href="https://github.com/canonical/vanilla-framework/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork vanilla-framework/vanilla-framework on GitHub">Fork</a></p>
-      </div>
-      <div class="col-3">
-        <h2>Get involved</h2>
-        <ul class="p-list--divided">
-          <li class="p-list__item">
-            <a href="https://twitter.com/vanillaframewrk" class="p-link--soft">Twitter&nbsp;&rsaquo;</a>
-          </li>
-          <li class="p-list__item">
-            <a href="https://github.com/canonical/vanilla-framework" class="p-link--soft">GitHub&nbsp;&rsaquo;</a>
-          </li>
-        </ul>
-      </div>
-      <div class="col-6">
-        <h2>Subscribe to Vanilla updates</h2>
-        <form action="//canonical.us3.list-manage.com/subscribe/post?u=56dac47c206ba0f58ec25f314&amp;id=36f7d8394e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="p-form">
-          <div class="p-form__group">
-            <label for="mce-EMAIL">Email address</label>
-            <input type="email" value="" name="EMAIL" placeholder="vanilla@example.com" id="mce-EMAIL" aria-label="Email address" autocomplete="email" required />
-            <input class="u-off-screen" aria-hidden="true" type="hidden" name="b_56dac47c206ba0f58ec25f314_36f7d8394e" tabindex="-1" value="" />
-            <p class="p-form-help-text">Know about new releases, features, blog posts, calls&#8209;for&#8209;help&nbsp;and more.</p>
-          </div>
-          <button name="subscribe" type="submit" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Subscribe', 'eventLabel' : 'Subcribe to Vanilla updates', 'eventValue' : undefined });" class="p-button--positive">Subscribe</button>
-        </form>
-      </div>
+<div class="p-strip">
+  <div class="row">
+    <div class="col-3">
+      <h2>Contribute</h2>
+      <p><a class="github-button" href="https://github.com/canonical/vanilla-framework" data-size="large" data-show-count="true" aria-label="Follow @vanilla-framework on GitHub">Follow @vanilla-framework</a></p>
+      <p><a class="github-button" href="https://github.com/canonical/vanilla-framework/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork vanilla-framework/vanilla-framework on GitHub">Fork</a></p>
+    </div>
+    <div class="col-3">
+      <h2>Get involved</h2>
+      <ul class="p-list--divided">
+        <li class="p-list__item">
+          <a href="https://twitter.com/vanillaframewrk" class="p-link--soft">Twitter&nbsp;&rsaquo;</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://github.com/canonical/vanilla-framework" class="p-link--soft">GitHub&nbsp;&rsaquo;</a>
+        </li>
+      </ul>
+    </div>
+    <div class="col-6">
+      <h2>Subscribe to Vanilla updates</h2>
+      <form action="//canonical.us3.list-manage.com/subscribe/post?u=56dac47c206ba0f58ec25f314&amp;id=36f7d8394e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="p-form">
+        <div class="p-form__group">
+          <label for="mce-EMAIL">Email address</label>
+          <input type="email" value="" name="EMAIL" placeholder="vanilla@example.com" id="mce-EMAIL" aria-label="Email address" autocomplete="email" required />
+          <input class="u-off-screen" aria-hidden="true" type="hidden" name="b_56dac47c206ba0f58ec25f314_36f7d8394e" tabindex="-1" value="" />
+          <p class="p-form-help-text">Know about new releases, features, blog posts, calls&#8209;for&#8209;help&nbsp;and more.</p>
+        </div>
+        <button name="subscribe" type="submit" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Subscribe', 'eventLabel' : 'Subcribe to Vanilla updates', 'eventValue' : undefined });" class="p-button--positive">Subscribe</button>
+      </form>
     </div>
   </div>
 </div>

--- a/templates/static/js/example.js
+++ b/templates/static/js/example.js
@@ -3,6 +3,20 @@
     throw Error('VANILLA_VERSION not specified.');
   }
 
+  // throttling function calls, by Remy Sharp
+  // http://remysharp.com/2010/07/21/throttling-function-calls/
+  var throttle = function (fn, delay) {
+    var timer = null;
+    return function () {
+      var context = this,
+        args = arguments;
+      clearTimeout(timer);
+      timer = setTimeout(function () {
+        fn.apply(context, args);
+      }, delay);
+    };
+  };
+
   var CODEPEN_CONFIG = {
     title: 'Vanilla framework example',
     head: "<meta name='viewport' content='width=device-width, initial-scale=1'>",
@@ -146,6 +160,14 @@
     }
   }
 
+  function resizeIframe(iframe) {
+    if (iframe.contentDocument.readyState == 'complete') {
+      var frameHeight = iframe.contentDocument.body.scrollHeight;
+      var style = iframe.contentWindow.getComputedStyle(iframe.contentDocument.body);
+      iframe.height = frameHeight + 32 + 'px'; // accommodate for body margin
+    }
+  }
+
   function renderIframe(container, html, height) {
     var iframe = document.createElement('iframe');
 
@@ -163,9 +185,7 @@
       // Wait for content to load before determining height
       var resizeInterval = setInterval(function () {
         if (iframe.contentDocument.readyState == 'complete') {
-          var frameHeight = iframe.contentDocument.body.scrollHeight;
-          var style = iframe.contentWindow.getComputedStyle(iframe.contentDocument.body);
-          iframe.height = frameHeight + 32 + 'px'; // accommodate for body margin
+          resizeIframe(iframe);
           clearInterval(resizeInterval);
           fixScroll();
         }
@@ -175,6 +195,13 @@
       setTimeout(function () {
         clearInterval(resizeInterval);
       }, 5000);
+
+      window.addEventListener(
+        'resize',
+        throttle(function () {
+          resizeIframe(iframe);
+        }, 10)
+      );
     }
 
     return iframe;

--- a/templates/static/js/scripts.js
+++ b/templates/static/js/scripts.js
@@ -209,7 +209,7 @@
     var toc = document.querySelector('#toc');
     if (toc) {
       toc.appendChild(list);
-      toc.closest(".u-hide").classList.remove("u-hide");
+      toc.closest('.u-hide').classList.remove('u-hide');
     }
   }
 

--- a/templates/static/js/scripts.js
+++ b/templates/static/js/scripts.js
@@ -213,11 +213,13 @@
     }
   }
 
-  //
+  // accordion side navigation
   var currentPage = document.querySelector('.p-side-navigation__link[aria-current="page"]');
-  var parentList = currentPage.parentNode.parentNode;
-  parentList.setAttribute('aria-expanded', true);
-  parentList.previousElementSibling.setAttribute('aria-expanded', true);
+  if (currentPage) {
+    var parentList = currentPage.parentNode.parentNode;
+    parentList.setAttribute('aria-expanded', true);
+    parentList.previousElementSibling.setAttribute('aria-expanded', true);
+  }
 
   function setupSideNavigationExpandToggle(toggle) {
     const isExpanded = toggle.getAttribute('aria-expanded') === 'true';

--- a/templates/static/js/scripts.js
+++ b/templates/static/js/scripts.js
@@ -73,7 +73,7 @@
 
   /**
     Toggles the expanded/collapsed classes on side navigation element.
-  
+
     @param {HTMLElement} sideNavigation The side navigation element.
     @param {Boolean} show Whether to show or hide the drawer.
   */
@@ -184,15 +184,15 @@
     heading.setAttribute('id', id);
   });
 
-  // get all headings from page and add it to current highligted item in side navigation
+  // get all headings from page and add it to table of contents
   var list = document.createElement('ul');
-  list.classList.add('p-side-navigation__list');
+  list.classList.add('p-table-of-contents__list');
 
   var item = document.createElement('li');
-  item.classList.add('p-side-navigation__item');
+  item.classList.add('p-table-of-contents__item');
 
   var anchor = document.createElement('a');
-  anchor.classList.add('p-side-navigation__link');
+  anchor.classList.add('p-table-of-contents__link');
 
   // Add all H2s with IDs to the table of contents list
   [].slice.call(document.querySelectorAll('main h2[id]')).forEach(function (heading) {
@@ -200,21 +200,63 @@
     var thisAnchor = anchor.cloneNode();
     thisAnchor.setAttribute('href', '#' + heading.id);
     thisAnchor.textContent = heading.textContent;
-    thisAnchor.addEventListener('click', () => {
-      toggleDrawer(sideNav, false);
-    });
     thisItem.appendChild(thisAnchor);
     list.appendChild(thisItem);
   });
 
   // Add table of contents as nested list to side navigation
   if (list.querySelectorAll('li').length > 0) {
-    var currentPage = document.querySelector('.p-side-navigation__link[aria-current="page"]');
-    if (currentPage) {
-      var parent = currentPage.parentNode;
-      parent.appendChild(list);
+    var toc = document.querySelector('#toc');
+    if (toc) {
+      toc.appendChild(list);
+      toc.closest(".u-hide").classList.remove("u-hide");
     }
   }
+
+  //
+  var currentPage = document.querySelector('.p-side-navigation__link[aria-current="page"]');
+  var parentList = currentPage.parentNode.parentNode;
+  parentList.setAttribute('aria-expanded', true);
+  parentList.previousElementSibling.setAttribute('aria-expanded', true);
+
+  function setupSideNavigationExpandToggle(toggle) {
+    const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+    if (!isExpanded) {
+      toggle.setAttribute('aria-expanded', isExpanded);
+    }
+    const item = toggle.closest('.p-side-navigation__item');
+    const link = item.querySelector('.p-side-navigation__link');
+    const nestedList = item.querySelector('.p-side-navigation__list');
+    if (!link?.hasAttribute('aria-expanded')) {
+      link.setAttribute('aria-expanded', isExpanded);
+    }
+    if (!nestedList?.hasAttribute('aria-expanded')) {
+      nestedList.setAttribute('aria-expanded', isExpanded);
+    }
+  }
+
+  function handleExpandToggle(event) {
+    const item = event.currentTarget.closest('.p-side-navigation__item');
+    const button = item.querySelector('.p-side-navigation__expand, .p-side-navigation__accordion-button');
+    const link = item.querySelector('.p-side-navigation__link');
+    const nestedList = item.querySelector('.p-side-navigation__list');
+
+    [button, link, nestedList].forEach((el) => {
+      el.setAttribute('aria-expanded', el.getAttribute('aria-expanded') === 'true' ? 'false' : 'true');
+    });
+  }
+
+  function setupSideNavigationExpands() {
+    var expandToggles = document.querySelectorAll('.p-side-navigation__expand, .p-side-navigation__accordion-button');
+    expandToggles.forEach((toggle) => {
+      setupSideNavigationExpandToggle(toggle);
+      toggle.addEventListener('click', (e) => {
+        handleExpandToggle(e);
+      });
+    });
+  }
+
+  setupSideNavigationExpands();
 })();
 
 // scroll active side navigation item into view (without scrolling whole page)


### PR DESCRIPTION
## Done

Apply new documentation layout to Vanilla website.
This mostly affects docs section, but the whole site now uses paper background as well.

Fixes [WD-6055](https://warthogs.atlassian.net/browse/WD-6055)

## QA

- Open [demo](https://vanilla-framework-4863.demos.haus/docs)
- Review the docs, make sure layout is fine and components look good on new background



[WD-6055]: https://warthogs.atlassian.net/browse/WD-6055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ