### PR TITLE
Adjust font-weight of small caps and h5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -110,7 +110,7 @@
   %vf-heading-5 {
     font-size: 1rem;
     font-style: normal;
-    font-weight: 500;
+    font-weight: $font-weight-bold;
     line-height: map-get($line-heights, default-text);
     margin-bottom: map-get($sp-after, p) - map-get($nudges, p);
     margin-top: 0;
@@ -214,6 +214,7 @@
     @extend %default-text;
     font-variant-caps: all-small-caps;
     font-variant-numeric: oldstyle-nums;
+    font-weight: $font-weight-bold;
     letter-spacing: 0.05em;
     margin-bottom: map-get($sp-after, p-small-caps) - map-get($nudges, p);
 

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -214,7 +214,6 @@
     @extend %default-text;
     font-variant-caps: all-small-caps;
     font-variant-numeric: oldstyle-nums;
-    font-weight: $font-weight-bold;
     letter-spacing: 0.05em;
     margin-bottom: map-get($sp-after, p-small-caps) - map-get($nudges, p);
 

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -82,6 +82,7 @@
   // deprecated: .p-text--x-small-capitalised is deprecated, use .p-text--small-caps instead
   .p-text--x-small-capitalised {
     @extend %small-caps-text;
+    font-weight: $font-weight-bold;
   }
 
   //@section Adjusted spacing for headings (or a p) following a paragraph

--- a/scss/_patterns_muted-heading.scss
+++ b/scss/_patterns_muted-heading.scss
@@ -2,5 +2,6 @@
 @mixin vf-p-muted-heading {
   .p-muted-heading {
     @extend %small-caps-text;
+    font-weight: $font-weight-bold;
   }
 }


### PR DESCRIPTION
## Done

- adjust font weight of small caps and h5 to 550


## QA

- Open [demo](insert-demo-url)
- Verify new weight


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
