### PR TITLE
Add theme support for forms help text

### DIFF
--- a/scss/_patterns_form-help-text.scss
+++ b/scss/_patterns_form-help-text.scss
@@ -4,39 +4,11 @@
   .p-form-help-text {
     @extend %small-text;
 
-    color: $color-mid-dark;
+    color: $colors--theme--text-muted;
     margin-top: -$sp-unit;
 
     &.is-tick-element {
       margin-left: $sph--large + $form-tick-box-size;
     }
   }
-
-  @if ($theme-default-forms == 'dark') {
-    .p-form-help-text {
-      @include vf-form-help-text-dark-theme;
-    }
-  } @else {
-    .p-form-help-text {
-      @include vf-form-help-text-light-theme;
-    }
-  }
-
-  .is-dark .p-form-help-text,
-  .p-form-help-text.is-dark {
-    @include vf-form-help-text-dark-theme;
-  }
-
-  .is-light .p-form-help-text,
-  .p-form-help-text.is-light {
-    @include vf-form-help-text-light-theme;
-  }
-}
-
-@mixin vf-form-help-text-dark-theme {
-  color: $colors--dark-theme--text-muted;
-}
-
-@mixin vf-form-help-text-light-theme {
-  color: $colors--light-theme--text-muted;
 }


### PR DESCRIPTION
## Done

- Depends on base forms theme update: https://github.com/canonical/vanilla-framework/pull/4974
- Add theme support for Forms / Help text

Fixes [list issues/bugs if needed]

## QA

- Open [demo](insert-demo-url)
- Go to `/docs/examples/patterns/forms/help-text`
- Check if themes are updated accordingly for help text
- Note: checkbox label shouldn't be updating with the theme as it's still WIP

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
