### PR TITLE
feat: contextual menu css position

### DIFF
--- a/scss/_patterns_contextual-menu.scss
+++ b/scss/_patterns_contextual-menu.scss
@@ -16,7 +16,7 @@
     @extend %vf-has-box-shadow;
 
     display: none;
-    margin: 0;
+    margin: 0 0 $input-margin-bottom 0;
     max-width: 21rem;
     min-width: 10rem;
     padding: 0;
@@ -83,6 +83,8 @@
   }
 
   .p-contextual-menu__toggle {
+    // Remove margin bottom for the dropdown menu to be aligned with the toggle
+    margin-bottom: 0;
     // All buttons have a margin right, unless they are a last child.
     // In cases where contextual menu toggle is a button, we do not want it to
     // have a margin, but since it is never the last child in this pattern,

--- a/templates/docs/examples/patterns/contextual-menu/_script.js
+++ b/templates/docs/examples/patterns/contextual-menu/_script.js
@@ -12,10 +12,6 @@ function toggleMenu(element, show, top) {
     element.setAttribute('aria-expanded', show);
     target.setAttribute('aria-hidden', !show);
 
-    if (typeof top !== 'undefined') {
-      target.style.top = top + 'px';
-    }
-
     if (show) {
       target.focus();
     }


### PR DESCRIPTION
## Done

This PR removes the need for using JavaScript for vertical positioning of the contextual menu and will subsequently allow to simplify implementations of this pattern.

- feat: contextual menu css position

## QA

- Open [demo](insert-demo-url)
- Go to /docs/patterns/contextual-menu and ensure all examples are displayed exactly the same as before

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
No visual changes, looks exactly the same way as before. E.g.:
![Google Chrome screenshot 001104@2x](https://github.com/canonical/vanilla-framework/assets/7452681/528e430f-7009-45ad-bdda-84ac3cf20cc1)


## Notes
Somewhat related PR in react-components: https://github.com/canonical/react-components/pull/1000