### PR TITLE
Adjust spacing between heading groups

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -8,6 +8,10 @@
       url: /docs/patterns/grid#responsive-5050-and-2575
       status: Removed
       notes: We are removing the <code>is-split-on-medium</code> class name as same behaviour is now implemented in `row--25-75` with introduction of the responsive variants <code>row--25-75-on-medium</code> and <code>row--25-75-on-large</code>.
+    - component: Headings
+      url: /docs/base/typography
+      status: Updated
+      notes: We've adjusted the spacing between headings of the same size when they follow one another.
 - version: 4.5.0
   features:
     - component: Documentation layout / Sticky container

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -86,35 +86,21 @@
     &.u-no-margin--bottom {
       @extend %u-no-margin--bottom--h3;
     }
+
+    & + & {
+      // move it up under the heading above by the amoung of bottom margin + top padding
+      margin-top: calc(-1 * map-get($sp-after, h3-mobile));
+
+      @media (min-width: $breakpoint-heading-threshold) {
+        margin-top: calc(-1 * map-get($sp-after, h3));
+      }
+    }
   }
 
   %vf-heading-4 {
     @extend %vf-heading--common;
-    @extend %vf-is-accent;
-
-    font-size: #{map-get($font-sizes, h4-mobile)}rem;
+    @extend %vf-heading-3;
     font-weight: 275; // custom font weight adjusted for h4
-    line-height: map-get($line-heights, h4-mobile);
-    margin-bottom: map-get($sp-after, h4-mobile) - map-get($nudges, h4-mobile);
-    padding-top: map-get($nudges, h4-mobile);
-
-    @media (min-width: $breakpoint-heading-threshold) {
-      font-size: #{map-get($font-sizes, h4)}rem;
-      line-height: map-get($line-heights, h4);
-      margin-bottom: map-get($sp-after, h4) - map-get($nudges, h4);
-      padding-top: map-get($nudges, h4);
-    }
-
-    @if ($increase-font-size-on-larger-screens) {
-      @media (min-width: $breakpoint-x-large) {
-        margin-bottom: map-get($sp-after, h4) - map-get($nudges, h4-large);
-        padding-top: map-get($nudges, h4-large);
-      }
-    }
-
-    &.u-no-margin--bottom {
-      @extend %u-no-margin--bottom--h4;
-    }
   }
 
   %vf-heading-5 {
@@ -129,26 +115,24 @@
     &.u-no-margin--bottom {
       @extend %u-no-margin--bottom--default-text;
     }
+
+    & + & {
+      // move it up under the heading above by the amoung of bottom margin + top padding
+      margin-top: calc(-1 * map-get($sp-after, p));
+    }
   }
 
   %vf-heading-6 {
     @extend %vf-heading--common;
+    @extend %vf-heading-5;
 
-    font-size: 1rem;
     font-style: italic;
     font-weight: $font-weight-regular-text;
-    line-height: map-get($line-heights, default-text);
-    margin-bottom: map-get($sp-after, p) - map-get($nudges, p);
-    padding-top: map-get($nudges, h6);
 
     @if ($increase-font-size-on-larger-screens) {
       @media (min-width: $breakpoint-x-large) {
         padding-top: map-get($nudges, h6-large);
       }
-    }
-
-    &.u-no-margin--bottom {
-      @extend %u-no-margin--bottom--default-text;
     }
   }
 

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -5,17 +5,21 @@
     }
   }
 
+  %vf-heading--common {
+    font-style: normal;
+    margin-top: 0;
+    max-width: $text-max-width;
+  }
+
   //@section Heading styling in placeholders
-  %vf-heading-2 {
+  %vf-heading-1 {
+    @extend %vf-heading--common;
     @extend %vf-is-accent;
 
     font-size: #{map-get($font-sizes, h2-mobile)}rem;
-    font-style: normal;
-    font-weight: 180;
+    font-weight: $font-weight-bold;
     line-height: map-get($line-heights, h2-mobile);
     margin-bottom: map-get($sp-after, h2-mobile) - map-get($nudges, h2-mobile);
-    margin-top: 0;
-    max-width: $text-max-width;
     padding-top: map-get($nudges, h2-mobile);
 
     @media (min-width: $breakpoint-heading-threshold) {
@@ -30,16 +34,28 @@
     }
   }
 
-  %vf-heading-1 {
-    @extend %vf-heading-2;
-    font-weight: 550;
+  %vf-heading-2 {
+    @extend %vf-heading--common;
+    @extend %vf-heading-1;
+    font-weight: 180; // custom font weight adjusted for h2
+
+    h1 + &,
+    .p-heading--1 + & {
+      // move it up under the heading above by the amoung of bottom margin + top padding
+      margin-top: calc(-1 * map-get($sp-after, h2-mobile));
+
+      @media (min-width: $breakpoint-heading-threshold) {
+        margin-top: calc(-1 * map-get($sp-after, h2));
+      }
+    }
   }
 
   %vf-heading-display {
+    @extend %vf-heading--common;
     @extend %vf-heading-2;
 
     font-size: #{map-get($font-sizes, display-mobile)}rem;
-    font-weight: 100;
+    font-weight: $font-weight-display-heading;
     line-height: map-get($line-heights, display-mobile);
     margin-bottom: map-get($sp-after, display-mobile) - map-get($nudges, display-mobile);
     padding-top: map-get($nudges, display-mobile);
@@ -53,15 +69,13 @@
   }
 
   %vf-heading-3 {
+    @extend %vf-heading--common;
     @extend %vf-is-accent;
 
     font-size: #{map-get($font-sizes, h3-mobile)}rem;
-    font-style: normal;
-    font-weight: 550;
+    font-weight: $font-weight-bold;
     line-height: map-get($line-heights, h3-mobile);
     margin-bottom: map-get($sp-after, h3-mobile) - map-get($nudges, h3-mobile);
-    margin-top: 0;
-    max-width: $text-max-width;
     padding-top: map-get($nudges, h3-mobile);
 
     @media (min-width: $breakpoint-heading-threshold) {
@@ -77,15 +91,13 @@
   }
 
   %vf-heading-4 {
+    @extend %vf-heading--common;
     @extend %vf-is-accent;
 
     font-size: #{map-get($font-sizes, h4-mobile)}rem;
-    font-style: normal;
-    font-weight: 275;
+    font-weight: 275; // custom font weight adjusted for h4
     line-height: map-get($line-heights, h4-mobile);
     margin-bottom: map-get($sp-after, h4-mobile) - map-get($nudges, h4-mobile);
-    margin-top: 0;
-    max-width: $text-max-width;
     padding-top: map-get($nudges, h4-mobile);
 
     @media (min-width: $breakpoint-heading-threshold) {
@@ -108,13 +120,12 @@
   }
 
   %vf-heading-5 {
+    @extend %vf-heading--common;
+
     font-size: 1rem;
-    font-style: normal;
     font-weight: $font-weight-bold;
     line-height: map-get($line-heights, default-text);
     margin-bottom: map-get($sp-after, p) - map-get($nudges, p);
-    margin-top: 0;
-    max-width: $text-max-width;
     padding-top: map-get($nudges, p);
 
     &.u-no-margin--bottom {
@@ -123,13 +134,13 @@
   }
 
   %vf-heading-6 {
+    @extend %vf-heading--common;
+
     font-size: 1rem;
     font-style: italic;
     font-weight: $font-weight-regular-text;
     line-height: map-get($line-heights, default-text);
     margin-bottom: map-get($sp-after, p) - map-get($nudges, p);
-    margin-top: 0;
-    max-width: $text-max-width;
     padding-top: map-get($nudges, h6);
 
     @if ($increase-font-size-on-larger-screens) {

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -34,7 +34,7 @@
     }
 
     &:not(.u-no-margin):not(.u-no-margin--bottom) + & {
-      // move it up under the heading above by the amoung of bottom margin + top padding
+      // move it up under the heading above by the amount of bottom margin + top padding
       margin-top: calc(-1 * map-get($sp-after, h1-mobile));
 
       @media (min-width: $breakpoint-heading-threshold) {
@@ -88,7 +88,7 @@
     }
 
     &:not(.u-no-margin):not(.u-no-margin--bottom) + & {
-      // move it up under the heading above by the amoung of bottom margin + top padding
+      // move it up under the heading above by the amount of bottom margin + top padding
       margin-top: calc(-1 * map-get($sp-after, h3-mobile));
 
       @media (min-width: $breakpoint-heading-threshold) {

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -16,21 +16,30 @@
     @extend %vf-heading--common;
     @extend %vf-is-accent;
 
-    font-size: #{map-get($font-sizes, h2-mobile)}rem;
+    font-size: #{map-get($font-sizes, h1-mobile)}rem;
     font-weight: $font-weight-bold;
-    line-height: map-get($line-heights, h2-mobile);
-    margin-bottom: map-get($sp-after, h2-mobile) - map-get($nudges, h2-mobile);
-    padding-top: map-get($nudges, h2-mobile);
+    line-height: map-get($line-heights, h1-mobile);
+    margin-bottom: map-get($sp-after, h1-mobile) - map-get($nudges, h1-mobile);
+    padding-top: map-get($nudges, h1-mobile);
 
     @media (min-width: $breakpoint-heading-threshold) {
-      font-size: #{map-get($font-sizes, h2)}rem;
-      line-height: map-get($line-heights, h2);
-      margin-bottom: map-get($sp-after, h2) - map-get($nudges, h2);
-      padding-top: map-get($nudges, h2);
+      font-size: #{map-get($font-sizes, h1)}rem;
+      line-height: map-get($line-heights, h1);
+      margin-bottom: map-get($sp-after, h1) - map-get($nudges, h1);
+      padding-top: map-get($nudges, h1);
     }
 
     &.u-no-margin--bottom {
-      @extend %u-no-margin--bottom--h2;
+      @extend %u-no-margin--bottom--h1;
+    }
+
+    & + & {
+      // move it up under the heading above by the amoung of bottom margin + top padding
+      margin-top: calc(-1 * map-get($sp-after, h1-mobile));
+
+      @media (min-width: $breakpoint-heading-threshold) {
+        margin-top: calc(-1 * map-get($sp-after, h1));
+      }
     }
   }
 
@@ -38,21 +47,10 @@
     @extend %vf-heading--common;
     @extend %vf-heading-1;
     font-weight: 180; // custom font weight adjusted for h2
-
-    h1 + &,
-    .p-heading--1 + & {
-      // move it up under the heading above by the amoung of bottom margin + top padding
-      margin-top: calc(-1 * map-get($sp-after, h2-mobile));
-
-      @media (min-width: $breakpoint-heading-threshold) {
-        margin-top: calc(-1 * map-get($sp-after, h2));
-      }
-    }
   }
 
   %vf-heading-display {
     @extend %vf-heading--common;
-    @extend %vf-heading-2;
 
     font-size: #{map-get($font-sizes, display-mobile)}rem;
     font-weight: $font-weight-display-heading;

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -33,7 +33,7 @@
       @extend %u-no-margin--bottom--h1;
     }
 
-    & + & {
+    &:not(.u-no-margin):not(.u-no-margin--bottom) + & {
       // move it up under the heading above by the amoung of bottom margin + top padding
       margin-top: calc(-1 * map-get($sp-after, h1-mobile));
 
@@ -87,7 +87,7 @@
       @extend %u-no-margin--bottom--h3;
     }
 
-    & + & {
+    &:not(.u-no-margin):not(.u-no-margin--bottom) + & {
       // move it up under the heading above by the amoung of bottom margin + top padding
       margin-top: calc(-1 * map-get($sp-after, h3-mobile));
 
@@ -116,7 +116,7 @@
       @extend %u-no-margin--bottom--default-text;
     }
 
-    & + & {
+    &:not(.u-no-margin):not(.u-no-margin--bottom) + & {
       // move it up under the heading above by the amoung of bottom margin + top padding
       margin-top: calc(-1 * map-get($sp-after, p));
     }

--- a/scss/_base_typography-heading-mixins.scss
+++ b/scss/_base_typography-heading-mixins.scss
@@ -1,3 +1,5 @@
+// DEPRECATED: This file is deprecated and will be removed in a future version of Vanilla
+
 // For compatibility with other sites which rely on these mixins
 @mixin vf-heading-1 {
   @extend %vf-heading-1;

--- a/templates/docs/base/typography.md
+++ b/templates/docs/base/typography.md
@@ -75,7 +75,7 @@ Our type scale consists of 5 font sizes, expressed as rems (root em units). For 
     <td>Body text, all component, <code>h5</code> and <code>h6</code> headings.</td>
     <td>
       Standard body text
-      <p class="p-heading--5 u-no-margin--bottom">H5 heading</p>
+      <p class="p-heading--5">H5 heading</p>
       <p class="p-heading--6">H6 heading</p>
     </td>
   </tr>
@@ -92,7 +92,7 @@ Our type scale consists of 5 font sizes, expressed as rems (root em units). For 
     <td><code>h1</code> and <code>h2</code> level headings on small and medium screens..</td>
     <td>
       <p class="p-heading--2 u-no-padding--top" style="font-size: 2rem; line-height: 2.5rem">H2 heading (small and medium screens)</p>
-      <p class="p-heading--1 u-no-padding--top" style="font-size: 2rem; line-height: 2.5rem">H1 heading (small and medium screens)</p>
+      <p class="p-heading--1" style="font-size: 2rem; line-height: 2.5rem">H1 heading (small and medium screens)</p>
     </td>
   </tr>
   <tr>
@@ -100,13 +100,13 @@ Our type scale consists of 5 font sizes, expressed as rems (root em units). For 
     <td><code>h1</code> and <code>h2</code> level headings on large screens.</td>
     <td>
       <p class="p-heading--2 u-no-padding--top" style="font-size: 2.5rem; line-height: 3rem">H2 heading</p>
-      <p class="p-heading--1 u-no-padding--top" style="font-size: 2.5rem; line-height: 3rem">H1 heading</p>
+      <p class="p-heading--1" style="font-size: 2.5rem; line-height: 3rem">H1 heading</p>
     </td>
   </tr>
   <tr>
-    <td>120px</td>
+    <td>80px</td>
     <td>Ad hoc display headings for important bespoke pages.</td>
-    <td><h1 style="font-size: 7.5rem; line-height: 8rem; font-weight: 100">Ubuntu Pro</h1></td>
+    <td><h1 class="p-heading--display">Ubuntu Pro</h1></td>
   </tr>
 </tbody>
 </table>


### PR DESCRIPTION
## Done

Adjusts spacing between pairs of h1+h2, h3+h4 and h5+h6.
Also refactors shared styles of headings for better code clarity.

Fixes [WD-7708](https://warthogs.atlassian.net/browse/WD-7708)

## QA

- Open [demo](https://vanilla-framework-4941.demos.haus/docs/base/typography)
- Review heading examples
  - Make sure there is no margins between headings of the same size: h1 and h2s, h3 and h4s, h5 and h6s, both when using elements `h1` etc and classes `p-heading--1` etc.
  - https://vanilla-framework-4941.demos.haus/docs/examples/base/headings
  - https://vanilla-framework-4941.demos.haus/docs/examples/patterns/headings/default
  - https://vanilla-framework-4941.demos.haus/docs/examples/patterns/headings/mixed
  - https://vanilla-framework-4941.demos.haus/docs/examples/templates/typographic-spacing
- Review updated documentation:
  - The docs haven't changed, but you can check if they are still OK: https://vanilla-framework-4941.demos.haus/docs/base/typography

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="794" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/8eaa2f00-ac74-417e-8bb4-e64b5b955826">



[WD-7708]: https://warthogs.atlassian.net/browse/WD-7708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ