### PR TITLE
Fixed typo for Button docs

### DIFF
--- a/templates/docs/patterns/buttons/index.md
+++ b/templates/docs/patterns/buttons/index.md
@@ -107,7 +107,7 @@ View example of the processing button pattern
 
 The buttons use Vanilla's light theme by default. There are two ways to switch between the light and the dark themes:
 
-- Override the default by adding a state to `p-putton`: `is-dark` when the default navigation is light, or `is-light` when the default has been changed to dark:
+- Override the default by adding a state to `p-button`: `is-dark` when the default navigation is light, or `is-light` when the default has been changed to dark:
 - Change the default: go to `_settings_themes.scss` and set `$theme-default-p-button` to `dark`
 
 <div class="embedded-example"><a href="/docs/examples/patterns/buttons/dark" class="js-example">


### PR DESCRIPTION
## Done

* Fixed documentation typo for Buttons

## Screenshots

<img width="1150" alt="Screenshot 2023-10-17 at 6 16 57 PM" src="https://github.com/canonical/vanilla-framework/assets/62298176/5b1f782d-8f1c-4d5f-ba0c-d18ddfe39ac5">

