### PR TITLE
Add theme support for forms password toggle

### DIFF
--- a/scss/_patterns_form-password-toggle.scss
+++ b/scss/_patterns_form-password-toggle.scss
@@ -18,7 +18,7 @@
   .p-form-password-toggle + [type='text'] {
     &[readonly],
     &[readonly='readonly'] {
-      color: $colors--light-theme--text-default;
+      color: $colors--theme--text-default;
     }
   }
 }


### PR DESCRIPTION
## Done

- Depends on base forms theme update: https://github.com/canonical/vanilla-framework/pull/4974
- Added CSS variable theme support for Forms / Password toggle

Fixes [list issues/bugs if needed]

## QA

- Open [demo](insert-demo-url)
- Go to `/docs/examples/patterns/forms/password-toggle`
- Add `readonly="readonly"` to one of the input texts and click on Show password toggle
- The readonly text should inherit the correct colour according to its theme
- Note: Show button shouldn't be updating with the theme as it's still WIP
### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
