### PR TITLE
Fix GitHub contributors URLs

### DIFF
--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -55,7 +55,7 @@
             <img src="{{ contributor.avatar_url }}" class="p-media-object__image is-round" alt="">
             <div class="p-media-object__details">
               <h3 class="p-media-object__title">
-                <a href="https://github.com/{{ contributor.login }}">{{ contributor.login }}</a>
+                <a href="{{ contributor.html_url }}">{{ contributor.login }}</a>
               </h3>
               <p class="p-media-object__content u-no-margin--bottom">{{ contributor.role }}</p>
 


### PR DESCRIPTION
## Done

To fix bot contributors, uses proper URL from API instead of trying to build one based on user name.

Fixes #4945

## QA

- Open [demo](https://vanilla-framework-4946.demos.haus/contribute)
- Click on dependabot, or renovate contributors links. Make sure they work.
