### PR TITLE
Fixed minor typos for Inline Radio and Checkbox docs

### DIFF
--- a/templates/docs/examples/patterns/forms/_checkbox-inline.html
+++ b/templates/docs/examples/patterns/forms/_checkbox-inline.html
@@ -3,7 +3,7 @@
     <input type="checkbox" class="p-checkbox__input" aria-labelledby="inlineCheckbox1label"/>
     <span class="p-checkbox__label" id="inlineCheckbox1label">.p-checkbox--inline</span>
   </label>
-  alonside some text
+  alongside some text
 </p>
 
 <table aria-label="Checkbox in table example">

--- a/templates/docs/examples/patterns/forms/_radio-inline.html
+++ b/templates/docs/examples/patterns/forms/_radio-inline.html
@@ -3,7 +3,7 @@
     <input type="radio" class="p-radio__input" name="radioPattern" aria-labelledby="inlineRadioExample1"/>
     <span class="p-radio__label" id="inlineRadioExample1">.p-radio--inline</span>
   </label>
-  alonside some text
+  alongside some text
 </p>
 
 <table aria-label="Radio button in table example">


### PR DESCRIPTION
## Done

* Fixed documentation typos for Forms/Radio and Forms/Checkbox inline

## Screenshots
<img width="485" alt="Screenshot 2023-10-13 at 12 01 46 PM" src="https://github.com/canonical/vanilla-framework/assets/62298176/8e55cdc8-6e92-43a4-a4d4-9388f1ccdce8">

<img width="358" alt="Screenshot 2023-10-13 at 12 01 55 PM" src="https://github.com/canonical/vanilla-framework/assets/62298176/410cf850-f4ba-4c50-b8b2-ecf7da572ac4">


