### PR TITLE
Configure renovate versioning for node stable versions only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
     {
       "matchDatasources": ["docker"],
       "matchPackageNames": ["node"],
-      "allowedVersions": "^16 || ^18 || ^20"
+      "versioning": "node"
     }
   ]
 }


### PR DESCRIPTION
## Done

Uses node versioning scheme in renovate config to avoid hardcoding stable node LTS versions.

See renovate docs in: https://docs.renovatebot.com/modules/versioning/#nodejs-versioning

