### PR TITLE
Proposal: Responsive equal heights 25/75 layout/component

### DIFF
--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -178,4 +178,168 @@
   @include vf-u-no-print;
   @include vf-u-text-max-width;
   @include vf-u-text-figures;
+
+  .p-equal-heights--subgrid {
+    display: grid;
+    grid-template-rows: auto;
+
+    .p-equal-heights--subgrid__item {
+      display: grid;
+      grid-template-columns: subgrid;
+      grid-template-rows: subgrid;
+
+      @media (max-width: $threshold-4-6-col) {
+        grid-column-end: span 4;
+        grid-column-start: 1;
+        grid-row-end: span 3;
+        position: relative;
+        @for $i from 1 through 3 {
+          &:nth-of-type(#{$i}) {
+            grid-row-start: #{$i * 3 + 1};
+          }
+        }
+      }
+
+      @media (min-width: $threshold-4-6-col) and (max-width: $breakpoint-large) {
+        border-top: 1px solid $colors--light-theme--border-default;
+        grid-column-end: span 6;
+        grid-column-start: 1;
+        grid-row-end: span 2;
+        position: relative;
+        @for $i from 1 through 3 {
+          &:nth-of-type(#{$i}) {
+            grid-row-start: #{$i * 2};
+          }
+        }
+      }
+
+      @media (min-width: $breakpoint-large) {
+        grid-column-end: span 3;
+        grid-column-start: auto;
+        grid-row: 1 / 4;
+        @for $i from 1 through 3 {
+          &:nth-of-type(#{$i}) {
+            grid-column-start: #{$i * 3 + 1};
+          }
+        }
+      }
+    }
+
+    .p-equal-heights__header {
+      @extend %large-breakpoint-behaviour;
+
+      grid-column: 1 / span 4;
+
+      &:nth-of-type(1) {
+        grid-row-start: 1;
+      }
+
+      &:nth-of-type(2) {
+        grid-row-start: 4;
+      }
+
+      &:nth-of-type(3) {
+        grid-row-start: 7;
+      }
+
+      @media (min-width: $threshold-4-6-col) {
+        grid-column: 1 / span 3;
+
+        &:nth-of-type(1) {
+          grid-row-start: 1;
+        }
+
+        &:nth-of-type(2) {
+          grid-row-start: 3;
+        }
+
+        &:nth-of-type(3) {
+          grid-row-start: 5;
+        }
+      }
+    }
+
+    .p-equal-heights__content {
+      @extend %large-breakpoint-behaviour;
+
+      grid-column: 1 / span 4;
+
+      &:nth-of-type(1) {
+        grid-row-start: 2;
+      }
+
+      &:nth-of-type(2) {
+        grid-row-start: 5;
+      }
+
+      &:nth-of-type(3) {
+        grid-row-start: 8;
+      }
+
+      @media (min-width: $threshold-4-6-col) {
+        grid-column: 4 / span 3;
+
+        &:nth-of-type(1) {
+          grid-row-start: 1;
+        }
+
+        &:nth-of-type(2) {
+          grid-row-start: 3;
+        }
+
+        &:nth-of-type(3) {
+          grid-row-start: 5;
+        }
+      }
+    }
+
+    .p-equal-heights__footer {
+      @extend %large-breakpoint-behaviour;
+
+      grid-column: 1 / span 4;
+
+      &:nth-of-type(1) {
+        grid-row-start: 3;
+      }
+
+      &:nth-of-type(2) {
+        grid-row-start: 6;
+      }
+
+      &:nth-of-type(3) {
+        grid-row-start: 9;
+      }
+      @media (min-width: $threshold-4-6-col) {
+        grid-column-end: span 3;
+        grid-column-start: 4;
+
+        &:nth-of-type(1) {
+          grid-row-start: 2;
+        }
+
+        &:nth-of-type(2) {
+          grid-row-start: 4;
+        }
+
+        &:nth-of-type(3) {
+          grid-row-start: 6;
+        }
+      }
+    }
+
+    %large-breakpoint-behaviour {
+      @media (min-width: $breakpoint-large) {
+        grid-column-start: auto;
+        grid-row-start: auto;
+
+        &:nth-of-type(1),
+        &:nth-of-type(2),
+        &:nth-of-type(3) {
+          grid-row-start: auto;
+        }
+
+        grid-column-end: span 3;
+      }
+    }
+  }
 }

--- a/templates/docs/examples/patterns/grid/25-75-responsive-equal-heights.html
+++ b/templates/docs/examples/patterns/grid/25-75-responsive-equal-heights.html
@@ -1,0 +1,54 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Grid / 25/75 responsive-equal-heights{% endblock %}
+
+{% block standalone_css %}patterns_grid{% endblock %}
+
+{% block content %}
+<section class="p-section--deep">
+    <div class="u-fixed-width p-section--shallow">
+        <hr class="p-rule" />
+        <h2>Get started with Ubuntu today</h2>
+    </div>
+    <div class="row p-equal-heights--subgrid">
+        <div class="p-equal-heights--subgrid__item">
+            <header class="p-equal-heights__header">
+                <h3 class="p-heading--5">Download and&nbsp;install</h3>
+            </header>
+            <div class="p-equal-heights__content">
+                <p>Download Ubuntu desktop and replace your current operating system. It's easy to install on Windows or
+                    Mac OS, or
+                    run Ubuntu alongside it.</p>
+            </div>
+            <footer class="p-equal-heights__footer p-section">
+                <a href="/download/desktop" class="p-button--positive">Download Ubuntu</a>
+            </footer>
+        </div>
+        <div class="p-equal-heights--subgrid__item">
+            <header class="p-equal-heights__header">
+                <h3 class="p-heading--5">Professional support</h3>
+            </header>
+            <div class="p-equal-heights__content">
+                <p>Get professional support from Canonical to manage your Ubuntu desktop, cloud and server deployments.
+                </p>
+            </div>
+            <footer class="p-equal-heights__footer p-section">
+                <a href="/pro" class="p-button">Buy Ubuntu Pro Desktop</a><br>
+                <a href="/support">Find out more&nbsp;&rsaquo;</a>
+            </footer>
+        </div>
+        <div class="p-equal-heights--subgrid__item">
+            <header class="p-equal-heights__header">
+                <h3 class="p-heading--5">Ubuntu flavours</h3>
+            </header>
+            <div class="p-equal-heights__content">
+                <p>Experience Ubuntu with different choices of default applications and settings, backed by the full
+                    Ubuntu archive
+                    for packages and updates.</p>
+            </div>
+            <footer class="p-equal-heights__footer p-section">
+                <a href="/download/ubuntu-flavours">Download Ubuntu&nbsp;&rsaquo;</a>
+            </footer>
+        </div>
+    </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Done

Proposal: subgrid responsive equal heights module

Quick and dirty subgrid implementation of the often used 3 column  25/75 layout:

![image](https://github.com/canonical/vanilla-framework/assets/2741678/a000d54d-a039-4e95-bbe9-e3c6807e42ca)


Currently, this is built iwth a min-height to align the 3 collumns regardless of the volume of content in them, but that doesn't work well, as on screens smaller than the fixed width, the height changes constantly as you resize.

A better way would be vto use subgrid, lay thjings on the grid, and rely on css grid to automartically adjust heights.

Warning - the code is quick and dirty, will need cleanup.
## QA

- Open [demo example](insert-demo-url)
- navigate to /docs/examples/patterns/grid/25-75-responsive-equal-heights
- Make the code nicer :)

## Screenshots
![image](https://github.com/canonical/vanilla-framework/assets/2741678/0ae1461d-0767-4b77-8b3f-bda1f91fc476)
![image](https://github.com/canonical/vanilla-framework/assets/2741678/85bc1bf3-b6d3-4943-a122-1f40aaf1986c)

[if relevant, include a screenshot or screen capture]
