### PR TITLE
Add paper background support to side navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.4.0
+  features:
+    - component: Side navigation / Paper
+      url: /docs/patterns/navigation#paper
+      status: New
+      notes: We've added a support for paper background for the side navigation (via <code>is-paper</code> class on body element).
 - version: 4.3.0
   features:
     - component: Logo section

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -539,7 +539,7 @@
     .p-side-navigation--raw-html {
       @include vf-side-navigation-raw-html-theme-light;
 
-      &.is-light {
+      &.is-dark {
         @include vf-side-navigation-raw-html-theme-dark;
       }
     }
@@ -723,6 +723,20 @@
     $color-sidenav-list-border: $colors--light-theme--border-low-contrast,
     $color-sidenav-toggle-icon: $colors--light-theme--text-inactive
   );
+
+  .is-paper & {
+    @include vf-side-navigation-theme(
+      $color-sidenav-text-default: $colors--light-theme--text-inactive,
+      $color-sidenav-background-default: $color-paper,
+      $color-sidenav-background-overlay: $colors--light-theme--background-overlay,
+      $color-sidenav-text-active: $colors--light-theme--text-default,
+      $color-sidenav-item-background-active: $colors--paper-theme--background-active,
+      $color-sidenav-item-background-hover: $colors--paper-theme--background-hover,
+      $color-sidenav-item-border-highlight: $colors--light-theme--text-default,
+      $color-sidenav-list-border: $colors--light-theme--border-low-contrast,
+      $color-sidenav-toggle-icon: $colors--light-theme--text-inactive
+    );
+  }
 }
 
 @mixin vf-side-navigation-theme-dark {
@@ -804,6 +818,17 @@
     $color-sidenav-item-border-highlight: $colors--light-theme--text-default,
     $color-sidenav-list-border: $colors--light-theme--border-low-contrast
   );
+
+  .is-paper {
+    @include vf-side-navigation-raw-html-theme(
+      $color-sidenav-text-default: $colors--light-theme--text-inactive,
+      $color-sidenav-text-active: $colors--light-theme--text-default,
+      $color-sidenav-item-background-active: $colors--paper-theme--background-active,
+      $color-sidenav-item-background-hover: $colors--paper-theme--background-hover,
+      $color-sidenav-item-border-highlight: $colors--light-theme--text-default,
+      $color-sidenav-list-border: $colors--light-theme--border-low-contrast
+    );
+  }
 }
 
 @mixin vf-side-navigation-raw-html-theme-dark {

--- a/templates/docs/examples/patterns/side-navigation/_icons.html
+++ b/templates/docs/examples/patterns/side-navigation/_icons.html
@@ -9,7 +9,7 @@
   <!-- dark background color should be changed via color theme variables, inline style is used here for example purposes -->
   {% endif %}
   <nav class="p-side-navigation__drawer" aria-label="Example side navigation with icons"
-    style="background: {% if is_dark %}#003b4e{% else %}#f7f7f7{% endif %}">
+    style="background: {% if is_dark %}#003b4e{% elif is_paper %}transparent{% else %}#f7f7f7{% endif %}">
     <div class="p-side-navigation__drawer-header" style="background: {% if is_dark %}#003b4e{% else %}#f7f7f7{% endif %}">
       <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer-icons">
         Toggle side navigation

--- a/templates/docs/examples/patterns/side-navigation/_icons.html
+++ b/templates/docs/examples/patterns/side-navigation/_icons.html
@@ -9,8 +9,8 @@
   <!-- dark background color should be changed via color theme variables, inline style is used here for example purposes -->
   {% endif %}
   <nav class="p-side-navigation__drawer" aria-label="Example side navigation with icons"
-    style="background: {% if is_dark %}#003b4e{% elif is_paper %}transparent{% else %}#f7f7f7{% endif %}">
-    <div class="p-side-navigation__drawer-header" style="background: {% if is_dark %}#003b4e{% else %}#f7f7f7{% endif %}">
+    style="{% if is_dark %}background: #003b4e;{% elif not is_paper %}background: #f7f7f7{% endif %}">
+    <div class="p-side-navigation__drawer-header" style="background: {% if is_dark %}#003b4e{% elif not is_paper %}#f7f7f7{% endif %}">
       <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer-icons">
         Toggle side navigation
       </a>

--- a/templates/docs/examples/patterns/side-navigation/paper.html
+++ b/templates/docs/examples/patterns/side-navigation/paper.html
@@ -1,0 +1,26 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Side navigation / Paper{% endblock %}
+
+{% block standalone_css %}patterns_side-navigation{% endblock %}
+
+{% set is_paper = True %}
+{% block content %}
+<div class="row">
+  <div class="col-4">
+      {% include "docs/examples/patterns/side-navigation/_default.html" %}
+  </div>
+  <div class="col-4">
+      {% include "docs/examples/patterns/side-navigation/_icons.html" %}
+  </div>
+  <div class="col-4">
+    {% with is_sticky = True %}
+      {% include "docs/examples/patterns/side-navigation/_default.html" %}
+    {% endwith %}
+  </div>
+</div>
+
+<script>
+  {% include "docs/examples/patterns/side-navigation/_example_script.js" %}
+  {% include "docs/examples/patterns/side-navigation/_toggle_script.js" %}
+</script>
+{% endblock %}

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -12,7 +12,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Stylesheet size',
       benchmark: 150000,
-      threshold: 380000,
+      threshold: 430000,
       result: results['total-stylesheet-size'],
     },
     {
@@ -37,13 +37,13 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Identifiers per selectors',
       benchmark: 1.75,
-      threshold: 2.8,
+      threshold: 3.0,
       result: results['identifiers-per-selector'],
     },
     {
       name: 'Specificity per selector',
       benchmark: 15,
-      threshold: 23,
+      threshold: 25,
       result: results['specificity-per-selector'],
     },
     {


### PR DESCRIPTION
## Done

As part one building block of new documentation layout this PR updates side navigation component by adding new paper background colour support to the light theme.

## QA

- Open [demo](https://vanilla-framework-4881.demos.haus/docs/examples/patterns/side-navigation/paper)
- Make sure side navigation looks fine on paper background (check mobile view as well).
  - example contains 3 variants (standard, with icons and sticky)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
