### PR TITLE
Update publish-on-release.yml

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -77,4 +77,4 @@ jobs:
           fetch-depth: 0
       - name: Push to release branch
         run: |
-          git push --force
+          git push --force origin release

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+  
 jobs:
   build:
     name: Build Vanilla
@@ -67,10 +70,11 @@ jobs:
 
   publish-website:
     name: Publish to the production website
-    needs: [publish-assets]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: release
       - name: Push to release branch  
         run: |
-          git push --force origin release
+          git push --force

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: release
-      - name: Push to release branch  
+          fetch-depth: 0
+      - name: Push to release branch
         run: |
           git push --force


### PR DESCRIPTION
## Done

- Granted Github Actions the write permission to push to `release` branch
- Added `release` ref to the checkout action to set upstream to the release branch automatically

## QA
Real QA can only be run after merging, but here's a demo of the job:
https://github.com/samhotep/codespaces-actions-playground/actions/runs/6162324000/workflow