### PR TITLE
Show suru on all screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_suru.scss
+++ b/scss/_patterns_suru.scss
@@ -5,14 +5,8 @@
     aspect-ratio: calc(2216 / 428); // aspect ratio calculated from image dimensions
     background-image: url('#{$assets-path}7f34ade9-website_suru_25.jpg');
     background-size: contain;
-    display: none; // only show suru on large screens
     margin: 0 auto;
     max-width: $grid-max-width;
-
-    // show suru only on large screens
-    @media (min-width: $breakpoint-large) {
-      display: block;
-    }
 
     &.is-dark {
       aspect-ratio: calc(2580 / 501); // aspect ratio calculated from image dimensions


### PR DESCRIPTION
## Done

- Suru component was hidden on smaller screens, now it's visible on all screens.

Fixes #4894 
Fixes [WD-7506](https://warthogs.atlassian.net/browse/WD-7506)

## QA

- Open demo url
- Go to /docs/examples/patterns/suru/default and try resizing the page.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]


[WD-7506]: https://warthogs.atlassian.net/browse/WD-7506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ