### PR TITLE
Use dark search in the top navbar

### DIFF
--- a/templates/_layouts/_header.html
+++ b/templates/_layouts/_header.html
@@ -42,7 +42,7 @@
           </li>
         </ul>
         <div class="p-navigation__search">
-          <form class="p-search-box" action="/docs/search">
+          <form class="p-search-box is-dark" action="/docs/search">
             <input type="search" id="search-docs" class="p-search-box__input" name="q" {% if query %}value="{{ query }}"{% endif %} placeholder="Search the docs" title="Search the documentation"  autocomplete="on" aria-label="Search the docs" required />
             <button type="reset" id="search-docs-reset" class="p-search-box__reset u-no-margin--right" name="close"><i class="p-icon--close">Clear input</i></button>
             <button type="submit" class="p-search-box__button" name="submit"><i class="p-icon--search">Submit</i></button>


### PR DESCRIPTION
## Done

Uses dark theme of search box in the (dark) top navigation.

Workaround for #4887 - while it "fixes" the issue on the Vanilla site, ideally it needs to be fixed in search box component so it doesn't require the dark class name to not be broken.

## QA

- Open [demo](https://vanilla-framework-4888.demos.haus/)
- Open search, type something, make sure it looks OK
- Check both in Chrome and Firefox
