### PR TITLE
Fix margin in brochure example

### DIFF
--- a/templates/docs/examples/brochure/hero-75-offset.html
+++ b/templates/docs/examples/brochure/hero-75-offset.html
@@ -11,7 +11,7 @@
     <div class="row--25-75 is-split-on-medium">
         <div class="col">
             <div class="p-section">
-                <h1>H1: 3-5 words</h1>
+                <h1 class="u-no-margin--bottom">H1: 3-5 words</h1>
                 <p class="p-heading--2">H2: 5-15 words, up to 3 rows of copy...</p>
             </div>
             <div class="p-section">


### PR DESCRIPTION
## Done

- Added u-no-margin--bottom to the h1 so that it looks like one paragraph with a line break.

Fixes https://github.com/canonical/vanilla-framework/issues/4859

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
