### PR TITLE
Update links component a11y documentation [WD-6190]

### DIFF
--- a/templates/docs/patterns/links/accessibility.md
+++ b/templates/docs/patterns/links/accessibility.md
@@ -10,14 +10,14 @@ Links are used as navigational elements and can be used on their own or inline w
 
 ## Considerations
 
-This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects.
 
 #### Link text
 
-- As screen reader users can choose to read link text in isolation, avoid using non descriptive text like “Read more”, “Learn more”, “Click here” etc. Out of context, it isn’t obvious where these links take you.
-- Use unique link text where possible. Speech recognition software users may have a bad experience with duplicated link text.
-- Avoid using anything longer than a full sentence for a link.
-- Use judgement when linking URLs, think about how these may be read out.
+- Avoid using generic link descriptions such as “Read more”, “Learn more”, or “Click here”. Out of context, it isn’t obvious where these links take you. As screen reader users can choose to read link text in isolation.
+- Use unique link text where possible. Screen reader and speech recognition software users may have trouble differentiating links that have the same text but different destination or purpose.
+- Avoid using anything longer than a full sentence for a link, ideally ten words or fewer.
+- Use judgement when linking URLs, think about how these may be read out by a screen reader.
 
 #### Images
 


### PR DESCRIPTION
## Done

- Updated a11y documentation for links component from the copydoc: https://docs.google.com/document/d/1DcYBpmuLKZGLIWR6jgjYfZc1X64d8HtDt9uKMoB0POE/edit

Fixes [list issues/bugs if needed]

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
