### PR TITLE
Add CSS theme support for Side Navigation 

### DIFF
--- a/scss/_patterns_side-navigation-expandable.scss
+++ b/scss/_patterns_side-navigation-expandable.scss
@@ -12,35 +12,6 @@
     padding-right: 3rem;
   }
 
-  // FIXME: Temporary workaround for unsupported theme colors in vf-icon-chevron
-  .p-side-navigation__expand::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .p-side-navigation__expand.is-light::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .is-light .p-side-navigation__expand::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .p-side-navigation__expand.is-paper::before {
-      @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .is-paper .p-side-navigation__expand::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-  
-  .p-side-navigation__expand.is-dark::before {
-    @include vf-icon-chevron(#999);
-  }
-
-  .is-dark .p-side-navigation__expand::before {
-    @include vf-icon-chevron(#999);
-  }
-
   .p-side-navigation__expand {
     @include vf-button-base;
     background: none;
@@ -58,6 +29,7 @@
 
     &::before {
       @extend %icon;
+      @include vf-icon-chevron($colors--light-theme--text-inactive);
       content: '';
       transform: rotate(-90deg);
       transition: transform 100ms;
@@ -68,21 +40,44 @@
       color: $colors--theme--text-default;
     }
   }
-  
-  
-  .p-side-navigation__expand[aria-expanded='true']{
+
+  // FIXME: Temporary workaround for unsupported theme colors in vf-icon-chevron
+  .p-side-navigation__expand.is-light::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .is-light .p-side-navigation__expand::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .p-side-navigation__expand.is-paper::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .is-paper .p-side-navigation__expand::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .p-side-navigation__expand.is-dark::before {
+    @include vf-icon-chevron(#999);
+  }
+
+  .is-dark .p-side-navigation__expand::before {
+    @include vf-icon-chevron(#999);
+  }
+
+  .p-side-navigation__expand[aria-expanded='true'] {
     background-color: inherit;
-    
+
     &::before {
       transform: rotate(0deg);
     }
-    
+
     &:hover {
       background: $colors--theme--background-hover;
       color: $colors--theme--text-default;
     }
   }
-
 
   // transition
   .p-side-navigation__list {
@@ -104,26 +99,4 @@
     transform: translate3d(0, 0, 0);
     visibility: visible;
   }
-
-  // Theming for the expandable variant
-  // @if ($theme-default-p-side-navigation == 'dark') {
-  //   .p-side-navigation,
-  //   [class*='p-side-navigation--'] {
-  //     @include vf-side-navigation-expandable-theme-dark;
-
-  //     &.is-light {
-  //       @include vf-side-navigation-expandable-theme-light;
-  //     }
-  //   }
-  // } @else {
-  //   .p-side-navigation,
-  //   [class*='p-side-navigation--'] {
-  //     @include vf-side-navigation-expandable-theme-light;
-
-  //     &.is-dark {
-  //       @include vf-side-navigation-expandable-theme-dark;
-  //     }
-  //   }
-  // }
 }
-

--- a/scss/_patterns_side-navigation-expandable.scss
+++ b/scss/_patterns_side-navigation-expandable.scss
@@ -42,27 +42,17 @@
   }
 
   // FIXME: Temporary workaround for unsupported theme colors in vf-icon-chevron
-  .p-side-navigation__expand.is-light::before {
+  // stylelint-disable-next-line selector-max-type
+  .p-side-navigation__expand.is-light::before,
+  .p-side-navigation__expand.is-paper::before,
+  body.is-light .p-side-navigation__expand::before,
+  body.is-paper .p-side-navigation__expand::before {
     @include vf-icon-chevron($colors--light-theme--text-inactive);
   }
 
-  .is-light .p-side-navigation__expand::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .p-side-navigation__expand.is-paper::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .is-paper .p-side-navigation__expand::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .p-side-navigation__expand.is-dark::before {
-    @include vf-icon-chevron(#999);
-  }
-
-  .is-dark .p-side-navigation__expand::before {
+  // stylelint-disable-next-line selector-max-type
+  .p-side-navigation__expand.is-dark::before,
+  body.is-dark .p-side-navigation__expand::before {
     @include vf-icon-chevron(#999);
   }
 

--- a/scss/_patterns_side-navigation-expandable.scss
+++ b/scss/_patterns_side-navigation-expandable.scss
@@ -12,9 +12,39 @@
     padding-right: 3rem;
   }
 
+  // FIXME: Temporary workaround for unsupported theme colors in vf-icon-chevron
+  .p-side-navigation__expand::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .p-side-navigation__expand.is-light::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .is-light .p-side-navigation__expand::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .p-side-navigation__expand.is-paper::before {
+      @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .is-paper .p-side-navigation__expand::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+  
+  .p-side-navigation__expand.is-dark::before {
+    @include vf-icon-chevron(#999);
+  }
+
+  .is-dark .p-side-navigation__expand::before {
+    @include vf-icon-chevron(#999);
+  }
+
   .p-side-navigation__expand {
     @include vf-button-base;
     background: none;
+    background-color: inherit;
     border: 0;
     border-radius: 0;
     font-size: inherit;
@@ -28,16 +58,31 @@
 
     &::before {
       @extend %icon;
-      @include vf-icon-chevron;
       content: '';
       transform: rotate(-90deg);
       transition: transform 100ms;
     }
+
+    &:hover {
+      background: $colors--theme--background-hover;
+      color: $colors--theme--text-default;
+    }
+  }
+  
+  
+  .p-side-navigation__expand[aria-expanded='true']{
+    background-color: inherit;
+    
+    &::before {
+      transform: rotate(0deg);
+    }
+    
+    &:hover {
+      background: $colors--theme--background-hover;
+      color: $colors--theme--text-default;
+    }
   }
 
-  .p-side-navigation__expand[aria-expanded='true']::before {
-    transform: rotate(0deg);
-  }
 
   // transition
   .p-side-navigation__list {
@@ -61,54 +106,24 @@
   }
 
   // Theming for the expandable variant
-  @if ($theme-default-p-side-navigation == 'dark') {
-    .p-side-navigation,
-    [class*='p-side-navigation--'] {
-      @include vf-side-navigation-expandable-theme-dark;
+  // @if ($theme-default-p-side-navigation == 'dark') {
+  //   .p-side-navigation,
+  //   [class*='p-side-navigation--'] {
+  //     @include vf-side-navigation-expandable-theme-dark;
 
-      &.is-light {
-        @include vf-side-navigation-expandable-theme-light;
-      }
-    }
-  } @else {
-    .p-side-navigation,
-    [class*='p-side-navigation--'] {
-      @include vf-side-navigation-expandable-theme-light;
+  //     &.is-light {
+  //       @include vf-side-navigation-expandable-theme-light;
+  //     }
+  //   }
+  // } @else {
+  //   .p-side-navigation,
+  //   [class*='p-side-navigation--'] {
+  //     @include vf-side-navigation-expandable-theme-light;
 
-      &.is-dark {
-        @include vf-side-navigation-expandable-theme-dark;
-      }
-    }
-  }
+  //     &.is-dark {
+  //       @include vf-side-navigation-expandable-theme-dark;
+  //     }
+  //   }
+  // }
 }
 
-@mixin vf-side-navigation-expandable-theme($color-sidenav-text-active, $color-sidenav-item-background-hover, $color-sidenav-toggle-icon) {
-  .p-side-navigation__expand {
-    background-color: inherit;
-    &::before {
-      @include vf-icon-chevron($color-sidenav-toggle-icon);
-    }
-
-    &:hover {
-      background: $color-sidenav-item-background-hover;
-      color: $color-sidenav-text-active;
-    }
-  }
-}
-
-@mixin vf-side-navigation-expandable-theme-light {
-  @include vf-side-navigation-expandable-theme(
-    $color-sidenav-text-active: $colors--light-theme--text-default,
-    $color-sidenav-item-background-hover: $colors--light-theme--background-hover,
-    $color-sidenav-toggle-icon: $colors--light-theme--text-inactive
-  );
-}
-
-@mixin vf-side-navigation-expandable-theme-dark {
-  @include vf-side-navigation-expandable-theme(
-    $color-sidenav-text-active: $colors--dark-theme--text-default,
-    $color-sidenav-item-background-hover: $colors--dark-theme--background-hover,
-    // color of toggle icon - needed because of lack of rgba support in icon mixin
-    $color-sidenav-toggle-icon: #999
-  );
-}

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -195,16 +195,6 @@
   .p-side-navigation__toggle,
   .p-side-navigation__toggle--in-drawer {
     @extend %vf-button-base;
-    @include vf-button-pattern(
-      $button-background-color: $color-transparent,
-      $button-border-color: $colors--theme--border-high-contrast,
-      $button-text-color: $colors--theme--text-inactive,
-      $button-hover-background-color: $colors--theme--background-hover,
-      $button-hover-border-color: $colors--theme--border-high-contrast,
-      $button-active-background-color: $colors--theme--background-active,
-      $button-active-border-color: $color-transparent
-    );
-
     &::before {
       @extend %icon;
 
@@ -217,6 +207,8 @@
   // toggle to open side navigation is supposed to be in main content (on light background)
   // it's using default 'neutral' button look regardless of the theme used by side navigation
   .p-side-navigation__toggle {
+    @include vf-button-pattern;
+
     &::before {
       @include vf-icon-chevron;
       transform: rotate(-90deg);
@@ -224,6 +216,15 @@
   }
 
   .p-side-navigation__toggle--in-drawer {
+    @include vf-button-pattern(
+      $button-background-color: $color-transparent,
+      $button-border-color: $colors--theme--border-high-contrast,
+      $button-text-color: $colors--theme--text-inactive,
+      $button-hover-background-color: $colors--theme--background-hover,
+      $button-hover-border-color: $colors--theme--border-high-contrast,
+      $button-active-background-color: $colors--theme--background-active,
+      $button-active-border-color: $color-transparent
+    );
     margin-bottom: $sp-unit * 2 - $spv-nudge * 2;
 
     &::before {
@@ -242,27 +243,17 @@
   }
 
   // FIXME: Temporary workaround for unsupported theme colors in vf-icon-chevron
-  .p-side-navigation__toggle--in-drawer.is-light::before {
+  // stylelint-disable-next-line selector-max-type
+  .p-side-navigation__toggle--in-drawer.is-light::before,
+  .p-side-navigation__toggle--in-drawer.is-paper::before,
+  body.is-light .p-side-navigation__toggle--in-drawer::before,
+  body.is-paper .p-side-navigation__toggle--in-drawer::before {
     @include vf-icon-chevron($colors--light-theme--text-inactive);
   }
 
-  .is-light .p-side-navigation__toggle--in-drawer::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .p-side-navigation__toggle--in-drawer.is-paper::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .is-paper .p-side-navigation__toggle--in-drawer::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .p-side-navigation__toggle--in-drawer.is-dark::before {
-    @include vf-icon-chevron(#999);
-  }
-
-  .is-dark .p-side-navigation__toggle--in-drawer::before {
+  // stylelint-disable-next-line selector-max-type
+  .p-side-navigation__toggle--in-drawer.is-dark::before,
+  body.is-dark .p-side-navigation__toggle--in-drawer::before {
     @include vf-icon-chevron(#999);
   }
 
@@ -386,7 +377,6 @@
 
   %side-navigation__link {
     @include vf-focus;
-    // color: $colors--theme--text-inactive;
 
     &,
     &:visited {
@@ -486,27 +476,17 @@
   }
 
   // FIXME: Temporary workaround for unsupported theme colors in vf-icon-chevron
-  .p-side-navigation__accordion-button.is-light::before {
+  // stylelint-disable-next-line selector-max-type
+  .p-side-navigation__accordion-button.is-light::before,
+  .p-side-navigation__accordion-button.is-paper::before,
+  body.is-light .p-side-navigation__accordion-button::before,
+  body.is-paper .p-side-navigation__accordion-button::before {
     @include vf-icon-chevron($colors--light-theme--text-inactive);
   }
 
-  .is-light .p-side-navigation__accordion-button::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .p-side-navigation__accordion-button.is-paper::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .is-paper .p-side-navigation__accordion-button::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .p-side-navigation__accordion-button.is-dark::before {
-    @include vf-icon-chevron(#999);
-  }
-
-  .is-dark .p-side-navigation__accordion-button::before {
+  // stylelint-disable-next-line selector-max-type
+  .p-side-navigation__accordion-button.is-dark::before,
+  body.is-dark .p-side-navigation__accordion-button::before {
     @include vf-icon-chevron(#999);
   }
 

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -217,46 +217,17 @@
   // toggle to open side navigation is supposed to be in main content (on light background)
   // it's using default 'neutral' button look regardless of the theme used by side navigation
   .p-side-navigation__toggle {
-    
     &::before {
       @include vf-icon-chevron;
       transform: rotate(-90deg);
     }
   }
 
-  // FIXME: Temporary workaround for unsupported theme colors in vf-icon-chevron
-  .p-side-navigation__toggle--in-drawer::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .p-side-navigation__toggle--in-drawer.is-light::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .is-light .p-side-navigation__toggle--in-drawer::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .p-side-navigation__toggle--in-drawer.is-paper::before {
-      @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .is-paper .p-side-navigation__toggle--in-drawer::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-  
-  .p-side-navigation__toggle--in-drawer.is-dark::before {
-    @include vf-icon-chevron(#999);
-  }
-
-  .is-dark .p-side-navigation__toggle--in-drawer::before {
-    @include vf-icon-chevron(#999);
-  }
-
   .p-side-navigation__toggle--in-drawer {
     margin-bottom: $sp-unit * 2 - $spv-nudge * 2;
 
     &::before {
+      @include vf-icon-chevron($colors--light-theme--text-inactive);
       transform: rotate(90deg);
     }
 
@@ -268,6 +239,31 @@
         color: $colors--theme--text-default;
       }
     }
+  }
+
+  // FIXME: Temporary workaround for unsupported theme colors in vf-icon-chevron
+  .p-side-navigation__toggle--in-drawer.is-light::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .is-light .p-side-navigation__toggle--in-drawer::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .p-side-navigation__toggle--in-drawer.is-paper::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .is-paper .p-side-navigation__toggle--in-drawer::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .p-side-navigation__toggle--in-drawer.is-dark::before {
+    @include vf-icon-chevron(#999);
+  }
+
+  .is-dark .p-side-navigation__toggle--in-drawer::before {
+    @include vf-icon-chevron(#999);
   }
 
   @media (min-width: $threshold-6-12-col) {
@@ -321,7 +317,7 @@
       @include vf-side-navigation-spacing-left($prop: left);
 
       background: $colors--theme--border-low-contrast;
-      bottom: -0.5 * $spv--x-large; // place border in the middle of the margin      
+      bottom: -0.5 * $spv--x-large; // place border in the middle of the margin
     }
 
     .p-side-navigation--icons &::after {
@@ -400,6 +396,7 @@
     &:hover {
       background: $colors--theme--background-hover;
       color: $colors--theme--text-default;
+      text-decoration: none;
     }
 
     &:active,
@@ -428,10 +425,6 @@
     &:focus:not(:focus-visible)::before {
       display: block;
     }
-
-    &:hover {
-      text-decoration: none;
-    }
   }
 
   .p-side-navigation__link {
@@ -440,35 +433,6 @@
     &:visited {
       color: $colors--theme--text-inactive;
     }
-  }
-
-  // FIXME: Temporary workaround for unsupported theme colors in vf-icon-chevron
-  .p-side-navigation__accordion-button::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .p-side-navigation__accordion-button.is-light::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .is-light .p-side-navigation__accordion-button::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .p-side-navigation__accordion-button.is-paper::before {
-      @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-
-  .is-paper .p-side-navigation__accordion-button::before {
-    @include vf-icon-chevron($colors--light-theme--text-inactive);
-  }
-  
-  .p-side-navigation__accordion-button.is-dark::before {
-    @include vf-icon-chevron(#999);
-  }
-
-  .is-dark .p-side-navigation__accordion-button::before {
-    @include vf-icon-chevron(#999);
   }
 
   .p-side-navigation__accordion-button {
@@ -485,8 +449,9 @@
 
     &::before {
       @extend %icon;
+      @include vf-icon-chevron($colors--light-theme--text-inactive);
       @include vf-transition($property: transform, $duration: fast);
-      
+
       align-self: center;
       content: '';
       flex-shrink: 0;
@@ -518,6 +483,31 @@
 
       @include vf-transition(#{background-color, border-color});
     }
+  }
+
+  // FIXME: Temporary workaround for unsupported theme colors in vf-icon-chevron
+  .p-side-navigation__accordion-button.is-light::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .is-light .p-side-navigation__accordion-button::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .p-side-navigation__accordion-button.is-paper::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .is-paper .p-side-navigation__accordion-button::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .p-side-navigation__accordion-button.is-dark::before {
+    @include vf-icon-chevron(#999);
+  }
+
+  .is-dark .p-side-navigation__accordion-button::before {
+    @include vf-icon-chevron(#999);
   }
 
   .p-side-navigation__heading,

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -106,7 +106,9 @@
   }
 
   .p-side-navigation__drawer {
+    background: $colors--theme--background-default;
     bottom: 0;
+    color: $colors--theme--text-default;
     left: 0;
     overflow: auto;
     position: fixed;
@@ -155,6 +157,7 @@
   .p-side-navigation__overlay {
     @include vf-transition(opacity);
 
+    background: $colors--theme--background-overlay;
     bottom: 0;
     left: 0;
     opacity: 0;
@@ -176,8 +179,10 @@
   }
 
   .p-side-navigation__drawer-header {
+    background: $colors--theme--background-default;
     border-bottom-style: solid;
     border-bottom-width: 1px;
+    border-color: $colors--theme--border-low-contrast;
     margin-bottom: $spv--small;
     padding-bottom: calc($spv--small - 1px); // compensate for border thickness
     padding-left: 0.25rem; // nudge to visually align icon with text
@@ -190,6 +195,15 @@
   .p-side-navigation__toggle,
   .p-side-navigation__toggle--in-drawer {
     @extend %vf-button-base;
+    @include vf-button-pattern(
+      $button-background-color: $color-transparent,
+      $button-border-color: $colors--theme--border-high-contrast,
+      $button-text-color: $colors--theme--text-inactive,
+      $button-hover-background-color: $colors--theme--background-hover,
+      $button-hover-border-color: $colors--theme--border-high-contrast,
+      $button-active-background-color: $colors--theme--background-active,
+      $button-active-border-color: $color-transparent
+    );
 
     &::before {
       @extend %icon;
@@ -200,10 +214,43 @@
     }
   }
 
+  // toggle to open side navigation is supposed to be in main content (on light background)
+  // it's using default 'neutral' button look regardless of the theme used by side navigation
   .p-side-navigation__toggle {
+    
     &::before {
+      @include vf-icon-chevron;
       transform: rotate(-90deg);
     }
+  }
+
+  // FIXME: Temporary workaround for unsupported theme colors in vf-icon-chevron
+  .p-side-navigation__toggle--in-drawer::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .p-side-navigation__toggle--in-drawer.is-light::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .is-light .p-side-navigation__toggle--in-drawer::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .p-side-navigation__toggle--in-drawer.is-paper::before {
+      @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .is-paper .p-side-navigation__toggle--in-drawer::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+  
+  .p-side-navigation__toggle--in-drawer.is-dark::before {
+    @include vf-icon-chevron(#999);
+  }
+
+  .is-dark .p-side-navigation__toggle--in-drawer::before {
+    @include vf-icon-chevron(#999);
   }
 
   .p-side-navigation__toggle--in-drawer {
@@ -211,6 +258,15 @@
 
     &::before {
       transform: rotate(90deg);
+    }
+
+    &[aria-expanded='true'] {
+      background-color: $color-transparent;
+
+      &:hover {
+        background: $colors--theme--background-hover;
+        color: $colors--theme--text-default;
+      }
     }
   }
 
@@ -259,11 +315,13 @@
   %side-navigation__list {
     @extend %vf-list;
     @extend %vf-pseudo-border--bottom;
+    color: $colors--theme--text-inactive;
 
     &::after {
       @include vf-side-navigation-spacing-left($prop: left);
 
-      bottom: -0.5 * $spv--x-large; // place border in the middle of the margin
+      background: $colors--theme--border-low-contrast;
+      bottom: -0.5 * $spv--x-large; // place border in the middle of the margin      
     }
 
     .p-side-navigation--icons &::after {
@@ -313,6 +371,7 @@
     padding-top: $spv--x-small;
 
     .p-side-navigation__item--title > & {
+      color: $colors--theme--text-default;
       font-weight: $font-weight-bold;
     }
   }
@@ -331,6 +390,32 @@
 
   %side-navigation__link {
     @include vf-focus;
+    // color: $colors--theme--text-inactive;
+
+    &,
+    &:visited {
+      color: $colors--theme--text-inactive;
+    }
+
+    &:hover {
+      background: $colors--theme--background-hover;
+      color: $colors--theme--text-default;
+    }
+
+    &:active,
+    &.is-active,
+    &[aria-current='page'],
+    &[aria-current='true'] {
+      background: $colors--theme--background-active;
+      color: $colors--theme--text-default;
+      cursor: default;
+    }
+
+    &.is-active,
+    &[aria-current='page'],
+    &[aria-current='true'] {
+      @include vf-highlight-bar($colors--theme--text-default, left);
+    }
 
     // vf-highlight-bar is rendered above focus outline
     // so we need to hide it on focus
@@ -351,12 +436,47 @@
 
   .p-side-navigation__link {
     @extend %side-navigation__link;
+
+    &:visited {
+      color: $colors--theme--text-inactive;
+    }
+  }
+
+  // FIXME: Temporary workaround for unsupported theme colors in vf-icon-chevron
+  .p-side-navigation__accordion-button::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .p-side-navigation__accordion-button.is-light::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .is-light .p-side-navigation__accordion-button::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .p-side-navigation__accordion-button.is-paper::before {
+      @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+
+  .is-paper .p-side-navigation__accordion-button::before {
+    @include vf-icon-chevron($colors--light-theme--text-inactive);
+  }
+  
+  .p-side-navigation__accordion-button.is-dark::before {
+    @include vf-icon-chevron(#999);
+  }
+
+  .is-dark .p-side-navigation__accordion-button::before {
+    @include vf-icon-chevron(#999);
   }
 
   .p-side-navigation__accordion-button {
     // reset default button styles
+    background-color: inherit;
     border: 0;
     border-radius: 0;
+    color: inherit;
     font-size: inherit;
     justify-content: flex-start;
     margin-bottom: 0;
@@ -366,12 +486,17 @@
     &::before {
       @extend %icon;
       @include vf-transition($property: transform, $duration: fast);
-
+      
       align-self: center;
       content: '';
       flex-shrink: 0;
       margin-left: calc(-1 * ($sph--large + $sp-sidenav--icon-width));
       margin-right: $sph--large;
+    }
+
+    &:hover {
+      background: $colors--theme--background-hover;
+      color: $colors--theme--text-default;
     }
 
     // aria-selected controls the open and closed state for the accordion tab
@@ -380,7 +505,8 @@
       background-color: inherit;
 
       &:hover {
-        background-color: $colors--light-theme--background-hover;
+        background: $colors--theme--background-hover;
+        color: $colors--theme--text-default;
       }
       @include vf-transition(#{background-color, border-color});
     }
@@ -468,6 +594,13 @@
     padding: 0; // padding will come from the link in heading
   }
 
+  .p-side-navigation__heading,
+  .p-side-navigation__heading--linked .p-side-navigation__link,
+  .p-side-navigation__item--title,
+  .p-side-navigation__item--title .p-side-navigation__link {
+    color: $colors--theme--text-default;
+  }
+
   // Styles for markup in raw HTML docs variant
   .p-side-navigation--raw-html {
     // stylelint-disable selector-max-type -- we support raw HTML markup for discourse-generated side nav
@@ -477,14 +610,39 @@
     h5,
     h6 {
       @extend %side-navigation__heading;
+      color: $colors--theme--text-default;
     }
 
     ul {
       @extend %side-navigation__list;
+
+      &::after {
+        background: $colors--theme--border-low-contrast;
+      }
     }
 
     li > a {
       @extend %side-navigation__link;
+
+      &,
+      &:visited {
+        color: $colors--theme--text-inactive;
+      }
+
+      &:hover {
+        background: $colors--theme--background-hover;
+        color: $colors--theme--text-default;
+      }
+
+      &:active,
+      &.is-active,
+      &[aria-current='page'],
+      &[aria-current='true'] {
+        @include vf-highlight-bar($colors--theme--text-default, left);
+
+        background: $colors--theme--background-active;
+        color: $colors--theme--text-default;
+      }
     }
 
     li > span,
@@ -509,46 +667,25 @@
     // stylelint-enable selector-max-type
   }
 
-  // Theming
-  @if ($theme-default-p-side-navigation == 'dark') {
-    .p-side-navigation,
-    [class*='p-side-navigation--'] {
-      @include vf-side-navigation-theme-dark;
+  @if mixin-exists(vf-application-layout--when-collapsed) {
+    .p-side-navigation__item.has-active-child {
+      // parent element that has active child should be selected when navigation is collapsed
+      @include vf-application-layout--when-collapsed() {
+        // @include vf-highlight-bar($color-sidenav-item-border-highlight, left);
+        @include vf-highlight-bar($colors--theme--text-default, left);
 
-      &.is-light {
-        @include vf-side-navigation-theme-light;
+        background: $colors--theme--background-hover;
+        color: $colors--theme--text-default;
+      }
+
+      // parent element with active child should not be selected when navigation is expanded
+      @include vf-application-layout--when-expanded() {
+        @include vf-highlight-bar(transparent, left);
+
+        background: transparent;
+        color: $colors--theme--text-inactive;
       }
     }
-
-    .p-side-navigation--raw-html {
-      @include vf-side-navigation-raw-html-theme-dark;
-
-      &.is-light {
-        @include vf-side-navigation-raw-html-theme-light;
-      }
-    }
-  } @else {
-    .p-side-navigation,
-    [class*='p-side-navigation--'] {
-      @include vf-side-navigation-theme-light;
-
-      &.is-dark {
-        @include vf-side-navigation-theme-dark;
-      }
-    }
-
-    .p-side-navigation--raw-html {
-      @include vf-side-navigation-raw-html-theme-light;
-
-      &.is-dark {
-        @include vf-side-navigation-raw-html-theme-dark;
-      }
-    }
-  }
-
-  .is-paper .p-side-navigation__drawer,
-  .is-paper .p-side-navigation__drawer-header {
-    background: $color-paper;
   }
 }
 
@@ -569,281 +706,4 @@
   @media (min-width: $threshold-4-6-col) {
     #{$prop}: $multiplier * map-get($grid-margin-widths, default) + $offset;
   }
-}
-
-// theme
-@mixin vf-side-navigation-theme(
-  // default text color in sidebar
-  $color-sidenav-text-default,
-  // default background color (for the drawer)
-  $color-sidenav-background-default,
-  // background color the overlay
-  $color-sidenav-background-overlay,
-  // text color of highlighted items
-  $color-sidenav-text-active,
-  // background color of active items
-  $color-sidenav-item-background-active,
-  // background color of hovered items
-  $color-sidenav-item-background-hover,
-  // border color of active item
-  $color-sidenav-item-border-highlight,
-  // border color of items list
-  $color-sidenav-list-border,
-  // color of toggle icon - needed because of lack of rgba support in icon mixin
-  $color-sidenav-toggle-icon
-) {
-  & {
-    color: $color-sidenav-text-default;
-  }
-
-  // toggle to open side navigation is supposed to be in main content (on light background)
-  // it's using default 'neutral' button look regardless of the theme used by side navigation
-  .p-side-navigation__toggle {
-    @include vf-button-pattern;
-
-    &::before {
-      @include vf-icon-chevron;
-    }
-  }
-
-  .p-side-navigation__toggle--in-drawer {
-    @include vf-button-pattern(
-      $button-background-color: $color-transparent,
-      $button-border-color: $color-transparent,
-      $button-text-color: $color-sidenav-text-default,
-      $button-hover-background-color: $color-sidenav-item-background-hover,
-      $button-hover-border-color: $color-transparent,
-      $button-active-background-color: $color-sidenav-item-background-active,
-      $button-active-border-color: $color-transparent
-    );
-
-    &::before {
-      @include vf-icon-chevron($color-sidenav-toggle-icon);
-    }
-
-    &[aria-expanded='true'] {
-      background-color: $color-transparent;
-
-      &:hover {
-        background: $color-sidenav-item-background-hover;
-        color: $color-sidenav-text-active;
-      }
-    }
-  }
-
-  .p-side-navigation__drawer {
-    background: $color-sidenav-background-default;
-  }
-
-  .p-side-navigation__overlay {
-    background: $color-sidenav-background-overlay;
-  }
-
-  .p-side-navigation__drawer-header {
-    background: $color-sidenav-background-default;
-    border-color: $color-sidenav-list-border;
-  }
-
-  .p-side-navigation__list::after {
-    background: $color-sidenav-list-border;
-  }
-
-  .p-side-navigation__link {
-    &,
-    &:visited {
-      color: $color-sidenav-text-default;
-    }
-
-    &:hover {
-      background: $color-sidenav-item-background-hover;
-      color: $color-sidenav-text-active;
-    }
-
-    &:active,
-    &.is-active,
-    &[aria-current='page'],
-    &[aria-current='true'] {
-      background: $color-sidenav-item-background-active;
-      color: $color-sidenav-text-active;
-      cursor: default;
-    }
-
-    &.is-active,
-    &[aria-current='page'],
-    &[aria-current='true'] {
-      @include vf-highlight-bar($color-sidenav-item-border-highlight, left);
-    }
-  }
-
-  .p-side-navigation__heading,
-  .p-side-navigation__heading--linked .p-side-navigation__link,
-  .p-side-navigation__item--title,
-  .p-side-navigation__item--title .p-side-navigation__link {
-    color: $color-sidenav-text-active;
-  }
-
-  .p-side-navigation__accordion-button {
-    background-color: inherit;
-    color: inherit;
-    &::before {
-      @include vf-icon-chevron($color-sidenav-toggle-icon);
-    }
-
-    &:hover {
-      background: $color-sidenav-item-background-hover;
-      color: $color-sidenav-text-active;
-    }
-  }
-
-  // styles applied when side nav is used in application layout
-  @if mixin-exists(vf-application-layout--when-collapsed) {
-    .p-side-navigation__item.has-active-child {
-      // parent element that has active child should be selected when navigation is collapsed
-      @include vf-application-layout--when-collapsed() {
-        @include vf-highlight-bar($color-sidenav-item-border-highlight, left);
-
-        background: $color-sidenav-item-background-hover;
-        color: $color-sidenav-text-active;
-      }
-
-      // parent element with active child should not be selected when navigation is expanded
-      @include vf-application-layout--when-expanded() {
-        @include vf-highlight-bar(transparent, left);
-
-        background: transparent;
-        color: $color-sidenav-text-default;
-      }
-    }
-  }
-}
-
-@mixin vf-side-navigation-theme-light {
-  @include vf-side-navigation-theme(
-    $color-sidenav-text-default: $colors--light-theme--text-inactive,
-    $color-sidenav-background-default: $colors--light-theme--background-default,
-    $color-sidenav-background-overlay: $colors--light-theme--background-overlay,
-    $color-sidenav-text-active: $colors--light-theme--text-default,
-    $color-sidenav-item-background-active: $colors--light-theme--background-active,
-    $color-sidenav-item-background-hover: $colors--light-theme--background-hover,
-    $color-sidenav-item-border-highlight: $colors--light-theme--text-default,
-    $color-sidenav-list-border: $colors--light-theme--border-low-contrast,
-    $color-sidenav-toggle-icon: $colors--light-theme--text-inactive
-  );
-
-  .is-paper & {
-    @include vf-side-navigation-theme(
-      $color-sidenav-text-default: $colors--light-theme--text-inactive,
-      $color-sidenav-background-default: $color-paper,
-      $color-sidenav-background-overlay: $colors--light-theme--background-overlay,
-      $color-sidenav-text-active: $colors--light-theme--text-default,
-      $color-sidenav-item-background-active: $colors--paper-theme--background-active,
-      $color-sidenav-item-background-hover: $colors--paper-theme--background-hover,
-      $color-sidenav-item-border-highlight: $colors--light-theme--text-default,
-      $color-sidenav-list-border: $colors--light-theme--border-low-contrast,
-      $color-sidenav-toggle-icon: $colors--light-theme--text-inactive
-    );
-  }
-}
-
-@mixin vf-side-navigation-theme-dark {
-  // FIXME:
-  // $color-sidenav-toggle-icon color should be same as $color-sidenav-text-default,
-  // but vf-url-friendly-color doesn't support rgba(),
-  // so we are using #999 as fallback for now
-  @include vf-side-navigation-theme(
-    $color-sidenav-text-default: $colors--dark-theme--text-inactive,
-    $color-sidenav-background-default: $colors--dark-theme--background-default,
-    $color-sidenav-background-overlay: $colors--dark-theme--background-overlay,
-    $color-sidenav-text-active: $colors--dark-theme--text-default,
-    $color-sidenav-item-background-active: $colors--dark-theme--background-active,
-    $color-sidenav-item-background-hover: $colors--dark-theme--background-hover,
-    $color-sidenav-item-border-highlight: $colors--dark-theme--text-default,
-    $color-sidenav-list-border: $colors--dark-theme--border-low-contrast,
-    $color-sidenav-toggle-icon: #999
-  );
-}
-
-// Theme for markup in raw HTML docs variant
-@mixin vf-side-navigation-raw-html-theme(
-  // default text color in sidebar
-  $color-sidenav-text-default,
-  // text color of highlighted items
-  $color-sidenav-text-active,
-  // background color of active items
-  $color-sidenav-item-background-active,
-  // background color of hovered items
-  $color-sidenav-item-background-hover,
-  // border color of active item
-  $color-sidenav-item-border-highlight,
-  // border color of items list
-  $color-sidenav-list-border
-) {
-  // stylelint-disable selector-max-type
-  ul::after {
-    background: $color-sidenav-list-border;
-  }
-
-  li > a {
-    &,
-    &:visited {
-      color: $color-sidenav-text-default;
-    }
-
-    &:hover {
-      background: $color-sidenav-item-background-hover;
-      color: $color-sidenav-text-active;
-    }
-
-    &:active,
-    &.is-active,
-    &[aria-current='page'],
-    &[aria-current='true'] {
-      @include vf-highlight-bar($color-sidenav-item-border-highlight, left);
-
-      background: $color-sidenav-item-background-active;
-      color: $color-sidenav-text-active;
-    }
-  }
-
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    color: $color-sidenav-text-active;
-  }
-  // stylelint-enable selector-max-type
-}
-
-@mixin vf-side-navigation-raw-html-theme-light {
-  @include vf-side-navigation-raw-html-theme(
-    $color-sidenav-text-default: $colors--light-theme--text-inactive,
-    $color-sidenav-text-active: $colors--light-theme--text-default,
-    $color-sidenav-item-background-active: $colors--light-theme--background-active,
-    $color-sidenav-item-background-hover: $colors--light-theme--background-hover,
-    $color-sidenav-item-border-highlight: $colors--light-theme--text-default,
-    $color-sidenav-list-border: $colors--light-theme--border-low-contrast
-  );
-
-  .is-paper {
-    @include vf-side-navigation-raw-html-theme(
-      $color-sidenav-text-default: $colors--light-theme--text-inactive,
-      $color-sidenav-text-active: $colors--light-theme--text-default,
-      $color-sidenav-item-background-active: $colors--paper-theme--background-active,
-      $color-sidenav-item-background-hover: $colors--paper-theme--background-hover,
-      $color-sidenav-item-border-highlight: $colors--light-theme--text-default,
-      $color-sidenav-list-border: $colors--light-theme--border-low-contrast
-    );
-  }
-}
-
-@mixin vf-side-navigation-raw-html-theme-dark {
-  @include vf-side-navigation-raw-html-theme(
-    $color-sidenav-text-default: $colors--dark-theme--text-inactive,
-    $color-sidenav-text-active: $colors--dark-theme--text-default,
-    $color-sidenav-item-background-active: $colors--dark-theme--background-active,
-    $color-sidenav-item-background-hover: $colors--dark-theme--background-hover,
-    $color-sidenav-item-border-highlight: $colors--dark-theme--text-default,
-    $color-sidenav-list-border: $colors--dark-theme--border-low-contrast
-  );
 }

--- a/templates/docs/examples/patterns/side-navigation/_accordion.html
+++ b/templates/docs/examples/patterns/side-navigation/_accordion.html
@@ -1,4 +1,4 @@
-<div class="p-side-navigation--accordion{% if is_dark %} is-dark{% endif %}" id="drawer">
+<div class="p-side-navigation--accordion" id="drawer">
   <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
     Toggle side navigation
   </a>

--- a/templates/docs/examples/patterns/side-navigation/_default.html
+++ b/templates/docs/examples/patterns/side-navigation/_default.html
@@ -1,4 +1,4 @@
-<div class="p-side-navigation {% if is_dark %}is-dark{% endif %} {% if is_sticky %}is-sticky{% endif %}" id="drawer{% if is_sticky %}-sticky{% endif %}">
+<div class="p-side-navigation {% if is_sticky %}is-sticky{% endif %}" id="drawer{% if is_sticky %}-sticky{% endif %}">
 
   <a href="#drawer{% if is_sticky %}-sticky{% endif %}" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer{% if is_sticky %}-sticky{% endif %}">
     Toggle side navigation

--- a/templates/docs/examples/patterns/side-navigation/_expandable.html
+++ b/templates/docs/examples/patterns/side-navigation/_expandable.html
@@ -1,4 +1,4 @@
-<div class="p-side-navigation {% if is_dark %}is-dark{% endif %} {% if is_sticky %}is-sticky{% endif %}" id="drawer">
+<div class="p-side-navigation {% if is_sticky %}is-sticky{% endif %}" id="drawer">
   <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
     Toggle side navigation
   </a>

--- a/templates/docs/examples/patterns/side-navigation/_icons.html
+++ b/templates/docs/examples/patterns/side-navigation/_icons.html
@@ -1,4 +1,4 @@
-<div class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" id="drawer-icons">
+<div class="p-side-navigation--icons" id="drawer-icons">
   <a href="#drawer-icons" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer-icons">
     Toggle side navigation
   </a>
@@ -10,7 +10,7 @@
   {% endif %}
   <nav class="p-side-navigation__drawer" aria-label="Example side navigation with icons"
     style="{% if is_dark %}background: #003b4e;{% elif not is_paper %}background: #f7f7f7{% endif %}">
-    <div class="p-side-navigation__drawer-header" style="background: {% if is_dark %}#003b4e{% elif not is_paper %}#f7f7f7{% endif %}">
+    <div class="p-side-navigation__drawer-header">
       <a href="#" class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer-icons">
         Toggle side navigation
       </a>

--- a/templates/docs/examples/patterns/side-navigation/_layout-JAAS.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-JAAS.html
@@ -1,6 +1,6 @@
 {# used by the application layout example #}
 
-<nav class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" aria-label="Main">
+<nav class="p-side-navigation--icons" aria-label="Main">
   <ul class="p-side-navigation__list">
     <li class="p-side-navigation__item">
       <a class="p-side-navigation__link" href="#" aria-current="page">

--- a/templates/docs/examples/patterns/side-navigation/_layout-application.html
+++ b/templates/docs/examples/patterns/side-navigation/_layout-application.html
@@ -1,6 +1,6 @@
 {# used by the application layout example #}
 
-<div class="p-side-navigation--icons {% if is_dark %}is-dark{% endif %}" id="drawer-icons">
+<div class="p-side-navigation--icons" id="drawer-icons">
   <nav aria-label="Main">
     <ul class="p-side-navigation__list">
       <li class="p-side-navigation__item--title">

--- a/templates/docs/examples/patterns/side-navigation/accordion-dark.html
+++ b/templates/docs/examples/patterns/side-navigation/accordion-dark.html
@@ -3,10 +3,9 @@
 
 {% block standalone_css %}patterns_side-navigation{% endblock %}
 
+{% set is_dark = true %}
 {% block content %}
-{% with is_dark = True %}
-  {% include "docs/examples/patterns/side-navigation/_accordion.html" %}
-{% endwith %}
+{% include "docs/examples/patterns/side-navigation/_accordion.html" %}
 
 <script>
   {% include "docs/examples/patterns/side-navigation/_example_script.js" %}

--- a/templates/docs/examples/patterns/side-navigation/application.html
+++ b/templates/docs/examples/patterns/side-navigation/application.html
@@ -3,20 +3,7 @@
 
 {% block standalone_css %}patterns_side-navigation{% endblock %}
 
-{% block style %}
-<style>
-  /*
-    Making background dark for the sake of this example.
-    In the real application you would place the side navigation inside
-    the `l-navigation` panel that should provide the background color.
-  */
-  html, body { background: #111 }
-</style>
-{% endblock %}
-
+{% set is_dark = True %}
 {% block content %}
-{% with is_dark=True %}
   {% include "docs/examples/patterns/side-navigation/_layout-JAAS.html" %}
-{% endwith %}
-
 {% endblock %}

--- a/templates/docs/examples/patterns/side-navigation/dark.html
+++ b/templates/docs/examples/patterns/side-navigation/dark.html
@@ -3,13 +3,8 @@
 
 {% block standalone_css %}patterns_side-navigation{% endblock %}
 
-{% block style %}
-<style>body { background: #111 }</style>
-{% endblock %}
-
+{% set is_dark = True %}
 {% block content %}
-
-{% with is_dark = True %}
 <div class="row">
   <div class="col-4">
       {% include "docs/examples/patterns/side-navigation/_default.html" %}
@@ -23,7 +18,6 @@
     {% endwith %}
   </div>
 </div>
-{% endwith %}
 
 <script>
   {% include "docs/examples/patterns/side-navigation/_example_script.js" %}

--- a/templates/docs/examples/patterns/side-navigation/expandable-dark.html
+++ b/templates/docs/examples/patterns/side-navigation/expandable-dark.html
@@ -3,18 +3,13 @@
 
 {% block standalone_css %}patterns_side-navigation{% endblock %}
 
-{% block style %}
-<style>body { background: #111 }</style>
-{% endblock %}
-
+{% set is_dark = True %}
 {% block content %}
-{% with is_dark=True %}
 <div class="row">
    <div class="col-4">
     {% include "docs/examples/patterns/side-navigation/_expandable.html" %}
   </div>
 </div>
-{% endwith %}
 
 <script>
   {% include "docs/examples/patterns/side-navigation/_example_script.js" %}


### PR DESCRIPTION
## Done

* Added new CSS theme support for Side Navigation component
* Note:
    * ~Added dark stylings for `Toggle side navigation` button - previously only had light theme in the examples~
    * Added workaround for unsupported dark themed icons, currently only done for chevron for Expandables and Accordion but there are more icons used as seen in `/docs/examples/patterns/side-navigation/icons`

Fixes [WD-7599](https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/970?selectedIssue=WD-7599)

## QA

- Open [demo](https://vanilla-framework-4972.demos.haus/)
- Go to `/docs/examples` and check out `Side navigation /  XXX` examples
- Side navigation theming should be consistent with the current examples in [vanillaframework.io](vanillaframework.io)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]


[WD-7599]: https://warthogs.atlassian.net/browse/WD-7599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ