### PR TITLE
New documentation layout

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1,8 +1,16 @@
 - version: 4.4.0
   features:
+    - component: Documentation layout
+      url: /docs/layouts/documentation
+      status: New
+      notes: We've implemented a new full-width documentation layout.
+    - component: Full-width layout
+      url: /docs/layouts/full-width
+      status: Deprecated
+      notes: We've deprecated the full-width layout in favour of the new documentation layout.
     - component: Side navigation / Paper
       url: /docs/patterns/navigation#paper
-      status: New
+      status: Updated
       notes: We've added a support for paper background for the side navigation (via <code>is-paper</code> class on body element).
     - component: Table of contents
       url: /docs/patterns/table-of-contents

--- a/scss/_layouts_docs.scss
+++ b/scss/_layouts_docs.scss
@@ -1,5 +1,5 @@
 @mixin vf-l-docs {
-  $l-documentation-sidebar-width: 15rem;
+  $l-documentation-sidebar-width: 15rem !default;
 
   // we switch to full screen layout (with side navigation fixed to left side)
   // when screen is big enough to fit 12 column grid and side navigation

--- a/scss/_layouts_docs.scss
+++ b/scss/_layouts_docs.scss
@@ -1,0 +1,98 @@
+@mixin vf-l-docs {
+  $l-documentation-sidebar-width: 15rem;
+
+  // we switch to full screen layout (with side navigation fixed to left side)
+  // when screen is big enough to fit 12 column grid and side navigation
+  $breakpoint-full-screen-layout: calc($breakpoint-large + $l-documentation-sidebar-width);
+
+  // root element for the documentation layout
+  .l-docs,
+  // root element for that can be used on a nested container to create a subgrid aligned with the main documentation layout grid
+  .l-docs__subgrid {
+    // container for the site global navigation header
+    .l-docs__header {
+      grid-area: header;
+    }
+
+    // left side container, for side navigation
+    .l-docs__sidebar {
+      grid-area: sidebar;
+    }
+
+    // main content title container
+    // will appear above table of contents on medium screens
+    .l-docs__title {
+      grid-area: title;
+    }
+
+    // metadata container (for table of contents, etc)
+    // will appear between title and content on medium screens
+    // and on the right side on large screens
+    .l-docs__meta {
+      grid-area: meta;
+    }
+
+    // main content container
+    // will appear below table of contents on medium screens
+    .l-docs__main {
+      grid-area: main;
+    }
+
+    // container for site global footer
+    .l-docs__footer {
+      grid-area: footer;
+    }
+  }
+
+  @media (min-width: $breakpoint-large) {
+    .l-docs {
+      display: grid;
+      grid-gap: 0;
+      grid-template-areas:
+        'header  header'
+        'sidebar title'
+        'sidebar meta'
+        'sidebar main'
+        'footer  footer';
+
+      grid-template-columns: $l-documentation-sidebar-width minmax(0, 1fr);
+      grid-template-rows: auto auto auto 1fr auto; // stretch main content to fill the space
+      width: 100%;
+    }
+
+    .l-docs__subgrid {
+      display: grid;
+      grid-template-areas: 'sidebar main meta';
+      grid-template-columns: $l-documentation-sidebar-width minmax(0, 1fr) min-content;
+      width: 100%;
+    }
+  }
+
+  @media (min-width: $breakpoint-full-screen-layout) {
+    .l-docs {
+      grid-template-areas:
+        'header  header header'
+        'sidebar title  meta'
+        'sidebar main   meta'
+        'footer  footer footer';
+
+      grid-template-columns: $l-documentation-sidebar-width minmax(0, 1fr) $l-documentation-sidebar-width;
+      grid-template-rows: auto auto 1fr auto; // stretch main content to fill the space
+
+      .l-docs__content {
+        display: contents;
+      }
+    }
+
+    .l-docs__subgrid {
+      grid-template-columns: $l-documentation-sidebar-width minmax(0, 1fr) $l-documentation-sidebar-width;
+    }
+
+    // on largest screens we want to keep the table of contents sticky
+    .l-docs__meta {
+      align-self: start;
+      position: sticky;
+      top: 0;
+    }
+  }
+}

--- a/scss/_layouts_full-width.scss
+++ b/scss/_layouts_full-width.scss
@@ -1,3 +1,5 @@
+// DEPRECATED
+// .l-full-width is deprecated, use .l-docs and .l-docs__container instead
 @mixin vf-l-full-width {
   $l-full-screen-aside-width: 15rem;
 

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -57,6 +57,7 @@
 
 // Layouts
 @import 'layouts_application';
+@import 'layouts_docs';
 @import 'layouts_full-width';
 @import 'layouts_site';
 @import 'layouts_fluid-breakout';
@@ -147,6 +148,7 @@
 
   // Layouts
   @include vf-l-application;
+  @include vf-l-docs;
   @include vf-l-full-width;
   @include vf-l-site;
   @include vf-l-fluid-breakout;

--- a/templates/docs/examples/layouts/docs.html
+++ b/templates/docs/examples/layouts/docs.html
@@ -1,0 +1,422 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Documentation / Full width{% endblock %}
+
+{% block style %}
+<style>
+  body { margin: 0; }
+</style>
+{% endblock %}
+
+{% set is_paper = True %}
+{% block content %}
+
+
+<div class="l-docs">
+  <div class="l-docs__header">
+    <header id="navigation" class="p-navigation is-dark">
+      <div class="l-docs__subgrid">
+        <div class="l-docs__sidebar">
+          <div class="p-navigation__banner">
+            <div class="p-navigation__tagged-logo">
+              <a class="p-navigation__link" href="#">
+                <div class="p-navigation__logo-tag">
+                  <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="">
+                </div>
+                <span class="p-navigation__logo-title">Ubuntu</span>
+              </a>
+            </div>
+            <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+            <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+          </div>
+        </div>
+        <div class="l-docs__main">
+          <div class="p-navigation__row u-fixed-width">
+            <nav class="p-navigation__nav" aria-label="Example main">
+              <ul class="p-navigation__items">
+                <li class="p-navigation__item">
+                  <a class="p-navigation__link" href="#">Products</a>
+                </li>
+                <li class="p-navigation__item">
+                  <a class="p-navigation__link" href="#">Services</a>
+                </li>
+                <li class="p-navigation__item">
+                  <a class="p-navigation__link" href="#">Partners</a>
+                </li>
+                <li class="p-navigation__item is-selected">
+                  <a class="p-navigation__link" href="#">Docs</a>
+                </li>
+              </ul>
+            </nav>
+          </div>
+        </div>
+      </div>
+    </header>
+    <section id="search-docs" class="p-strip is-bordered is-shallow l-docs__subgrid">
+      <div class="l-docs__sidebar u-hide--medium u-hide--small">
+        <div class="u-fixed-width">
+          <h5 class="u-sv-2">Documentation example</h5>
+        </div>
+      </div>
+      <div class="l-docs__main">
+        <div class="row">
+          <form class="p-search-box u-no-margin--bottom">
+            <input type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="" autocomplete="on"/>
+            <button type="reset" class="p-search-box__reset" name="close"><i class="p-icon--close">Close</i></button>
+            <button type="submit" class="p-search-box__button" name="submitSearch"><i class="p-icon--search">Search</i></button>
+          </form>
+        </div>
+        <!--div class="row grid-demo">
+          <div class="col-1 col-medium-1 col-small-1">
+            <span>.col-1</span>
+          </div>
+          <div class="col-1 col-medium-1 col-small-1">
+            <span>.col-1</span>
+          </div>
+          <div class="col-1 col-medium-1 col-small-1">
+            <span>.col-1</span>
+          </div>
+          <div class="col-1 col-medium-1 col-small-1">
+            <span>.col-1</span>
+          </div>
+          <div class="col-1 col-medium-1 col-small-1 u-hide--small">
+            <span>.col-1</span>
+          </div>
+          <div class="col-1 col-medium-1 col-small-1 u-hide--small">
+            <span>.col-1</span>
+          </div>
+          <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
+            <span>.col-1</span>
+          </div>
+          <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
+            <span>.col-1</span>
+          </div>
+          <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
+            <span>.col-1</span>
+          </div>
+          <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
+            <span>.col-1</span>
+          </div>
+          <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
+            <span>.col-1</span>
+          </div>
+          <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
+            <span>.col-1</span>
+          </div>
+        </div -->
+      </div>
+  </section>
+  </div>
+
+  <aside class="l-docs__sidebar">
+    <nav class="p-side-navigation--raw-html is-sticky" id="drawer" aria-label="Table of contents">
+      <div class="u-hide--large p-strip is-shallow">
+        <div class="u-fixed-width">
+          <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
+            Toggle side navigation
+          </a>
+        </div>
+      </div>
+
+      <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
+
+      <div class="p-side-navigation__drawer">
+        <div class="p-side-navigation__drawer-header">
+          <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+            Toggle side navigation
+          </a>
+        </div>
+        <h3>Side navigation</h3>
+        <ul>
+          <li>
+            <a>First page</a>
+          </li>
+          <li>
+            <a href="#">Second page</a>
+          </li>
+          <li>
+            <a href="#">Third page</a>
+          </li>
+          <li>
+            <strong>Sub section</strong>
+            <ul>
+              <li>
+                <a href="#">Second level link</a>
+              </li>
+              <li>
+                <a class="is-active" href="#">Current page</a>
+              </li>
+              <li>
+                <a href="#">Another second level link</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <a href="#">Last page</a>
+          </li>
+        </ul>
+
+        <ul>
+          <li>
+            <a href="#"><strong>Another group</strong></a>
+          </li>
+          <li>
+            <a href="#">First page</a>
+          </li>
+          <li>
+            <a href="#">Second page</a>
+          </li>
+          <li>
+            <a href="#">Third page</a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  </aside>
+
+  <div class="l-docs__title" id="main-content">
+    <div class="p-section--shallow">
+      <div class="row">
+        <div class="col-12">
+          <h1>Main documentation content</h1>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <aside class="l-docs__meta">
+
+      <aside class="p-table-of-contents">
+        <div class="p-table-of-contents__section">
+          <h4 class="p-table-of-contents__header">On this page:</h4>
+          <nav class="p-table-of-contents__nav" aria-label="Table of contents">
+            <ul class="p-list">
+              <li><a class="p-table-of-contents__link" href="#link1">Install from snap</a></li>
+              <li><a class="p-table-of-contents__link" href="#link2">Initialisation</a></li>
+              <li><a class="p-table-of-contents__link is-active" href="#link3">Configuration verification</a></li>
+              <li><a class="p-table-of-contents__link" href="#link4">Service statuses</a></li>
+            </ul>
+          </nav>
+        </div>
+      </aside>
+
+  </aside>
+
+  <main class="l-docs__main">
+    <!-- div class="p-strip is-shallow">
+      <div class="row grid-demo">
+        <div class="col-1 col-medium-1 col-small-1">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1 col-medium-1 col-small-1">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1 col-medium-1 col-small-1">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1 col-medium-1 col-small-1">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1 col-medium-1 col-small-1 u-hide--small">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1 col-medium-1 col-small-1 u-hide--small">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
+          <span>.col-1</span>
+        </div>
+        <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
+          <span>.col-1</span>
+        </div>
+      </div -->
+      <div class="row">
+        <div class="col-12">
+          <p>Main documentation content block is contained in grid <code>col-9</code>. Any standard base elements or Vanilla components can be used in the documentation pages.</p>
+
+          <h2>Examples</h2>
+
+          <p>Below you can find examples of components commonly used in documentation</p>
+
+          <h3>Code blocks</h3>
+          <pre><code>// Import Vanilla framework
+    @import 'vanilla-framework';
+
+    // Include base Vanilla styles
+    @include vf-base;
+
+    // Include the components you want
+    @include vf-p-buttons;
+    @include vf-p-forms;
+    @include vf-p-links;
+    </code></pre>
+
+          <h3>Lists</h3>
+
+          <ul>
+            <li><a href="#docs/what-is-maas">What is MAAS – and what does it really do for me?</a></li>
+            <li><a href="#docs/maas-example-config">Can you show me an example datacentre using MAAS?</a></li>
+            <li><a href="#docs/what-is-maas#heading--how-maas-works">How does MAAS work, in detail?</a></li>
+            <li><a href="#docs/concepts-and-terms">What concepts might I need to understand before starting?</a></li>
+            <li><a href="#docs/explore-maas">Can I just install it and try it for myself?</a></li>
+          </ul>
+
+          <h3>Tables</h3>
+          <table aria-label="MAAS table example">
+            <thead>
+              <tr>
+                <th>Interface name</th>
+                <th>Description</th>
+                <th>Auto-connect</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><a href="#docs/account-control-interface">account-control</a></td>
+                <td>add/remove user accounts or change passwords</td>
+                <td>no</td>
+              </tr>
+              <tr>
+                <td><a href="#docs/accounts-service-interface">accounts-service</a></td>
+                <td>allows communication with the accounts service</td>
+                <td>no</td>
+              </tr>
+              <tr>
+                <td><a href="#docs/adb-support-interface">adb-support</a></td>
+                <td>allows operating as Android Debug Bridge service</td>
+                <td>no</td>
+              </tr>
+              <tr>
+                <td><a href="#docs/alsa-interface">alsa</a></td>
+                <td>play or record sound</td>
+                <td>no</td>
+              </tr>
+              <tr>
+                <td><a href="#docs/appstream-metadata-interface">appstream-metadata</a></td>
+                <td>allows access to AppStream metadata</td>
+                <td>no</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h3>Notifications</h3>
+
+          <div class="p-notification">
+            <p class="p-notification__content">
+              In versions prior to <code>v.2.6.1</code> the <code>add-cloud</code> command only operates locally (there is no <code>--local</code> option).
+            </p>
+          </div>
+
+          <div class="p-notification--caution">
+            <p class="p-notification__content">
+              Multi-cloud functionality via <code>add-cloud</code> (not <code>add-k8s</code>) is available as “early access” and requires the use of a feature flag. Once the controller
+              is created, you can enable it with: <code>juju controller-config features="[multi-cloud]"</code>
+            </p>
+          </div>
+
+          <div class="p-notification--information">
+            <p class="p-notification__content">
+              Last updated 29 days ago.
+              <a href="#clouds/1100">Help improve this document in the forum</a>.
+            </p>
+          </div>
+
+          <h3>Grid</h3>
+
+          <p>Main documentation content block is contained in grid <code>col-9</code>.</p>
+
+          <p>For two columns split use two <code>col-4</code> columns.</p>
+          <div class="row">
+            <div class="col-4">
+              <ul class="p-list">
+                <li class="p-list__item"><a href="#docs/whats-new-2-6">New features in 2.6&nbsp;›</a></li>
+                <li class="p-list__item"><a href="#docs/clouds">Clouds&nbsp;›</a></li>
+                <li class="p-list__item"><a href="#docs/vsphere-cloud">Using VMware vSphere with Juju&nbsp;›</a></li>
+                <li class="p-list__item"><a href="#docs/k8s-cloud">Using Kubernetes with Juju&nbsp;›</a></li>
+                <li class="p-list__item"><a href="#docs/k8s-charms-tutorial">Understanding Kubernetes charms&nbsp;›</a></li>
+              </ul>
+            </div>
+            <div class="col-4">
+              <ul class="p-list">
+                <li class="p-list__item"><a href="#docs/migrating-models">Migrating models&nbsp;›</a></li>
+                <li class="p-list__item"><a href="#docs/bundle-reference">Bundle reference&nbsp;›</a></li>
+                <li class="p-list__item"><a href="#docs/microk8s-cloud">Using Juju with MicroK8s&nbsp;›</a></li>
+                <li class="p-list__item"><a href="#docs/removing-things">Removing things&nbsp;›</a></li>
+                <li class="p-list__item"><a href="#docs/controller-logins">Controller logins&nbsp;›</a></li>
+              </ul>
+            </div>
+          </div>
+
+          <p>For three columns split use three <code>col-3</code> columns.</p>
+
+          <div class="row">
+            <div class="col-3">
+              <ul class="p-list--divided">
+                <li class="p-list__item"><a href="#docs/settings/animation-settings">Animation</a></li>
+                <li class="p-list__item"><a href="#docs/settings/assets-settings">Assets</a></li>
+                <li class="p-list__item"><a href="#docs/settings/breakpoint-settings">Breakpoint</a></li>
+              </ul>
+            </div>
+            <div class="col-3">
+              <ul class="p-list--divided">
+                <li class="p-list__item"><a href="#docs/settings/color-settings">Color</a></li>
+                <li class="p-list__item"><a href="#docs/settings/font-settings">Font</a></li>
+                <li class="p-list__item"><a href="#docs/settings/layout-settings">Layout</a></li>
+              </ul>
+            </div>
+            <div class="col-3">
+              <ul class="p-list--divided">
+                <li class="p-list__item"><a href="#docs/settings/placeholder-settings">Placeholder</a></li>
+                <li class="p-list__item"><a href="#docs/settings/spacing-settings">Spacing</a></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </main>
+
+  <div class="l-docs__footer">
+    <footer class="p-strip--dark l-docs__subgrid">
+      <div class="l-docs__sidebar">
+        <p style="padding-left: 1.5rem">© 2020 Canonical Ltd.</p>
+      </div>
+      <div class="l-docs__main">
+        <nav class="row" aria-label="Footer">
+          <div class="has-cookie">
+            <p><a class="is-dark" href="#">Ubuntu</a> and <a class="is-dark" href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>
+            <ul class="p-inline-list--middot">
+              <li class="p-inline-list__item">
+                <a class="is-dark" href="#"><small>Legal information</small></a>
+              </li>
+              <li class="p-inline-list__item">
+                <a class="is-dark" href="#"><small>Report a bug on this site</small></a>
+              </li>
+            </ul>
+            <span class="u-off-screen"><a href="#">Go to the top of the page</a></span>
+          </div>
+        </nav>
+      </div>
+    </footer>
+  </div>
+</div>
+
+
+
+<script>
+  {% include "docs/examples/patterns/side-navigation/_example_script.js" %}
+  {% include "docs/examples/patterns/side-navigation/_toggle_script.js" %}
+</script>
+{% endblock %}

--- a/templates/docs/examples/layouts/docs.html
+++ b/templates/docs/examples/layouts/docs.html
@@ -185,19 +185,19 @@
 
   <aside class="l-docs__meta">
 
-      <aside class="p-table-of-contents">
-        <div class="p-table-of-contents__section">
-          <h4 class="p-table-of-contents__header">On this page:</h4>
-          <nav class="p-table-of-contents__nav" aria-label="Table of contents">
-            <ul class="p-list">
-              <li><a class="p-table-of-contents__link" href="#link1">Install from snap</a></li>
-              <li><a class="p-table-of-contents__link" href="#link2">Initialisation</a></li>
-              <li><a class="p-table-of-contents__link is-active" href="#link3">Configuration verification</a></li>
-              <li><a class="p-table-of-contents__link" href="#link4">Service statuses</a></li>
-            </ul>
-          </nav>
-        </div>
-      </aside>
+    <aside class="p-table-of-contents">
+      <div class="p-table-of-contents__section">
+        <h2 class="p-table-of-contents__header">On this page</h2>
+        <nav class="p-table-of-contents__nav" aria-label="Table of contents">
+          <ul class="p-table-of-contents__list">
+            <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#link1">Install from snap</a></li>
+            <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#link2">Initialisation</a></li>
+            <li class="p-table-of-contents__item"><a class="p-table-of-contents__link is-active" href="#link3">Configuration verification</a></li>
+            <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#link4">Service statuses</a></li>
+          </ul>
+        </nav>
+      </div>
+    </aside>
 
   </aside>
 

--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Documentation{% endblock %}
+{% block title %}Documentation / Brochure{% endblock %}
 
 {% block style %}
 <style>

--- a/templates/docs/layouts/documentation-brochure.md
+++ b/templates/docs/layouts/documentation-brochure.md
@@ -1,0 +1,95 @@
+---
+wrapper_template: '_layouts/docs.html'
+context:
+  title: Documentation | Layouts
+---
+
+# Documentation layout
+
+<hr>
+
+<div class="p-notification--caution">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Legacy</h5>
+    <p class="p-notification__message">Please note that this is a documentation for a legacy documentation layout using our brochure site grid. <a href="/docs/layouts/documentation">New documentation layout</a> is documented separately.</p>
+  </div>
+</div>
+
+## Structure
+
+The documentation layout is built using Vanilla grid classes and common components. It consists of 3 horizontal areas that span the entire fixed width of the grid: header, content, footer.
+
+![Documentation layout structure](https://assets.ubuntu.com/v1/2725610a-Documentation+layout+text+to+curves.svg)
+
+At the large breakpoint, the content area is further divided into an aside (3 columns) and a main content area (9 columns).
+
+At smaller breakpoints, the aside is moved off-screen and shown / hidden using a toggle.
+
+### Header
+
+Place the [navigation component](/docs/patterns/navigation#global-navigation) and any other full width elements in the header. This could include a strip with a search, a hero element, etc.
+
+Style and contents of the documentation main navigation should be consistent with rest of the site.
+
+#### Search
+
+Documentation pages may have an optional search box in the main navigation.
+
+Alternatively, a search can be added in a full-width area under the top navigation, but above the aside and main content in a [strip component](/docs/patterns/strip) with grid row inside. The specific styling of the strip can be customised to match the site branding or other design requirements.
+
+### Content area
+
+The content area is implemented as a regular strip (`.p-strip`) with a grid row (`.row`) inside. Within the standard Vanilla 12 column grid, 3 of the columns are reserved for the side navigation (`.col-3`) with the rest of the row width (9 columns, `.col-9`) is dedicated to the main documentation content.
+
+The aside area should contain the [side navigation component](/docs/patterns/navigation#side-navigation) with a list of all documentation pages. Grouping and nesting of navigation items should be used to build the logical structure of the documentation navigation. The side navigation component has built-in responsive functionality which makes it appear / go off-screen using a toggle.
+
+If the contents of the side navigation are generated in a way that doesn't provide the specific class names required by Vanilla, use a [raw HTML variant of the pattern](/docs/patterns/navigation#raw-html) to style the basic HTML lists of links.
+
+The main content area is placed in a `col-9` grid container. Note that the number of columns available to use by content inside this container is equal to the number of columns the container spans. For the main content this means 9 available columns.
+
+A visualisation of the grid, and how to nest different layouts inside the main content container:
+
+<div class="grid-demo">
+  <div class="row">
+    <div class="col-1">.col-1</div>
+    <div class="col-1">.col-1</div>
+    <div class="col-1">.col-1</div>
+    <div class="col-1">.col-1</div>
+    <div class="col-1">.col-1</div>
+    <div class="col-1">.col-1</div>
+    <div class="col-1">.col-1</div>
+    <div class="col-1">.col-1</div>
+    <div class="col-1">.col-1</div>
+  </div>
+</div>
+
+To split the main content area into 3 parts, use `col-3`:
+
+<div class="grid-demo">
+  <div class="row">
+    <div class="col-3">.col-3</div>
+    <div class="col-3">.col-3</div>
+    <div class="col-3">.col-3</div>
+  </div>
+</div>
+
+To split the main content into 2 parts, use `col-4`:
+
+<div class="grid-demo">
+  <div class="row">
+    <div class="col-4">.col-4</div>
+    <div class="col-4">.col-4</div>
+  </div>
+</div>
+
+### Footer
+
+The footer is built using a [strip component](/docs/patterns/strip).
+
+## Example
+
+<div class="embedded-example"><a href="/docs/examples/layouts/documentation/" class="js-example" data-height="600">
+View an example of the documentation layout
+</a></div>
+
+[View full screen example of the documentation layout](/docs/examples/layouts/documentation/).

--- a/templates/docs/layouts/documentation.md
+++ b/templates/docs/layouts/documentation.md
@@ -10,79 +10,54 @@ context:
 
 ## Structure
 
-The documentation layout is built using Vanilla grid classes and common components. It consists of 3 horizontal areas that span the entire fixed width of the grid: header, content, footer.
+The documentation layout utilises the whole width of the screen reserving some space on the left for side bar (with side navigation) and space on the right for additional meta data (usually table of contents). The central main area of the screen is utilising the whole width of 12 column Vanilla grid for main documentation content.
 
-![Documentation layout structure](https://assets.ubuntu.com/v1/2725610a-Documentation+layout+text+to+curves.svg)
+![Documentation layout structure with table of contents below the title](https://assets.ubuntu.com/v1/e25d272e-vanilla-docs-layout-structure-large.png)
 
-At the large breakpoint, the content area is further divided into an aside (3 columns) and a main content area (9 columns).
+This area is split between a title on the top and content below it, to allow placing the table of contents in between on smaller screen sizes.
 
-At smaller breakpoints, the aside is moved off-screen and shown / hidden using a toggle.
+![Documentation layout structure on large screens with table of contents on the right](https://assets.ubuntu.com/v1/4f55cec2-vanilla-docs-layout-structure-medium.png)
+
+At smaller breakpoints, the sidebar is moved off-screen and shown / hidden using a toggle button.
 
 ### Header
 
-Place the [navigation component](/docs/patterns/navigation#global-navigation) and any other full width elements in the header. This could include a strip with a search, a hero element, etc.
+The header area (`.l-docs__header`) is meant to contain main top navigation of the site and any other full width elements to be shown above the documentation content, such as search.
 
-Style and contents of the documentation main navigation should be consistent with rest of the site.
+The elements within the header area need to use `.l-docs__subgrid` to align with the main content area.
 
-#### Search
+### Sidebar
 
-Documentation pages may have an optional search box in the main navigation.
+The sidebar area (`.l-docs__sidebar`) is rendered at the left side of the screen with a predefined fixed width. It's main purpose is to contain the [side navigation component](/docs/patterns/navigation#side-navigation) with a list of all documentation pages. The side navigation component has built-in responsive functionality which makes it appear / go off-screen using a toggle.
 
-Alternatively, a search can be added in a full-width area under the top navigation, but above the aside and main content in a [strip component](/docs/patterns/strip) with grid row inside. The specific styling of the strip can be customised to match the site branding or other design requirements.
+### Title
 
-### Content area
+The title area (`.l-docs__title`) is rendered at the top of the main content area. It's main purpose is to contain the title of the documentation page. It's separated from the content to allow placing the table of contents in between on smaller screen sizes.
 
-The content area is implemented as a regular strip (`.p-strip`) with a grid row (`.row`) inside. Within the standard Vanilla 12 column grid, 3 of the columns are reserved for the side navigation (`.col-3`) with the rest of the row width (9 columns, `.col-9`) is dedicated to the main documentation content.
+### Main content
 
-The aside area should contain the [side navigation component](/docs/patterns/navigation#side-navigation) with a list of all documentation pages. Grouping and nesting of navigation items should be used to build the logical structure of the documentation navigation. The side navigation component has built-in responsive functionality which makes it appear / go off-screen using a toggle.
+The main content area (`.l-docs__main`) is rendered in the central part of the screen. It's main purpose is to contain the main documentation content. It's separated from the title to allow placing the table of contents in between on smaller screen sizes.
 
-If the contents of the side navigation are generated in a way that doesn't provide the specific class names required by Vanilla, use a [raw HTML variant of the pattern](/docs/patterns/navigation#raw-html) to style the basic HTML lists of links.
+### Meta data
 
-The main content area is placed in a `col-9` grid container. Note that the number of columns available to use by content inside this container is equal to the number of columns the container spans. For the main content this means 9 available columns.
+The meta data area (`.l-docs__meta`) is rendered at the right side of the screen with a predefined fixed width. It's main purpose is to contain the [table of contents](/docs/patterns/table-of-contents) component with a list of all sections of the documentation page.
 
-A visualisation of the grid, and how to nest different layouts inside the main content container:
-
-<div class="grid-demo">
-  <div class="row">
-    <div class="col-1">.col-1</div>
-    <div class="col-1">.col-1</div>
-    <div class="col-1">.col-1</div>
-    <div class="col-1">.col-1</div>
-    <div class="col-1">.col-1</div>
-    <div class="col-1">.col-1</div>
-    <div class="col-1">.col-1</div>
-    <div class="col-1">.col-1</div>
-    <div class="col-1">.col-1</div>
-  </div>
-</div>
-
-To split the main content area into 3 parts, use `col-3`:
-
-<div class="grid-demo">
-  <div class="row">
-    <div class="col-3">.col-3</div>
-    <div class="col-3">.col-3</div>
-    <div class="col-3">.col-3</div>
-  </div>
-</div>
-
-To split the main content into 2 parts, use `col-4`:
-
-<div class="grid-demo">
-  <div class="row">
-    <div class="col-4">.col-4</div>
-    <div class="col-4">.col-4</div>
-  </div>
-</div>
+When there is not enough space on the screen to render this area on right side of the screen, it's moved below the title area.
 
 ### Footer
 
-The footer is built using a [strip component](/docs/patterns/strip).
+The footer (`.l-docs__footer`) is rendered full width below the other areas and is meant to contain the site footer.
+
+The elements within the footer area need to use `.l-docs__subgrid` to align with the main content area.
 
 ## Example
 
-<div class="embedded-example"><a href="/docs/examples/layouts/documentation/" class="js-example" data-height="600">
+<div class="embedded-example"><a href="/docs/examples/layouts/docs/" class="js-example" data-height="600">
 View an example of the documentation layout
 </a></div>
 
-[View full screen example of the documentation layout](/docs/examples/layouts/documentation/).
+[View full screen example of the documentation layout](/docs/examples/layouts/docs/).
+
+## Legacy brochure site documentation layout
+
+For reference, you can check the [documentation of the legacy brochure site documentation layout](/docs/layouts/documentation-brochure) using existing 12 column grid and side navigation component.

--- a/templates/docs/layouts/full-width.md
+++ b/templates/docs/layouts/full-width.md
@@ -6,12 +6,11 @@ context:
 
 # Full-width site layout
 
-<div class="p-notification--caution">
+<div class="p-notification--negative">
   <div class="p-notification__content">
-    <h5 class="p-notification__title">Experimental</h5>
+    <h5 class="p-notification__title">Deprecated</h5>
     <p class="p-notification__message">
-      The full-width layout is currently considered as experimental and used only internally by Vanilla and Design sites.<br>
-      We may introduce breaking changes to it without major release.
+      The full-width layout was implemented as a proof of concept, but is now deprecated in favour of the new <a href="/docs/layouts/documentation">documentation layout</a>.
     </p>
   </div>
 </div>


### PR DESCRIPTION
## Done

Adds new full-width documentation layout to Vanilla.

Fixes [WD-6054](https://warthogs.atlassian.net/browse/WD-6054)

## QA

- Open [demo](https://vanilla-framework-4886.demos.haus/docs/examples/layouts/docs)
- QA an example of the new docs layout, check on different screen sizes
  - https://vanilla-framework-4886.demos.haus/docs/examples/layouts/docs
- Review updated documentation:
  - Documentation layout docs: https://vanilla-framework-4886.demos.haus/docs/layouts/documentation

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1890" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/af386fa7-310c-4c0a-8c12-3048a8539617">


[WD-6054]: https://warthogs.atlassian.net/browse/WD-6054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ