### PR TITLE
Fix u-show not working with list-items

### DIFF
--- a/scss/_utilities_show.scss
+++ b/scss/_utilities_show.scss
@@ -26,4 +26,28 @@
       }
     }
   }
+
+  // stylelint-disable selector-max-type
+  li.u-show {
+    display: list-item !important;
+
+    &--small {
+      @media (max-width: $breakpoint-small - 1) {
+        display: list-item !important;
+      }
+    }
+
+    &--medium {
+      @media (min-width: $breakpoint-small) and (max-width: $breakpoint-large - 1) {
+        display: list-item !important;
+      }
+    }
+
+    &--large {
+      @media (min-width: $breakpoint-large) {
+        display: list-item !important;
+      }
+    }
+  }
+  // stylelint-enable selector-max-type
 }


### PR DESCRIPTION
## Done

- Added `display: list-item` specifically for `li` on `u-show` class.

Fixes https://github.com/canonical/vanilla-framework/issues/4769

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
