### PR TITLE
Add missing white background to sticky panel

### DIFF
--- a/scss/_layouts_application-panels.scss
+++ b/scss/_layouts_application-panels.scss
@@ -18,6 +18,7 @@
   }
 
   .p-panel__header.is-sticky {
+    background: $colors--light-theme--background-default;
     position: sticky;
     top: 0;
     z-index: 1;


### PR DESCRIPTION
## Done

Light mode sticky panels were missing a background, added the light background.

Fixes #4907 
Fixes [WD-7507](https://warthogs.atlassian.net/browse/WD-7507)

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="886" alt="image" src="https://github.com/canonical/vanilla-framework/assets/54525904/6d1e2c38-1f8e-48e5-8ffe-330d3e557ad8">


[WD-7507]: https://warthogs.atlassian.net/browse/WD-7507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ