### PR TITLE
Fix tracker popup

### DIFF
--- a/templates/_layouts/_footer.html
+++ b/templates/_layouts/_footer.html
@@ -18,7 +18,7 @@
               <a class="is-dark" href="https://github.com/canonical/vanilla-framework/issues/new/choose">Report a bug</a>
             </li>
             <li class="p-list__item">
-              <a class="is-dark" href="#tracker-settings" class="js-revoke-cookie-manager">Manage your tracker settings</a>
+              <a class="is-dark js-revoke-cookie-manager" href="#tracker-settings">Manage your tracker settings</a>
             </li>
           </ul>
           <span class="u-off-screen">
@@ -50,7 +50,7 @@
           <a class="is-dark" href="https://github.com/canonical/vanilla-framework/issues/new/choose">Report a bug</a>
         </li>
         <li class="p-list__item">
-          <a class="is-dark" href="#tracker-settings" class="js-revoke-cookie-manager">Manage your tracker settings</a>
+          <a class="is-dark js-revoke-cookie-manager" href="#tracker-settings">Manage your tracker settings</a>
         </li>
       </ul>
       <span class="u-off-screen">


### PR DESCRIPTION
## Done

When `Manage your tracker settings` is clicked, the modal pops up as expected. 

Fixes https://github.com/canonical/vanilla-framework/issues/4959

## QA

- Run [demo](https://vanilla-framework-4962.demos.haus/)
- Scroll down to footer and click on `Manage your tracker settings`
- Tracker window should appear

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1506" alt="Screenshot 2024-01-31 at 11 21 27 AM" src="https://github.com/canonical/vanilla-framework/assets/62298176/8b95a6c0-3f5b-4513-91e0-8e14af00d952">

