### PR TITLE
Add more space between logo tag and text

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -282,7 +282,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     .p-navigation__link {
       @extend %navigation-link;
 
-      padding-left: calc($sph--x-large + 0.19rem);
+      padding-left: calc($sph--x-large + 0.19rem); // additional padding added to align better with logos as originally designed in SVG
 
       &:hover {
         background-color: transparent !important;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -282,7 +282,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     .p-navigation__link {
       @extend %navigation-link;
 
-      padding-left: $sph--x-large;
+      padding-left: calc($sph--x-large + 0.19rem);
 
       &:hover {
         background-color: transparent !important;


### PR DESCRIPTION
## Done

- Added 0.19rem (~3px) space between logo tag and the text besides it (padding-left).

Fixes https://github.com/canonical/vanilla-framework/issues/4789
Fixes  WD-7614

## QA

- Open [demo](https://vanilla-framework-4924.demos.haus/)
- Open navigation example with Ubuntu logo (like https://vanilla-framework-4924.demos.haus/docs/examples/patterns/navigation/default-dark)
- Verify spacing on the logos



## Screenshots

Before: 
<img width="1387" alt="image" src="https://github.com/canonical/vanilla-framework/assets/54525904/2c9beb25-e4b7-4ce6-b104-3e95e1096f9e">

After:
<img width="1449" alt="image" src="https://github.com/canonical/vanilla-framework/assets/54525904/19146183-a278-47a9-a5fb-53f9bbd1e62f">

