### PR TITLE
Hero section

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -8,6 +8,10 @@
       url: /docs/settings/color-settings#color-theming
       status: Deprecated
       notes: We're deprecating the SCSS variables used to set the default theme. Theme can be set by using a class name on an element.
+    - component: Section / Hero
+      url: /docs/patterns/section#hero-sections
+      status: New
+      notes: We've introduced a new hero variant to the section component using <code>p-sectoin--hero</code>.
 - version: 4.7.0
   features:
     - component: Navigation / 25/75 split

--- a/scss/_patterns_section.scss
+++ b/scss/_patterns_section.scss
@@ -1,5 +1,6 @@
 @mixin vf-p-section {
-  .p-section {
+  .p-section,
+  .p-section--hero {
     // same as %section-padding--default
     padding-bottom: $spv--strip-regular * 0.5;
 
@@ -21,5 +22,11 @@
   .p-section--shallow {
     // same as %section-padding--shallow
     padding-bottom: $spv--x-large;
+  }
+
+  // hero section has additional top padding (as it appears on the top of the page
+  .p-section--hero {
+    // same as %section-padding--shallow
+    padding-top: $spv--x-large;
   }
 }

--- a/scss/_patterns_section.scss
+++ b/scss/_patterns_section.scss
@@ -24,9 +24,13 @@
     padding-bottom: $spv--x-large;
   }
 
-  // hero section has additional top padding (as it appears on the top of the page
+  // hero section has additional top padding (as it appears on the top of the page)
   .p-section--hero {
-    // same as %section-padding--shallow
-    padding-top: $spv--x-large;
+    padding-top: $spv--large;
+
+    // on large screens, same as %section-padding--shallow
+    @media (min-width: $breakpoint-large) {
+      padding-top: $spv--x-large;
+    }
   }
 }

--- a/templates/docs/examples/brochure/hero-50-50.html
+++ b/templates/docs/examples/brochure/hero-50-50.html
@@ -6,20 +6,20 @@
 
 {% set is_paper = True %}
 {% block content %}
-<section>
+<section class="p-section--hero">
     <div class="row--50-50">
         <div class="col">
             <h1>H1: 3-8 words</h1>
         </div>
         <div class="col">
-            <div class="p-section">
+            <div class="p-section--shallow">
                 <p class="p-heading--2">H2: 5-13 words, up to 3 rows of copy...</p>
             </div>
-            <div class="p-section">
+            <div class="p-section--shallow">
                 <p>Multi-cloud (also referred to as multi cloud or multicloud) is a concept that refers to using multiple clouds from more than one cloud service provider at the same time. The term is also used to refer to the simultaneous running of bare metal, virtualised and containerised workloads.</p>
                 <p>In conjunction with a hybrid cloud architecture, the multi-cloud approach enables organisations to optimise their infrastructure costs. Multi-cloud reflects the reality of most organisations today and is expected to become the standard for cloud infrastructure in the coming years.</p>
             </div>
-            <div class="p-section">
+            <div class="p-section--shallow">
                 <hr />
                 <a href="#" class="p-button--positive">CTA up to 3 words</a>
                 <a href="#" class="p-button">CTA up to 3 words</a>

--- a/templates/docs/examples/patterns/section/hero.html
+++ b/templates/docs/examples/patterns/section/hero.html
@@ -1,0 +1,16 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Section / Hero{% endblock %}
+
+{% block standalone_css %}patterns_section{% endblock %}
+
+{% block content %}
+<main>
+  <section class="p-section--hero">
+    <div class="row--25-75">
+      <div class="col">
+        <h1>Hero section</h1>
+      </div>
+    </div>
+  </section>
+</main>
+{% endblock %}

--- a/templates/docs/patterns/section.md
+++ b/templates/docs/patterns/section.md
@@ -55,6 +55,14 @@ Please not that to emphasize the sections of the page with both top and bottom s
 View example of the shallow section
 </a></div>
 
+## Hero sections
+
+Use a hero section component (`.p-section--hero`) to create a hero section with top padding to be placed at the top of the page.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/section/hero" class="js-example">
+View example of the hero section
+</a></div>
+
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.

--- a/templates/docs/patterns/section.md
+++ b/templates/docs/patterns/section.md
@@ -6,6 +6,14 @@ context:
 
 Use section components to wrap around parts of content on the page. They are used for managing the bottom space after each element.
 
+## Hero sections
+
+Use a hero section component (`.p-section--hero`) to create a hero section with top padding to be placed at the top of the page.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/section/hero" class="js-example">
+View example of the hero section
+</a></div>
+
 ## Regular sections
 
 Use a section component (`.p-section`) for displaying subsequent sections on the page on a same background. They should be used in place of strips for most of the standard page content.
@@ -53,14 +61,6 @@ Please not that to emphasize the sections of the page with both top and bottom s
 
 <div class="embedded-example"><a href="/docs/examples/patterns/section/deep" class="js-example">
 View example of the shallow section
-</a></div>
-
-## Hero sections
-
-Use a hero section component (`.p-section--hero`) to create a hero section with top padding to be placed at the top of the page.
-
-<div class="embedded-example"><a href="/docs/examples/patterns/section/hero" class="js-example">
-View example of the hero section
 </a></div>
 
 ## Import

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,25 +6,32 @@
 {% block content %}
 <script defer src="https://buttons.github.io/buttons.js"></script>
 
-<div id="main-content" class="p-strip is-deep">
-  <div class="u-fixed-width">
-    <h1>A simple, extensible CSS framework</h1>
-    <p>Backed by open-source code and written in Sass by the Canonical Web Team.</p>
-    <ul class="p-inline-list u-no-margin--bottom">
-      <li class="p-inline-list__item">
-        <a href="/docs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Get started</a>
-      </li>
-      <li class="p-inline-list__item">
-        <a href="https://github.com/canonical/vanilla-framework/releases/latest" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download latest', 'eventValue' : undefined });" class="p-button u-no-margin--bottom">Download Vanilla v{{version}}</a>
-      </li>
-    </ul>
+<div id="main-content" class="p-section--hero">
+  <div class="row--25-75">
+    <div class="col">
+      <div class="p-section--shallow">
+        <h1>A simple, extensible CSS framework</h1>
+        <p class="p-heading--2">Backed by open-source code and written in Sass by the Canonical Web Team.</p>
+      </div>
+
+      <div class="p-section--shallow">
+        <ul class="p-inline-list u-no-margin--bottom">
+          <li class="p-inline-list__item">
+            <a href="/docs" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--positive u-no-margin--bottom">Get started</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="https://github.com/canonical/vanilla-framework/releases/latest" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download latest', 'eventValue' : undefined });" class="p-button u-no-margin--bottom">Download Vanilla v{{version}}</a>
+          </li>
+        </ul>
+      </div>
+    </div>
   </div>
 </div>
 
 <div class="p-section">
   <div class="row">
     <hr />
-    <div class="col-4 col-medium-2">
+    <div class="col-3 col-start-large-4 col-medium-2">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
           {{ image (
@@ -42,7 +49,7 @@
         <p>Vanilla contains a responsive CSS grid, basic style for HTML elements and a selection of key useful patterns and utility classes that you can extend.</p>
       </div>
     </div>
-    <div class="col-4 col-medium-2">
+    <div class="col-3 col-medium-2">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
           {{ image (
@@ -60,7 +67,7 @@
         <p>Designed to be composable — you can include the whole framework to avail of all styles or you can use only what you need for your project.</p>
       </div>
     </div>
-    <div class="col-4 col-medium-2">
+    <div class="col-3 col-medium-2">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header is-stacked">
           {{ image (


### PR DESCRIPTION
## Done

Adds new variant to p-section component for hero sections, as `p-section--hero`.
This is supposed to have asymetrical section padding (regular on bottom, shallow on top) as per [Figma design spec](https://www.figma.com/file/Hll6ZRvHyTTGBZZSoRd8ei/Hero-component?type=design&node-id=184-1566&mode=design)

Fixes [WD-7707](https://warthogs.atlassian.net/browse/WD-7707)
https://warthogs.atlassian.net/browse/WD-7707

## QA

- Open [demo](https://vanilla-framework-4973.demos.haus/)
- https://vanilla-framework-4973.demos.haus//docs/examples/patterns/section/hero
- make sure hero section has correct paddings
- https://vanilla-framework-4973.demos.haus/docs/examples/brochure/hero-50-50
- make sure that hero example uses correct new padding
- Review updated documentation:
  - https://vanilla-framework-4973.demos.haus//docs/patterns/section#hero-sections
  - review home page https://vanilla-framework-4973.demos.haus/, check if it uses new hero section

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1380" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/d38c3b10-bc8e-4103-9acf-c0dde5c1d85c">

Updated home page 

<img width="1305" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/e57e3217-e54a-46bc-9978-37df7efc9404">


[WD-7707]: https://warthogs.atlassian.net/browse/WD-7707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ