### PR TITLE
Ignore warnings to prevent redirects from failing the build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install linkchecker
         run: sudo pip install LinkChecker
       - name: Check internal links
-        run: linkchecker --ignore-url /search --ignore-url https://res.cloudinary.com --ignore-url q_auto --ignore-url  fl_sanitize --ignore-url  c_fill --ignore-url  e_sharpen --ignore-url  w_[0-9]* --ignore-url  h_[0-9]* http://localhost:${PORT}
+        run: linkchecker --no-warnings --ignore-url /search --ignore-url https://res.cloudinary.com --ignore-url q_auto --ignore-url  fl_sanitize --ignore-url  c_fill --ignore-url  e_sharpen --ignore-url  w_[0-9]* --ignore-url  h_[0-9]* http://localhost:${PORT}
 
   cypress:
     name: Cypress


### PR DESCRIPTION
## Done

Version 10.3 of linkchecker throws warnings on redirects and fails the build (https://linkchecker.github.io/linkchecker/upgrading.html#migrating-from-10-2-to-10-3).

This PR ignores linkchecker redirect warnings to prevent them from failing the CI.

## QA

- Make sure linkchecker CI job passes
