### PR TITLE
Sticky container for docs layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.5.0
+  features:
+    - component: Documentation layout / Sticky container
+      url: /docs/layouts/documentation
+      status: New
+      notes: We improved the support for sticky and scrollable table of contents in documentation layout.
 - version: 4.4.0
   features:
     - component: Documentation layout

--- a/scss/_layouts_docs.scss
+++ b/scss/_layouts_docs.scss
@@ -89,8 +89,9 @@
     }
 
     // on largest screens we want to keep the table of contents sticky
-    .l-docs__meta {
-      align-self: start;
+    .l-docs__sticky-container {
+      max-height: 100vh;
+      overflow-y: auto;
       position: sticky;
       top: 0;
     }

--- a/scss/_patterns_side-navigation-expandable.scss
+++ b/scss/_patterns_side-navigation-expandable.scss
@@ -46,6 +46,7 @@
   .p-side-navigation__expand[aria-expanded='false'] + .p-side-navigation__list {
     height: 0;
     opacity: 0;
+    overflow: hidden;
     transform: translate3d(0, -0.5rem, 0);
     // disable transition on close
     transition-duration: 0s;

--- a/templates/docs/examples/layouts/docs.html
+++ b/templates/docs/examples/layouts/docs.html
@@ -65,44 +65,6 @@
             <button type="submit" class="p-search-box__button" name="submitSearch"><i class="p-icon--search">Search</i></button>
           </form>
         </div>
-        <!--div class="row grid-demo">
-          <div class="col-1 col-medium-1 col-small-1">
-            <span>.col-1</span>
-          </div>
-          <div class="col-1 col-medium-1 col-small-1">
-            <span>.col-1</span>
-          </div>
-          <div class="col-1 col-medium-1 col-small-1">
-            <span>.col-1</span>
-          </div>
-          <div class="col-1 col-medium-1 col-small-1">
-            <span>.col-1</span>
-          </div>
-          <div class="col-1 col-medium-1 col-small-1 u-hide--small">
-            <span>.col-1</span>
-          </div>
-          <div class="col-1 col-medium-1 col-small-1 u-hide--small">
-            <span>.col-1</span>
-          </div>
-          <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
-            <span>.col-1</span>
-          </div>
-          <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
-            <span>.col-1</span>
-          </div>
-          <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
-            <span>.col-1</span>
-          </div>
-          <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
-            <span>.col-1</span>
-          </div>
-          <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
-            <span>.col-1</span>
-          </div>
-          <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
-            <span>.col-1</span>
-          </div>
-        </div -->
       </div>
   </section>
   </div>
@@ -183,64 +145,25 @@
     </div>
   </div>
 
-  <aside class="l-docs__meta">
-
-    <aside class="p-table-of-contents">
-      <div class="p-table-of-contents__section">
-        <h2 class="p-table-of-contents__header">On this page</h2>
-        <nav class="p-table-of-contents__nav" aria-label="Table of contents">
-          <ul class="p-table-of-contents__list">
-            <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#link1">Install from snap</a></li>
-            <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#link2">Initialisation</a></li>
-            <li class="p-table-of-contents__item"><a class="p-table-of-contents__link is-active" href="#link3">Configuration verification</a></li>
-            <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#link4">Service statuses</a></li>
-          </ul>
-        </nav>
-      </div>
-    </aside>
-
-  </aside>
+  <div class="l-docs__meta">
+    <div class="l-docs__sticky-container">
+      <aside class="p-table-of-contents">
+        <div class="p-table-of-contents__section">
+          <h2 class="p-table-of-contents__header">On this page</h2>
+          <nav class="p-table-of-contents__nav" aria-label="Table of contents">
+            <ul class="p-table-of-contents__list">
+              <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#link1">Install from snap</a></li>
+              <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#link2">Initialisation</a></li>
+              <li class="p-table-of-contents__item"><a class="p-table-of-contents__link is-active" href="#link3">Configuration verification</a></li>
+              <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#link4">Service statuses</a></li>
+            </ul>
+          </nav>
+        </div>
+      </aside>
+    </div>
+  </div>
 
   <main class="l-docs__main">
-    <!-- div class="p-strip is-shallow">
-      <div class="row grid-demo">
-        <div class="col-1 col-medium-1 col-small-1">
-          <span>.col-1</span>
-        </div>
-        <div class="col-1 col-medium-1 col-small-1">
-          <span>.col-1</span>
-        </div>
-        <div class="col-1 col-medium-1 col-small-1">
-          <span>.col-1</span>
-        </div>
-        <div class="col-1 col-medium-1 col-small-1">
-          <span>.col-1</span>
-        </div>
-        <div class="col-1 col-medium-1 col-small-1 u-hide--small">
-          <span>.col-1</span>
-        </div>
-        <div class="col-1 col-medium-1 col-small-1 u-hide--small">
-          <span>.col-1</span>
-        </div>
-        <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
-          <span>.col-1</span>
-        </div>
-        <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
-          <span>.col-1</span>
-        </div>
-        <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
-          <span>.col-1</span>
-        </div>
-        <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
-          <span>.col-1</span>
-        </div>
-        <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
-          <span>.col-1</span>
-        </div>
-        <div class="col-1 col-medium-1 col-small-1 u-hide--medium u-hide--small">
-          <span>.col-1</span>
-        </div>
-      </div -->
       <div class="row">
         <div class="col-12">
           <p>Main documentation content block is contained in grid <code>col-9</code>. Any standard base elements or Vanilla components can be used in the documentation pages.</p>


### PR DESCRIPTION
## Done

- add a sticky container to documentation layout to make table of contents sticky and scrollable
- drive-by: fix overflow in expandable side nav when collapsed

## QA

- Open [demo](https://vanilla-framework-4895.demos.haus/docs/examples/layouts/docs)
- Review docs layout example
  - https://vanilla-framework-4895.demos.haus/docs/examples/layouts/docs
  - make sure table of contents on right is sticky when you scroll
  - adjust window height to make is smaller than the table of contents (or add some items to it in dev tools), make sure you can scroll the table of contents if it doesn't fit on screen

