### PR TITLE
Add fallback variant for legacy misaligned logos

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.3.0
+  features:
+    - component: Logo section
+      url: /docs/patterns/logo-section#fallback-for-misaligned-logos
+      status: Updated
+      notes: We've introduced new fallback variant for logo sections with misaligned images.
 - version: 4.2.0
   features:
     - component: Forms / Dark

--- a/scss/_patterns_logo-section.scss
+++ b/scss/_patterns_logo-section.scss
@@ -87,4 +87,36 @@
       padding-top: $logo-section-offset-small;
     }
   }
+
+  // fallback for old logo sections that may have logos not properly aligned by design team
+  .p-logo-section.has-misaligned-images,
+  .p-logo-section--dense.has-misaligned-images {
+    .p-logo-section__item {
+      margin-bottom: $spv--small;
+      margin-top: 0;
+
+      width: $logo-section-item-size-small;
+
+      @media (min-width: $breakpoint-small) {
+        width: $logo-section-item-size-medium;
+      }
+
+      @media (min-width: $breakpoint-large) {
+        width: $logo-section-item-size;
+      }
+    }
+
+    .p-logo-section__items {
+      align-items: center;
+      display: flex;
+      flex-wrap: wrap;
+      padding-bottom: 0;
+      padding-top: 0;
+    }
+
+    .p-logo-section__logo {
+      height: auto;
+      width: 100%;
+    }
+  }
 }

--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -8,7 +8,7 @@
       url: /docs/customising-vanilla
     - title: What's new in {version}
       url: /docs/whats-new
-    - title: Migrating to v4.0
+    - title: Migrating to v4
       url: /docs/migration-guide-to-v4
 - heading: Base elements
   subheadings:

--- a/templates/docs/examples/patterns/logo-section/logo-section-fallback.html
+++ b/templates/docs/examples/patterns/logo-section/logo-section-fallback.html
@@ -40,42 +40,42 @@
     <h2 class="p-logo-section__title u-align--center" style="max-width: none">Read about the companies using app stores for IoT</h2>
     <div class="p-logo-section__items">
       <div class="p-logo-section__item">
-        <a href="/engage/case-study-rigado">
+        <a href="#">
           <div class=" lazyloaded" data-noscript="">
             <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_113,h_71/https://assets.ubuntu.com/v1/6d588a1f-RigadoFullColorVert-800px.png" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_226,h_142/https://assets.ubuntu.com/v1/6d588a1f-RigadoFullColorVert-800px.png 2x" alt="" width="113" height="71" loading="lazy" class="p-logo-section__logo">
           </div>
         </a>
       </div>
       <div class="p-logo-section__item">
-        <a href="/dell">
+        <a href="#">
           <div class=" lazyloaded" data-noscript="">
             <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_162,h_29/https://assets.ubuntu.com/v1/5c2662f7-dellemc.png" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_324,h_58/https://assets.ubuntu.com/v1/5c2662f7-dellemc.png 2x" alt="" width="162" height="29" loading="lazy" class="p-logo-section__logo">
           </div>
         </a>
       </div>
       <div class="p-logo-section__item">
-        <a href="/blog/bosch-rexroth-adopts-ubuntu-core-and-snaps-for-app-based-ctrlx-automation-platform">
+        <a href="#">
           <div class=" lazyloaded" data-noscript="">
             <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_131,h_53/https://assets.ubuntu.com/v1/156ddbf8-rexroth_logo.svg" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_262,h_106/https://assets.ubuntu.com/v1/156ddbf8-rexroth_logo.svg 2x" alt="" width="131" height="53" loading="lazy">
           </div>
         </a>
       </div>
       <div class="p-logo-section__item">
-        <a href="/engage/cyberdyne">
+        <a href="#">
           <div class=" lazyloaded" data-noscript="">
             <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_158,h_99/https://assets.ubuntu.com/v1/c5ee407e-cyberdyne.png" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_316,h_198/https://assets.ubuntu.com/v1/c5ee407e-cyberdyne.png 2x" alt="" width="158" height="99" loading="lazy" class="p-logo-section__logo">
           </div>
         </a>
       </div>
       <div class="p-logo-section__item">
-        <a href="/blog/lime-microsystems-and-canonical-announce-limenet-crowdfunding">
+        <a href="#">
           <div class=" lazyloaded" data-noscript="">
             <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_162,h_69/https://assets.ubuntu.com/v1/5651e32d-lime.png" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_324,h_138/https://assets.ubuntu.com/v1/5651e32d-lime.png 2x" alt="" width="162" height="69" loading="lazy" class="p-logo-section__logo">
           </div>
         </a>
       </div>
       <div class="p-logo-section__item">
-        <a href="/engage/domotz-case-study">
+        <a href="#">
           <div class=" lazyloaded" data-noscript="">
             <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_162,h_36/https://assets.ubuntu.com/v1/84d82478-domotz.svg" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_324,h_72/https://assets.ubuntu.com/v1/84d82478-domotz.svg 2x" alt="" width="162" height="36" loading="lazy" class="p-logo-section__logo">
           </div>

--- a/templates/docs/examples/patterns/logo-section/logo-section-fallback.html
+++ b/templates/docs/examples/patterns/logo-section/logo-section-fallback.html
@@ -1,0 +1,87 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Logo section / Misaligned logos{% endblock %}
+
+{% block standalone_css %}patterns_logo-section{% endblock %}
+
+{% block content %}
+<div class="u-fixed-width">
+  <div class="p-logo-section has-misaligned-images">
+    <h2 class="u-align--center u-sv3">Cloud Service Providers</h2>
+    <div class="p-logo-section__items">
+      <div class="p-logo-section__item">
+        <div class=" lazyloaded" data-noscript="">
+          <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_144,h_144/https://assets.ubuntu.com/v1/1ccd490e-equinix-white-space.svg" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_288,h_288/https://assets.ubuntu.com/v1/1ccd490e-equinix-white-space.svg 2x" alt="Equinix" width="144" height="144" loading="lazy" class="p-logo-section__logo">
+        </div>
+      </div>
+      <div class="p-logo-section__item">
+        <div class=" lazyloaded" data-noscript="">
+          <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_146,h_144/https://assets.ubuntu.com/v1/57e46e3b-google-logo.svg" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_292,h_288/https://assets.ubuntu.com/v1/57e46e3b-google-logo.svg 2x" alt="Google cloud platform" width="146" height="144" loading="lazy">
+        </div>
+      </div>
+      <div class="p-logo-section__item">
+        <div class=" lazyloaded" data-noscript="">
+          <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_146,h_144/https://assets.ubuntu.com/v1/538fe31a-MS+Azure-white-space.svg" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_292,h_288/https://assets.ubuntu.com/v1/538fe31a-MS+Azure-white-space.svg 2x" alt="Microsoft azure logo" width="146" height="144" loading="lazy" class="p-logo-section__logo">
+        </div>
+      </div>
+      <div class="p-logo-section__item">
+        <div class=" lazyloaded" data-noscript="">
+          <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_145,h_145/https://assets.ubuntu.com/v1/093f3200-aws-logo-white-spae.svg" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_290,h_290/https://assets.ubuntu.com/v1/093f3200-aws-logo-white-spae.svg 2x" alt="AWS logo" width="145" height="145" loading="lazy" class="p-logo-section__logo">
+        </div>
+      </div>
+      <div class="p-logo-section__item">
+        <div class=" lazyloaded" data-noscript="">
+          <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_350,h_165/https://assets.ubuntu.com/v1/debf01e1-Oracle-Cloud-Logo-350.png" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_700,h_330/https://assets.ubuntu.com/v1/debf01e1-Oracle-Cloud-Logo-350.png 2x" alt="Oracle cloud" width="350" height="165" loading="lazy" class="p-logo-section__logo">
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="p-logo-section has-misaligned-images">
+    <h2 class="p-logo-section__title u-align--center" style="max-width: none">Read about the companies using app stores for IoT</h2>
+    <div class="p-logo-section__items">
+      <div class="p-logo-section__item">
+        <a href="/engage/case-study-rigado">
+          <div class=" lazyloaded" data-noscript="">
+            <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_113,h_71/https://assets.ubuntu.com/v1/6d588a1f-RigadoFullColorVert-800px.png" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_226,h_142/https://assets.ubuntu.com/v1/6d588a1f-RigadoFullColorVert-800px.png 2x" alt="" width="113" height="71" loading="lazy" class="p-logo-section__logo">
+          </div>
+        </a>
+      </div>
+      <div class="p-logo-section__item">
+        <a href="/dell">
+          <div class=" lazyloaded" data-noscript="">
+            <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_162,h_29/https://assets.ubuntu.com/v1/5c2662f7-dellemc.png" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_324,h_58/https://assets.ubuntu.com/v1/5c2662f7-dellemc.png 2x" alt="" width="162" height="29" loading="lazy" class="p-logo-section__logo">
+          </div>
+        </a>
+      </div>
+      <div class="p-logo-section__item">
+        <a href="/blog/bosch-rexroth-adopts-ubuntu-core-and-snaps-for-app-based-ctrlx-automation-platform">
+          <div class=" lazyloaded" data-noscript="">
+            <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_131,h_53/https://assets.ubuntu.com/v1/156ddbf8-rexroth_logo.svg" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_262,h_106/https://assets.ubuntu.com/v1/156ddbf8-rexroth_logo.svg 2x" alt="" width="131" height="53" loading="lazy">
+          </div>
+        </a>
+      </div>
+      <div class="p-logo-section__item">
+        <a href="/engage/cyberdyne">
+          <div class=" lazyloaded" data-noscript="">
+            <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_158,h_99/https://assets.ubuntu.com/v1/c5ee407e-cyberdyne.png" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_316,h_198/https://assets.ubuntu.com/v1/c5ee407e-cyberdyne.png 2x" alt="" width="158" height="99" loading="lazy" class="p-logo-section__logo">
+          </div>
+        </a>
+      </div>
+      <div class="p-logo-section__item">
+        <a href="/blog/lime-microsystems-and-canonical-announce-limenet-crowdfunding">
+          <div class=" lazyloaded" data-noscript="">
+            <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_162,h_69/https://assets.ubuntu.com/v1/5651e32d-lime.png" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_324,h_138/https://assets.ubuntu.com/v1/5651e32d-lime.png 2x" alt="" width="162" height="69" loading="lazy" class="p-logo-section__logo">
+          </div>
+        </a>
+      </div>
+      <div class="p-logo-section__item">
+        <a href="/engage/domotz-case-study">
+          <div class=" lazyloaded" data-noscript="">
+            <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_162,h_36/https://assets.ubuntu.com/v1/84d82478-domotz.svg" srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_324,h_72/https://assets.ubuntu.com/v1/84d82478-domotz.svg 2x" alt="" width="162" height="36" loading="lazy" class="p-logo-section__logo">
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/docs/migration-guide-to-v4.md
+++ b/templates/docs/migration-guide-to-v4.md
@@ -1,10 +1,10 @@
 ---
 wrapper_template: '_layouts/docs.html'
 context:
-  title: Migrating to Vanilla 4.0
+  title: Migrating to Vanilla 4
 ---
 
-# Vanilla 4.0 migration
+# Vanilla 4 migration
 
 <hr>
 
@@ -136,6 +136,14 @@ In Vanilla 4.0 we remove rounded corners from all components. This change is aut
 The `$border-radius` variable still exists, but it’s value is now `0` and it’s deprecated. It will be removed in the future.
 
 If you are using the rounded corners in any custom styles or components, make sure to remove them.
+
+## Updated logo section
+
+In Vanilla 4.2 we updated the style of logo section component to allow using logos of variable width. This introduced a breaking change for some of the old logo sections that were using images not aligned by design team.
+
+If you have logos that are not aligned properly, you can use the `.has-misaligned-images` class as a workaround to apply some basic styling to them, before you replace images with correctly spaced.
+
+For more information see [the logo section component documentation](/docs/patterns/logo-section#fallback-for-misaligned-logos).
 
 ## New components
 

--- a/templates/docs/patterns/logo-section/index.md
+++ b/templates/docs/patterns/logo-section/index.md
@@ -43,6 +43,14 @@ View example of the logo section pattern with line breaks
 
 <span class="p-status-label--negative">Deprecated</span> The title element within logo section `p-logo-section__title` is deprecated and should not be used. Instead, if needed, use a heading element of an appropriate level based on the context of the page.
 
+## Fallback for misaligned logos
+
+In Vanilla 4.2 we introduced update to logo section component that breaks some old logo sections that were using images not aligned by design team. If you have logos that are not aligned properly, you can use the `.has-misaligned-images` class as a workaround to apply some basic styling to them, before you replace images with correctly spaced.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/logo-section/logo-section-fallback/" class="js-example">
+View example of the logo section pattern with misaligned images
+</a></div>
+
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

Fixes the issue introduced in Vanilla 4.2 where logo section was updated.

If logo section uses images that are not spaced out by design team it may render them in odd sizes (because in new version we switched to variable width keeping the height of logos equal).

This fallback variant introduces a class name that can be used temporary on such old logo sections before they get updated logo images. It will make logos have fixed width again, to avoid size issue. It is meant as temporary fallback to help migrate to latest Vanilla quicker (just by adding the `has-misaligned-images` class without waiting for new logos to be created. Eventually all logos should be updated by visual design team.

## QA

- Open [demo](https://vanilla-framework-4870.demos.haus/docs/examples/patterns/logo-section/logo-section-fallback)
- Remove `has-misaligned-images` class names from example logo sections, see how they would break on site
- Refresh to bring back the fallback classname, make sure logos look ok (they may not be perfectly aligned, but should not look broken)
- Review updated documentation:
  - Component docs: https://vanilla-framework-4870.demos.haus/docs/patterns/logo-section#fallback-for-misaligned-logos
  - Updated migration guide to Vanilla 4: https://vanilla-framework-4870.demos.haus/docs/migration-guide-to-v4#updated-logo-section

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

### BEFORE
<img width="1375" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/438ac353-144d-462d-87cc-7914d48f5ab1">

### AFTER

<img width="1377" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/18f4a97a-594e-4178-8e7b-64dbd43a6e58">

