### PR TITLE
Add support for "Removed" status label to Vanilla changelog

### DIFF
--- a/templates/docs/whats-new.html
+++ b/templates/docs/whats-new.html
@@ -28,7 +28,7 @@
         <span class="p-status-label--positive">
         {% elif feature.status=="Updated" %}
         <span class="p-status-label--information">
-        {% elif feature.status=="Deprecated" %}
+        {% elif feature.status=="Deprecated" or feature.status=="Removed" %}
         <span class="p-status-label--negative">
         {% elif updatedFeatures[url]=="In Progress" %}
         <span class="p-status-label--caution">


### PR DESCRIPTION
## Done

Fixes missing label for removed feature in Vanilla changelog.

## QA

- Open [demo](https://vanilla-framework-4943.demos.haus/docs/whats-new)
- Make sure that "Removed" status label in changelog appears correctly.


## Screenshots

[Before](https://staging.vanillaframework.io/docs/whats-new)

<img width="999" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/5082a3b0-d0cf-4de3-a80e-43ee9be505ac">


[After](https://vanilla-framework-4943.demos.haus/docs/whats-new)

<img width="988" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/c409c1a3-5ef9-4437-823c-8302c2e9a761">

