### PR TITLE
Update tab with new theme variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,9 @@ jobs:
             git config --global user.email "circleci@example.com"
             git config --global user.name "CircleCI"
             git checkout -b percy
-      - build-tools/merge-with-parent:
-          parent: main
+      # FIXME: Temporarily disable while in feature branch, bring it back before merging to main
+      # - build-tools/merge-with-parent:
+      #     parent: main
       - run:
           # https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix
           name: Install puppeteer dependencies

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -2,9 +2,8 @@
 
 @mixin vf-p-tabs {
   .p-tabs {
-    color: $colors--theme--text-default;
-
     border-radius: 0;
+    color: $colors--theme--text-default;
     overflow: hidden;
     padding: 0;
     position: relative;
@@ -42,13 +41,11 @@
         $button-active-border-color: $color-transparent,
         $button-disabled-border-color: $color-transparent
       );
-
-      background-color: transparent;
-      color: $colors--theme--text-default;
       @include vf-highlight-bar(transparent, bottom, false);
-
       align-items: center;
+      background-color: transparent;
       border: none;
+      color: $colors--theme--text-default;
       display: flex;
       gap: $sph--small;
       height: 100%;
@@ -56,36 +53,6 @@
       margin-bottom: 0;
       padding: $spv--medium $sph--large;
       position: relative;
-
-      // Display the highlight when focussing in modern browsers that support
-      // focus-visible.
-      &:focus:not(:focus-visible) {
-        @include vf-highlight-bar($colors--theme--text-default, bottom, false);
-      }
-
-      &:hover {
-        background-color: transparent;
-        @include vf-highlight-bar($colors--theme--border-default, bottom, false);
-
-        &::before,
-        &:focus:not(:focus-visible)::before {
-          bottom: 1px;
-          height: calc($bar-thickness - 1px);
-        }
-
-        // Display the highlight when focusing (in combination with the parent
-        // states) in modern browsers that support focus-visible.
-        &:focus:not(:focus-visible) {
-          @include vf-highlight-bar($colors--theme--border-default, bottom, false);
-        }
-
-        // Hide the highlight when focussing (in combination with the parent
-        // states) in browsers that don't support focus-visible.
-        &:focus::before,
-        &:focus::after {
-          content: none;
-        }
-      }
 
       &::before {
         @extend %vf-pseudo-border;
@@ -103,19 +70,49 @@
           content: none;
         }
       }
-      
+
+      // Display the highlight when focusing in modern browsers that support
+      // focus-visible.
+      &:focus:not(:focus-visible) {
+        @include vf-highlight-bar($colors--theme--text-default, bottom, false);
+      }
+
+      &:hover {
+        background-color: transparent;
+        @include vf-highlight-bar($colors--theme--border-default, bottom, false);
+
+        &::before,
+        &:focus:not(:focus-visible)::before {
+          bottom: 1px;
+          height: calc($bar-thickness - 1px);
+        }
+
+        // Hide the highlight when focusing (in combination with the parent
+        // states) in browsers that don't support focus-visible.
+        &:focus::before,
+        &:focus::after {
+          content: none;
+        }
+
+        // Display the highlight when focusing (in combination with the parent
+        // states) in modern browsers that support focus-visible.
+        &:focus:not(:focus-visible) {
+          @include vf-highlight-bar($colors--theme--border-default, bottom, false);
+        }
+      }
+
       &:active,
       &[aria-selected='true'] {
         background-color: transparent;
         @include vf-highlight-bar($colors--theme--text-default, bottom, false);
 
-        // Display the highlight when focussing (in combination with the parent
+        // Display the highlight when focusing (in combination with the parent
         // states) in modern browsers that support focus-visible.
         &:focus:not(:focus-visible) {
           @include vf-highlight-bar($colors--theme--text-default, bottom, false);
         }
 
-        // Hide the highlight when focussing (in combination with the parent
+        // Hide the highlight when focusing (in combination with the parent
         // states) in browsers that don't support focus-visible.
         &:focus::before,
         &:focus::after {

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -2,6 +2,8 @@
 
 @mixin vf-p-tabs {
   .p-tabs {
+    color: $colors--theme--text-default;
+
     border-radius: 0;
     overflow: hidden;
     padding: 0;
@@ -17,6 +19,9 @@
       position: relative;
       white-space: nowrap;
       width: 100%;
+      &::after {
+        background-color: $colors--theme--border-default;
+      }
     }
 
     &__item {
@@ -37,6 +42,9 @@
         $button-active-border-color: $color-transparent,
         $button-disabled-border-color: $color-transparent
       );
+
+      background-color: transparent;
+      color: $colors--theme--text-default;
       @include vf-highlight-bar(transparent, bottom, false);
 
       align-items: center;
@@ -48,6 +56,36 @@
       margin-bottom: 0;
       padding: $spv--medium $sph--large;
       position: relative;
+
+      // Display the highlight when focussing in modern browsers that support
+      // focus-visible.
+      &:focus:not(:focus-visible) {
+        @include vf-highlight-bar($colors--theme--text-default, bottom, false);
+      }
+
+      &:hover {
+        background-color: transparent;
+        @include vf-highlight-bar($colors--theme--border-default, bottom, false);
+
+        &::before,
+        &:focus:not(:focus-visible)::before {
+          bottom: 1px;
+          height: calc($bar-thickness - 1px);
+        }
+
+        // Display the highlight when focusing (in combination with the parent
+        // states) in modern browsers that support focus-visible.
+        &:focus:not(:focus-visible) {
+          @include vf-highlight-bar($colors--theme--border-default, bottom, false);
+        }
+
+        // Hide the highlight when focussing (in combination with the parent
+        // states) in browsers that don't support focus-visible.
+        &:focus::before,
+        &:focus::after {
+          content: none;
+        }
+      }
 
       &::before {
         @extend %vf-pseudo-border;
@@ -65,89 +103,16 @@
           content: none;
         }
       }
-
+      
       &:active,
       &[aria-selected='true'] {
-        // Hide the highlight when focussing (in combination with the parent
-        // states) in browsers that don't support focus-visible.
-        &:focus::before,
-        &:focus::after {
-          content: none;
-        }
-      }
-    }
-  }
-
-  // Theming
-  @if ($theme-default-p-tabs == 'dark') {
-    .p-tabs {
-      @include vf-p-tabs-dark-theme;
-    }
-
-    .p-tabs.is-light {
-      @include vf-p-tabs-light-theme;
-    }
-  } @else {
-    .p-tabs {
-      @include vf-p-tabs-light-theme;
-    }
-
-    .p-tabs.is-dark {
-      @include vf-p-tabs-dark-theme;
-    }
-  }
-}
-
-@mixin vf-p-tabs-theme($color-tabs-text, $color-tabs-border, $color-tabs-highlight-hover) {
-  color: $color-tabs-text;
-  .p-tabs {
-    &__list::after {
-      background-color: $color-tabs-border;
-    }
-
-    &__link {
-      background-color: transparent;
-
-      color: $color-tabs-text;
-      @include vf-highlight-bar(transparent, bottom, false);
-
-      // Display the highlight when focussing in modern browsers that support
-      // focus-visible.
-      &:focus:not(:focus-visible) {
-        @include vf-highlight-bar($color-tabs-text, bottom, false);
-      }
-
-      &:hover {
-        @include vf-highlight-bar($color-tabs-highlight-hover, bottom, false);
-
-        &::before,
-        &:focus:not(:focus-visible)::before {
-          bottom: 1px;
-          height: calc($bar-thickness - 1px);
-        }
+        background-color: transparent;
+        @include vf-highlight-bar($colors--theme--text-default, bottom, false);
 
         // Display the highlight when focussing (in combination with the parent
         // states) in modern browsers that support focus-visible.
         &:focus:not(:focus-visible) {
-          @include vf-highlight-bar($color-tabs-highlight-hover, bottom, false);
-        }
-
-        // Hide the highlight when focussing (in combination with the parent
-        // states) in browsers that don't support focus-visible.
-        &:focus::before,
-        &:focus::after {
-          content: none;
-        }
-      }
-
-      &:active,
-      &[aria-selected='true'] {
-        @include vf-highlight-bar($color-tabs-text, bottom, false);
-
-        // Display the highlight when focussing (in combination with the parent
-        // states) in modern browsers that support focus-visible.
-        &:focus:not(:focus-visible) {
-          @include vf-highlight-bar($color-tabs-text, bottom, false);
+          @include vf-highlight-bar($colors--theme--text-default, bottom, false);
         }
 
         // Hide the highlight when focussing (in combination with the parent
@@ -159,20 +124,4 @@
       }
     }
   }
-}
-
-@mixin vf-p-tabs-light-theme {
-  @include vf-p-tabs-theme(
-    $color-tabs-text: $colors--light-theme--text-default,
-    $color-tabs-border: $colors--light-theme--border-default,
-    $color-tabs-highlight-hover: $colors--light-theme--border-default
-  );
-}
-
-@mixin vf-p-tabs-dark-theme {
-  @include vf-p-tabs-theme(
-    $color-tabs-text: $colors--dark-theme--text-default,
-    $color-tabs-border: $colors--dark-theme--border-default,
-    $color-tabs-highlight-hover: $colors--dark-theme--border-default
-  );
 }

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -3,7 +3,6 @@
 @mixin vf-p-tabs {
   .p-tabs {
     border-radius: 0;
-    color: $colors--theme--text-default;
     overflow: hidden;
     padding: 0;
     position: relative;
@@ -69,6 +68,10 @@
         &::after {
           content: none;
         }
+      }
+
+      &:visited {
+        color: $colors--theme--text-default;
       }
 
       // Display the highlight when focusing in modern browsers that support

--- a/templates/docs/examples/patterns/tabs/content-dark.html
+++ b/templates/docs/examples/patterns/tabs/content-dark.html
@@ -3,54 +3,54 @@
 
 {% block standalone_css %}patterns_tabs{% endblock %}
 
+{% set is_dark = true %}
 {% block content %}
-<div class="p-strip--dark" style="background: #262626;">
-  <div class="p-tabs is-dark">
-    <div class="p-tabs__list" role="tablist" aria-label="Juju technology">
-      <div class="p-tabs__item">
-        <button
-          class="p-tabs__link"
-          role="tab"
-          aria-selected="true"
-          aria-controls="olm-tab"
-          id="olm"
-        >Charmed Operator Lifecycle Manager</button>
-      </div>
-      <div class="p-tabs__item">
-        <button
-          class="p-tabs__link"
-          role="tab"
-          aria-selected="false"
-          aria-controls="operator-tab"
-          id="operator"
-          tabindex="-1"
-        >Charmed Operator SDK</button>
-      </div>
-      <div class="p-tabs__item">
-        <button
-          class="p-tabs__link"
-          role="tab"
-          aria-selected="false"
-          aria-controls="charmhub-tab"
-          id="charmhub"
-          tabindex="-1"
-        >Charmhub</button>
-      </div>
+<div class="p-tabs">
+  <div class="p-tabs__list" role="tablist" aria-label="Juju technology">
+    <div class="p-tabs__item">
+      <button
+        class="p-tabs__link"
+        role="tab"
+        aria-selected="true"
+        aria-controls="olm-tab"
+        id="olm"
+      >Charmed Operator Lifecycle Manager</button>
     </div>
-  
-    <div tabindex="0" role="tabpanel" id="olm-tab" aria-labelledby="olm">
-      <p>A system to help you move from configuration management to application management across your hybrid cloud estate - through sharable, reusable, tiny applications called Charmed Operators.</p>
+    <div class="p-tabs__item">
+      <button
+        class="p-tabs__link"
+        role="tab"
+        aria-selected="false"
+        aria-controls="operator-tab"
+        id="operator"
+        tabindex="-1"
+      >Charmed Operator SDK</button>
     </div>
-  
-    <div tabindex="0" role="tabpanel" id="operator-tab" aria-labelledby="operator" hidden="hidden">
-      <p>A set of tools to help you write Charmed Operators and to package them as Charms.</p>
-    </div>
-  
-    <div tabindex="0" role="tabpanel" id="charmhub-tab" aria-labelledby="charmhub" hidden="hidden">
-      <p>A repository for charms - from Observability to Data to Identity and more.</p>
+    <div class="p-tabs__item">
+      <button
+        class="p-tabs__link"
+        role="tab"
+        aria-selected="false"
+        aria-controls="charmhub-tab"
+        id="charmhub"
+        tabindex="-1"
+      >Charmhub</button>
     </div>
   </div>
+
+  <div tabindex="0" role="tabpanel" id="olm-tab" aria-labelledby="olm">
+    <p>A system to help you move from configuration management to application management across your hybrid cloud estate - through sharable, reusable, tiny applications called Charmed Operators.</p>
+  </div>
+
+  <div tabindex="0" role="tabpanel" id="operator-tab" aria-labelledby="operator" hidden="hidden">
+    <p>A set of tools to help you write Charmed Operators and to package them as Charms.</p>
+  </div>
+
+  <div tabindex="0" role="tabpanel" id="charmhub-tab" aria-labelledby="charmhub" hidden="hidden">
+    <p>A repository for charms - from Observability to Data to Identity and more.</p>
+  </div>
 </div>
+
 
 <script>
   {% include 'docs/examples/patterns/tabs/_script.js' %}


### PR DESCRIPTION
## Done

Update Tab component to use new theme variables

Fixes [WD-7601](https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/970?selectedIssue=WD-7601)

## QA

- Open [demo](https://vanilla-framework-4963.demos.haus/)
- Go to `/docs/examples/patterns/tabs/navigation`, `/docs/examples/patterns/tabs/content-dark`, `/docs/examples/patterns/tabs/content`
- Inspect page and modify the class of <body> tag to `is-dark`, `is-light`, `is-paper`
- Tabs should update accordingly based on the body theme


## Screenshots
<img width="1459" alt="Screenshot 2024-02-02 at 9 54 21 AM" src="https://github.com/canonical/vanilla-framework/assets/62298176/70b547e0-87bf-4cdd-bbb2-3b4ed014fa30">


[WD-7601]: https://warthogs.atlassian.net/browse/WD-7601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ