### PR TITLE
Add new theme support for base forms

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -23,8 +23,7 @@
     // stylelint-enable property-no-vendor-prefix
     background-color: $colors--theme--background-inputs;
     border: 0 solid transparent;
-    border-bottom: $input-border-thickness solid $colors--theme--text-default;
-    border-color: $colors--theme--border-high-contrast;
+    border-bottom: $input-border-thickness solid $colors--theme--border-high-contrast;
     border-radius: 0;
     color: $colors--theme--text-default;
     font-family: unquote($font-base-family);

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -21,11 +21,12 @@
     -moz-appearance: textfield;
     appearance: textfield;
     // stylelint-enable property-no-vendor-prefix
-    background-color: $colors--light-theme--background-inputs;
+    background-color: $colors--theme--background-inputs;
     border: 0 solid transparent;
-    border-bottom: $input-border-thickness solid $colors--light-theme--text-default;
+    border-bottom: $input-border-thickness solid $colors--theme--text-default;
+    border-color: $colors--theme--border-high-contrast;
     border-radius: 0;
-    color: $colors--light-theme--text-default;
+    color: $colors--theme--text-default;
     font-family: unquote($font-base-family);
     font-size: 1rem;
     font-weight: $font-weight-regular-text;
@@ -38,12 +39,28 @@
     width: 100%;
 
     &:hover {
-      background-color: $colors--light-theme--background-hover;
+      background-color: $colors--theme--background-hover;
     }
 
     &:active,
     &:focus {
-      background-color: $colors--light-theme--background-active;
+      background-color: $colors--theme--background-active;
+    }
+
+    // stylelint-disable-next-line selector-max-type -- base styles can use type selectors
+    option,
+    option:checked {
+      background-color: $colors--theme--background-alt;
+      color: $colors--theme--text-default;
+    }
+
+    // stylelint-disable-next-line selector-max-type -- base styles can use type selectors
+    option:checked:not(:disabled) {
+      background-color: $colors--theme--background-active;
+    }
+
+    &::placeholder {
+      color: $colors--theme--text-muted;
     }
 
     &.is-dense {
@@ -65,32 +82,6 @@
     @each $state, $color in $states {
       &.has-#{$state} {
         border: $input-border-thickness solid $color;
-      }
-    }
-
-    // Theming
-    @if ($theme-default-forms == 'dark') {
-      @include vf-input-dark-theme;
-
-      &.is-light {
-        @include vf-input-light-theme;
-      }
-
-      .is-paper &,
-      &.is-paper {
-        @include vf-input-paper-theme;
-      }
-    } @else {
-      @include vf-input-light-theme;
-
-      .is-dark &,
-      &.is-dark {
-        @include vf-input-dark-theme;
-      }
-
-      .is-paper &,
-      &.is-paper {
-        @include vf-input-paper-theme;
       }
     }
   }
@@ -246,75 +237,4 @@
     padding: calc($spv--large - $input-border-thickness);
   }
   // stylelint-enable selector-max-type
-}
-
-@mixin vf-input-theme($color-background-default, $color-background-hover, $color-background-active, $color-background-option, $color-border, $color-text, $color-text-placeholder) {
-  background-color: $color-background-default;
-  border-color: $color-border;
-  color: $color-text;
-
-  &:hover {
-    background-color: $color-background-hover;
-  }
-
-  &:active,
-  &:focus {
-    background-color: $color-background-active;
-  }
-
-  // stylelint-disable-next-line selector-max-type -- base styles can use type selectors
-  option,
-  option:checked {
-    background-color: $color-background-option;
-    color: $color-text;
-  }
-
-  // stylelint-disable-next-line selector-max-type -- base styles can use type selectors
-  option:checked:not(:disabled) {
-    background-color: $color-background-active;
-  }
-
-  &::placeholder {
-    color: $color-text-placeholder;
-  }
-}
-
-@mixin vf-input-light-theme {
-  @include vf-input-theme(
-    $color-background-default: $colors--light-theme--background-inputs,
-    $color-background-hover: $colors--light-theme--background-hover,
-    $color-background-active: $colors--light-theme--background-active,
-    $color-background-option: $colors--light-theme--background-alt,
-    $color-border: $colors--light-theme--text-default,
-    $color-text: $colors--light-theme--text-default,
-    $color-text-placeholder: $colors--light-theme--text-muted
-  );
-}
-
-@mixin vf-input-paper-theme {
-  // XXX: currently these colours are transparent,
-  // so they work both on paper and white backgrounds.
-  // We may need later to add a specific override for
-  // a white background within paper themed pages.
-  @include vf-input-theme(
-    $color-background-default: $colors--paper-theme--background-inputs,
-    $color-background-hover: $colors--paper-theme--background-hover,
-    $color-background-active: $colors--paper-theme--background-active,
-    $color-background-option: $colors--light-theme--background-alt,
-    $color-border: $colors--light-theme--text-default,
-    $color-text: $colors--light-theme--text-default,
-    $color-text-placeholder: $colors--light-theme--text-muted
-  );
-}
-
-@mixin vf-input-dark-theme {
-  @include vf-input-theme(
-    $color-background-default: $colors--dark-theme--background-inputs,
-    $color-background-hover: $colors--dark-theme--background-hover,
-    $color-background-active: $colors--dark-theme--background-active,
-    $color-background-option: $colors--dark-theme--background-alt,
-    $color-border: $colors--dark-theme--border-high-contrast,
-    $color-text: $colors--dark-theme--text-default,
-    $color-text-placeholder: $colors--dark-theme--text-muted
-  );
 }

--- a/templates/docs/examples/base/forms/labels.html
+++ b/templates/docs/examples/base/forms/labels.html
@@ -9,7 +9,7 @@
   <input type="email" id="exampleTextInput" name="exampleTextInput" placeholder="example@canonical.com" autocomplete="email"/>
   <label for="textarea">Tell us about your project or interest</label>
   <textarea id="textarea" name="textarea" rows="3" name="textareaExample1">Ubuntu</textarea>
-  <label for="textarea2">Data privay</label>
+  <label for="textarea2">Data privacy</label>
   <textarea id="textarea2" name="textarea2" rows="3" readonly="readonly" name="textareaExample2">Read-only</textarea>
 </form>
 {% endblock %}

--- a/templates/docs/examples/patterns/forms/forms-dark.html
+++ b/templates/docs/examples/patterns/forms/forms-dark.html
@@ -3,26 +3,17 @@
 
 {% block standalone_css %}patterns_forms{% endblock %}
 
-
-{% block style %}
-<style>
-  body {
-    background: #262626;
-    color: #fff;
-  }
-</style>
-{% endblock %}
-
+{% set is_dark = true %}
 {% block content %}
 <form>
   <label for="exampleTextInputHelp">Email address</label>
-  <input class="p-form-validation__input is-dark" type="email" id="exampleTextInputHelp" placeholder="example@canonical.com" name="exampleTextInputHelp" autocomplete="email" aria-describedby="exampleInputHelpMessage"/>
-  <p class="p-form-help-text is-dark" id="exampleInputHelpMessage">
+  <input class="p-form-validation__input" type="email" id="exampleTextInputHelp" placeholder="example@canonical.com" name="exampleTextInputHelp" autocomplete="email" aria-describedby="exampleInputHelpMessage"/>
+  <p class="p-form-help-text" id="exampleInputHelpMessage">
     A notification email will be sent to entered email address.
   </p>
 
   <label for="exampleSelect">Ubuntu releases</label>
-  <select class="is-dark" name="exampleSelect" id="exampleSelect" name="exampleSelect" placeholder="Select an option">
+  <select name="exampleSelect" id="exampleSelect" name="exampleSelect" placeholder="Select an option">
     <option value="" disabled="disabled" selected>Select an option</option>
     <option value="1">Cosmic Cuttlefish</option>
     <option value="2">Bionic Beaver</option>
@@ -30,12 +21,12 @@
   </select>
 
   <label for="exampleTextarea">Comment</label>
-  <textarea id="exampleTextarea" class="is-dark" placeholder="Type your comment here..."></textarea>
+  <textarea id="exampleTextarea" placeholder="Type your comment here..."></textarea>
 
   <label class="p-checkbox is-dark">
     <input type="checkbox" aria-labelledby="checkboxLabel4" class="p-checkbox__input" aria-describedby="exampleTickHelpMessage">
     <span class="p-checkbox__label" id="checkboxLabel4">I agree to the Terms and Conditions</span>
   </label>
-  <p class="p-form-help-text is-tick-element is-dark" id="exampleTickHelpMessage">By checking this you confirm that you have read and agree to the Terms and Conditions.</p>
+  <p class="p-form-help-text is-tick-element" id="exampleTickHelpMessage">By checking this you confirm that you have read and agree to the Terms and Conditions.</p>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Done

- Add CSS variables theme support for base forms
- Fixed a minor typo
- Note: base forms now use `border-high-contrast` for the light & paper theme

Fixes [WD-7596](https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/970?selectedIssue=WD-7596)

## QA

- Open [demo](insert-demo-url)
- Go to `/docs/example`
- Make sure the base forms are consistent with their themes

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]


[WD-7596]: https://warthogs.atlassian.net/browse/WD-7596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ