### PR TITLE
Fix grid column reordering off by one err [WD-7580]

### DIFF
--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -144,9 +144,9 @@
 
   // column reordering
   $offsets: (
-    (small, 0, $threshold-4-6-col, $grid-columns-small - 1),
-    (medium, $threshold-4-6-col, $threshold-6-12-col, $grid-columns-medium - 1),
-    (large, $threshold-6-12-col, false, $grid-columns - 1)
+    (small, 0, $threshold-4-6-col, $grid-columns-small),
+    (medium, $threshold-4-6-col, $threshold-6-12-col, $grid-columns-medium),
+    (large, $threshold-6-12-col, false, $grid-columns)
   );
 
   @each $label, $breakpoint-min, $breakpoint-reset, $col-count in $offsets {


### PR DESCRIPTION
## Done

- Remove off by one that was preventing `col-start-*` classes work up to 11, not 12.

Fixes #4808 

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1448" alt="Screenshot 2023-11-27 at 7 30 56 PM" src="https://github.com/canonical/vanilla-framework/assets/54525904/0c48aed5-2c7e-470f-ac72-99dd03d7ffb3">
