### PR TITLE
Add paper theme and theme setting on body element

### DIFF
--- a/scss/_base_background.scss
+++ b/scss/_base_background.scss
@@ -1,11 +1,7 @@
 @mixin vf-base-background {
   // stylelint-disable-next-line selector-max-type -- base styles can use type selectors
   body {
-    background: $color-x-light;
-  }
-
-  // stylelint-disable-next-line selector-max-type -- base styles can use type selectors
-  body.is-paper {
-    background: $color-paper;
+    background: $colors--theme--background-default;
+    color: $colors--theme--text-default;
   }
 }

--- a/scss/_base_themes.scss
+++ b/scss/_base_themes.scss
@@ -11,5 +11,9 @@
     .is-dark {
       @include vf-theme-dark;
     }
+
+    .is-paper {
+      @include vf-theme-paper;
+    }
   }
 }

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -263,6 +263,18 @@ $colors--theme--border-low-contrast: var(--vf-color-border-low-contrast);
   --vf-color-border-low-contrast: #{$colors--dark-theme--border-low-contrast};
 }
 
+@mixin vf-theme-paper {
+  // paper theme is based on dark theme with some background colours adjusted
+  @include vf-theme-light;
+
+  // SCSS variables need to be interpolated to work in CSS custom properties
+  --vf-color-background-default: #{$color-paper};
+
+  --vf-color-background-inputs: #{$colors--paper-theme--background-inputs};
+  --vf-color-background-active: #{$colors--paper-theme--background-active};
+  --vf-color-background-hover: #{$colors--paper-theme--background-hover};
+}
+
 // Branding colors
 $color-ubuntu: #e95420; // Ubuntu orange, should not be overridden
 $color-brand: $color-ubuntu !default;

--- a/templates/_layouts/examples.html
+++ b/templates/_layouts/examples.html
@@ -49,7 +49,7 @@
     </script>
   </head>
 
-  <body {% if is_paper %}class="is-paper"{% endif %}>
+  <body {% if is_dark %}class="is-dark"{% elif is_paper %}class="is-paper"{% endif %}>
     {% block content %}{% endblock %}
   </body>
 </html>

--- a/templates/docs/examples/base/hr-dark.html
+++ b/templates/docs/examples/base/hr-dark.html
@@ -6,12 +6,12 @@
 {% block style %}
 <style>
   body {
-    background: #111;
     padding: 1rem 0;
   }
 </style>
 {% endblock %}
 
+{% set is_dark = true %}
 {% block content %}
 <hr class="is-dark">
 {% endblock %}

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -12,7 +12,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Stylesheet size',
       benchmark: 150000,
-      threshold: 430000,
+      threshold: 435000,
       result: results['total-stylesheet-size'],
     },
     {


### PR DESCRIPTION
## Done

Adds support for theme class names on body element (to change page background).
Adds basic paper theme support.

Fixes https://warthogs.atlassian.net/browse/WD-7604

## QA

- Open [demo](https://vanilla-framework-4970.demos.haus/)
- Open demo: https://vanilla-framework-4970.demos.haus/
  - Change class on `body` from `is-paper` to `is-light` or `is-dark`, make sure background of the page and text colour changes as expected.
- Open `hr` demo: https://vanilla-framework-4970.demos.haus/docs/examples/base/hr-dark
  - Remove class `is-dark` from `<hr>`, make sure it still is dark (inherited from body)
  - Change body class to `is-light` or `is-paper`, make sure background color, and line adjusted accordingly

### Note

This is merged into feature branch, we are fine with some CI jobs (like Percy) to fail on this one.