### PR TITLE
Correct calculation of input padding to take real border width in con…

### DIFF
--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -117,7 +117,7 @@ $sp-after: (
 $spv-nudge: map-get($nudges, p) !default; // top: nudge; bottom: unit - nudge; result: height = exact multiple of base unit
 $spv-nudge-compensation: $sp-unit - $spv-nudge !default;
 $input-margin-bottom: $sp-unit * 4 - $spv-nudge * 2;
-$input-vertical-padding: calc($spv-nudge - 1px);
+$input-vertical-padding: calc($spv-nudge - $input-border-thickness);
 
 // tick element variables
 $form-tick-box-size: 1rem;


### PR DESCRIPTION
…sideration

## Done

Inpuit padding has a correctionm for border, but it uses a hard-coded 1px value. We set borders using a variable, which happens to be 1.5px. This PR corrects that error by referencing the variable instead of the hard-coded 1px value.

## QA

- Open [demo](insert-demo-url)
- check buttons and inputs, verify the padding has 1.5px subtracted from the nudge value. This is a sub-pixel difference, but hsould help things adhere better to the baseline grid.
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
