### PR TITLE
Update implementation tab for tooltips [WD-6188]

### DIFF
--- a/templates/docs/patterns/tooltips/index.md
+++ b/templates/docs/patterns/tooltips/index.md
@@ -6,19 +6,23 @@ context:
 
 Tooltips are text labels that appear when the user hovers over, focuses on, or touches an element on the screen.
 
-They can be used to provide information about concepts/terms/actions that are not self-explanatory or well known.
+Use tooltips to further explain concepts, terms, or actions that are not immediately clear or well known, but are not necessary for users to complete an action.
 
 <div class="p-notification--caution">
   <p class="p-notification__content">
-    <span class="p-notification__title">Avoid:</span>
-    <span class="p-notification__message">Using tooltips to provide instructions or guidance. They shouldn't be used to show rich information including images and formatted text and avoid placing over plain text or other places where they are not discoverable.</span>
+    <span class="p-notification__message">Do not use them for information the user needs, it hides important information from the user. For example, the user should not need to scroll over a tooltip to find out that a button is disabled. </span>
   </p>
 </div>
 
 <div class="p-notification--caution">
   <p class="p-notification__content">
-    <span class="p-notification__title">Avoid:</span>
-    <span class="p-notification__message">Tooltips shouldn't be used on disabled elements, such as buttons. It should be clear to the user why the button is disabled, without the tooltip needing to be revealed first.</span>
+    <span class="p-notification__message">Do not use tooltips for disabled elements, such as buttons. It should be clear to the user why the button is disabled, without the tooltip needing to be revealed first.</span>
+  </p>
+</div>
+
+<div class="p-notification--caution">
+<p class="p-notification__content">
+    <span class="p-notification__message"> Do not use tooltips for rich information (such as images and formatted text). Avoid using them over plain text or other places where users will not be able to find them.</span>
   </p>
 </div>
 

--- a/templates/docs/patterns/tooltips/index.md
+++ b/templates/docs/patterns/tooltips/index.md
@@ -8,23 +8,11 @@ Tooltips are text labels that appear when the user hovers over, focuses on, or t
 
 Use tooltips to further explain concepts, terms, or actions that are not immediately clear or well known, but are not necessary for users to complete an action.
 
-<div class="p-notification--caution">
-  <p class="p-notification__content">
-    <span class="p-notification__message">Do not use them for information the user needs, it hides important information from the user. For example, the user should not need to scroll over a tooltip to find out that a button is disabled. </span>
-  </p>
-</div>
+Do not use them for information the user needs, it hides important information from the user. For example, the user should not need to scroll over a tooltip to find out that a button is disabled.
 
-<div class="p-notification--caution">
-  <p class="p-notification__content">
-    <span class="p-notification__message">Do not use tooltips for disabled elements, such as buttons. It should be clear to the user why the button is disabled, without the tooltip needing to be revealed first.</span>
-  </p>
-</div>
+Do not use tooltips for disabled elements, such as buttons. It should be clear to the user why the button is disabled, without the tooltip needing to be revealed first.
 
-<div class="p-notification--caution">
-<p class="p-notification__content">
-    <span class="p-notification__message"> Do not use tooltips for rich information (such as images and formatted text). Avoid using them over plain text or other places where users will not be able to find them.</span>
-  </p>
-</div>
+Do not use tooltips for rich information (such as images and formatted text). Avoid using them over plain text or other places where users will not be able to find them.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/tooltips/default" class="js-example">
 View example of the tooltips pattern


### PR DESCRIPTION
## Done

- Updated implementation tab according to the copydoc: https://docs.google.com/document/d/1YLEcTVR7wXQAzbNWObsE8VVIIviQvcVfM9AOMoMVSVs/edit

- Omitted the notification title "Avoid" because its grammar did not align well with the copydoc update.

Fixes WD-6188

## QA

- Open [demo](https://vanilla-framework-4913.demos.haus/docs/patterns/tooltips)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1432" alt="image" src="https://github.com/canonical/vanilla-framework/assets/54525904/1fccef01-ba85-4838-8465-8e77c7a16fe6">
