### PR TITLE
Add theme support for forms tick elements

### DIFF
--- a/scss/_patterns_form-tick-elements.scss
+++ b/scss/_patterns_form-tick-elements.scss
@@ -54,8 +54,8 @@
 
   %vf-pseudo-tick-box-checked {
     &::before {
-      background-color: $color-link;
-      border-color: $color-link;
+      background-color: $colors--theme--link;
+      border-color: $colors--theme--link;
     }
 
     &::after {
@@ -79,7 +79,7 @@
     &::after {
       border-bottom: 2px solid;
       border-left: 2px solid;
-      color: $colors--theme--tick-element;
+      color: $colors--theme--background-default;
       height: $form-tick-height;
       left: $form-tick-height * 0.5;
       top: calc($baseline-position - $form-tick-box-size + $form-tick-offset-top + $form-tick-box-nudge);
@@ -104,7 +104,7 @@
     }
 
     &::after {
-      background-color: $colors--theme--tick-element;
+      background-color: $colors--theme--background-default;
       border-radius: 50%;
       height: $form-radio-inner-circle-diameter;
       left: #{($form-tick-box-size - $form-radio-inner-circle-diameter) * 0.5};

--- a/scss/_patterns_form-tick-elements.scss
+++ b/scss/_patterns_form-tick-elements.scss
@@ -40,7 +40,7 @@
     // tick/circle
     &::after {
       content: '';
-      opacity: 0;      
+      opacity: 0;
     }
 
     .p-muted-heading & {

--- a/scss/_patterns_form-tick-elements.scss
+++ b/scss/_patterns_form-tick-elements.scss
@@ -11,6 +11,7 @@
   }
 
   %vf-pseudo-tick-box {
+    color: $colors--theme--text-default;
     padding-left: $sph--large + $form-tick-box-size;
     position: relative;
 
@@ -26,6 +27,8 @@
 
     // container
     &::before {
+      background: $colors--theme--background-default;
+      border: $input-border-thickness solid $colors--theme--border-high-contrast;
       content: '';
       height: $form-tick-box-size;
       left: 0;
@@ -37,15 +40,15 @@
     // tick/circle
     &::after {
       content: '';
-      opacity: 0;
+      opacity: 0;      
     }
 
     .p-muted-heading & {
-      color: $colors--light-theme--text-muted;
+      color: $colors--theme--text-muted;
     }
 
     &:hover::before {
-      background-color: $colors--light-theme--background-hover;
+      background-color: $colors--theme--background-hover;
     }
   }
 
@@ -76,6 +79,7 @@
     &::after {
       border-bottom: 2px solid;
       border-left: 2px solid;
+      color: $colors--theme--tick-element;
       height: $form-tick-height;
       left: $form-tick-height * 0.5;
       top: calc($baseline-position - $form-tick-box-size + $form-tick-offset-top + $form-tick-box-nudge);
@@ -100,6 +104,7 @@
     }
 
     &::after {
+      background-color: $colors--theme--tick-element;
       border-radius: 50%;
       height: $form-radio-inner-circle-diameter;
       left: #{($form-tick-box-size - $form-radio-inner-circle-diameter) * 0.5};
@@ -208,128 +213,4 @@
   .p-radio + .p-checkbox {
     margin-top: -$sp-unit;
   }
-
-  // Theming
-  @if ($theme-default-forms == 'dark') {
-    .p-checkbox__label {
-      @include vf-checkbox-dark-theme;
-    }
-
-    .p-radio__label {
-      @include vf-radio-dark-theme;
-    }
-
-    .p-checkbox.is-light .p-checkbox__label {
-      @include vf-checkbox-light-theme;
-    }
-
-    .p-radio.is-light .p-radio__label {
-      @include vf-radio-light-theme;
-    }
-  } @else {
-    .p-checkbox__label {
-      @include vf-checkbox-light-theme;
-    }
-
-    .p-radio__label {
-      @include vf-radio-light-theme;
-    }
-
-    .p-checkbox.is-dark .p-checkbox__label {
-      @include vf-checkbox-dark-theme;
-    }
-
-    .p-radio.is-dark .p-radio__label {
-      @include vf-radio-dark-theme;
-    }
-  }
-}
-
-// theme for common properties on radios and checkboxes
-@mixin vf-tick-elements-theme(
-  // color of the tick element label text
-  $color-tick-text,
-  // color of the tick element background
-  $color-tick-background,
-  // color of the tick element border
-  $color-tick-border: $colors--light-theme--border-high-contrast
-) {
-  color: $color-tick-text;
-
-  &::before {
-    background: $color-tick-background;
-    border: $input-border-thickness solid $color-tick-border;
-  }
-}
-
-// theme for checkbox (including common properties)
-@mixin vf-checkbox-theme(
-  // color of the tick element label text
-  $color-tick-text,
-  // color of the tick element background
-  $color-tick-background,
-  // color of the tick element border
-  $color-tick-border,
-  // color of the checkbox tick
-  $color-checkbox-tick
-) {
-  @include vf-tick-elements-theme($color-tick-text, $color-tick-background, $color-tick-border);
-
-  &::after {
-    color: $color-checkbox-tick;
-  }
-}
-
-@mixin vf-checkbox-light-theme {
-  @include vf-checkbox-theme(
-    $color-tick-text: $colors--light-theme--text-default,
-    $color-tick-background: $colors--light-theme--background-default,
-    $color-tick-border: $colors--light-theme--border-high-contrast,
-    $color-checkbox-tick: $colors--light-theme--background-default
-  );
-}
-
-@mixin vf-checkbox-dark-theme {
-  @include vf-checkbox-theme(
-    $color-tick-text: $colors--dark-theme--text-default,
-    $color-tick-background: $colors--dark-theme--background-default,
-    $color-tick-border: $colors--dark-theme--border-high-contrast,
-    $color-checkbox-tick: $colors--dark-theme--text-default
-  );
-}
-
-// theme for radio (including common properties)
-@mixin vf-radio-theme(
-  // color of the tick element label text
-  $color-tick-text,
-  // color of the tick element background
-  $color-tick-background,
-  // color of the tick element border
-  $color-tick-border,
-  // color of the radio dot
-  $color-radio-dot
-) {
-  @include vf-tick-elements-theme($color-tick-text, $color-tick-background, $color-tick-border);
-
-  &::after {
-    background-color: $color-radio-dot;
-  }
-}
-
-@mixin vf-radio-light-theme {
-  @include vf-radio-theme(
-    $color-tick-text: $colors--light-theme--text-default,
-    $color-tick-background: $colors--light-theme--background-default,
-    $color-tick-border: $colors--light-theme--border-high-contrast,
-    $color-radio-dot: $colors--light-theme--background-default
-  );
-}
-
-@mixin vf-radio-dark-theme {
-  @include vf-radio-theme(
-    $color-tick-text: $colors--dark-theme--text-default,
-    $color-tick-background: $colors--dark-theme--background-default,
-    $color-tick-border: $colors--dark-theme--border-high-contrast,
-    $color-radio-dot: $colors--dark-theme--text-default
-  );
 }

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -261,7 +261,6 @@ $colors--theme--background-information-active: var(--vf-color-background-informa
   --vf-color-text-inactive: #{$colors--light-theme--text-inactive};
 
   --vf-color-link: #{$colors--light-theme--link};
-  
   --vf-color-background-default: #{$colors--light-theme--background-default};
   --vf-color-background-alt: #{$colors--light-theme--background-alt};
   --vf-color-background-inputs: #{$colors--light-theme--background-inputs};
@@ -300,9 +299,7 @@ $colors--theme--background-information-active: var(--vf-color-background-informa
   --vf-color-text-default: #{$colors--dark-theme--text-default};
   --vf-color-text-muted: #{$colors--dark-theme--text-muted};
   --vf-color-text-inactive: #{$colors--dark-theme--text-inactive};
-  
   --vf-color-link: #{$colors--dark-theme--link};
-  
   --vf-color-background-default: #{$colors--dark-theme--background-default};
   --vf-color-background-alt: #{$colors--dark-theme--background-alt};
   --vf-color-background-inputs: #{$colors--dark-theme--background-inputs};

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -113,6 +113,8 @@ $colors--light-theme--border-default: rgba($color-x-dark, 0.2) !default;
 $colors--light-theme--border-high-contrast: rgba($color-x-dark, 0.56) !default;
 $colors--light-theme--border-low-contrast: rgba($color-x-dark, 0.1) !default;
 
+$colors--light-theme--tick-element: #fff !default;
+
 $colors-light-theme--tinted-backgrounds: (
   neutral: (
     default: #f2f2f2,
@@ -165,6 +167,8 @@ $colors--dark-theme--background-overlay: transparentize($color-dark, 0.15) !defa
 $colors--dark-theme--border-default: rgba($colors--dark-theme--text-default, 0.3) !default;
 $colors--dark-theme--border-high-contrast: rgba($colors--dark-theme--text-default, 0.5) !default;
 $colors--dark-theme--border-low-contrast: rgba($colors--dark-theme--text-default, 0.05) !default;
+
+$colors--dark-theme--tick-element: hsl(0, 0%, 100%) !default;
 
 $colors-dark-theme--tinted-backgrounds: (
   neutral: (
@@ -226,6 +230,8 @@ $colors--theme--border-default: var(--vf-color-border-default);
 $colors--theme--border-high-contrast: var(--vf-color-border-high-contrast);
 $colors--theme--border-low-contrast: var(--vf-color-border-low-contrast);
 
+$colors--theme--tick-element: var(--vf-color-tick-element);
+
 // Theme colors exposed as CSS custom properties
 @mixin vf-theme-light {
   // SCSS variables need to be interpolated to work in CSS custom properties
@@ -243,6 +249,8 @@ $colors--theme--border-low-contrast: var(--vf-color-border-low-contrast);
   --vf-color-border-default: #{$colors--light-theme--border-default};
   --vf-color-border-high-contrast: #{$colors--light-theme--border-high-contrast};
   --vf-color-border-low-contrast: #{$colors--light-theme--border-low-contrast};
+
+  --vf-color-tick-element: #{$colors--light-theme--tick-element};
 }
 
 @mixin vf-theme-dark {
@@ -261,6 +269,8 @@ $colors--theme--border-low-contrast: var(--vf-color-border-low-contrast);
   --vf-color-border-default: #{$colors--dark-theme--border-default};
   --vf-color-border-high-contrast: #{$colors--dark-theme--border-high-contrast};
   --vf-color-border-low-contrast: #{$colors--dark-theme--border-low-contrast};
+
+  --vf-color-tick-element: #{$colors--dark-theme--tick-element};
 }
 
 @mixin vf-theme-paper {

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -113,7 +113,7 @@ $colors--light-theme--border-default: rgba($color-x-dark, 0.2) !default;
 $colors--light-theme--border-high-contrast: rgba($color-x-dark, 0.56) !default;
 $colors--light-theme--border-low-contrast: rgba($color-x-dark, 0.1) !default;
 
-$colors--light-theme--tick-element: #fff !default;
+$colors--light-theme--link: $color-link !default;
 
 $colors-light-theme--tinted-backgrounds: (
   neutral: (
@@ -168,7 +168,7 @@ $colors--dark-theme--border-default: rgba($colors--dark-theme--text-default, 0.3
 $colors--dark-theme--border-high-contrast: rgba($colors--dark-theme--text-default, 0.5) !default;
 $colors--dark-theme--border-low-contrast: rgba($colors--dark-theme--text-default, 0.05) !default;
 
-$colors--dark-theme--tick-element: hsl(0, 0%, 100%) !default;
+$colors--dark-theme--link: $color-link-dark !default;
 
 $colors-dark-theme--tinted-backgrounds: (
   neutral: (
@@ -230,7 +230,7 @@ $colors--theme--border-default: var(--vf-color-border-default);
 $colors--theme--border-high-contrast: var(--vf-color-border-high-contrast);
 $colors--theme--border-low-contrast: var(--vf-color-border-low-contrast);
 
-$colors--theme--tick-element: var(--vf-color-tick-element);
+$colors--theme--link: var(--vf-color-link);
 
 // Theme colors exposed as CSS custom properties
 @mixin vf-theme-light {
@@ -250,7 +250,7 @@ $colors--theme--tick-element: var(--vf-color-tick-element);
   --vf-color-border-high-contrast: #{$colors--light-theme--border-high-contrast};
   --vf-color-border-low-contrast: #{$colors--light-theme--border-low-contrast};
 
-  --vf-color-tick-element: #{$colors--light-theme--tick-element};
+  --vf-color-link: #{$colors--light-theme--link};
 }
 
 @mixin vf-theme-dark {
@@ -270,7 +270,7 @@ $colors--theme--tick-element: var(--vf-color-tick-element);
   --vf-color-border-high-contrast: #{$colors--dark-theme--border-high-contrast};
   --vf-color-border-low-contrast: #{$colors--dark-theme--border-low-contrast};
 
-  --vf-color-tick-element: #{$colors--dark-theme--tick-element};
+  --vf-color-link: #{$colors--dark-theme--link};
 }
 
 @mixin vf-theme-paper {

--- a/templates/docs/examples/patterns/forms/forms-dark.html
+++ b/templates/docs/examples/patterns/forms/forms-dark.html
@@ -23,7 +23,7 @@
   <label for="exampleTextarea">Comment</label>
   <textarea id="exampleTextarea" placeholder="Type your comment here..."></textarea>
 
-  <label class="p-checkbox is-dark">
+  <label class="p-checkbox">
     <input type="checkbox" aria-labelledby="checkboxLabel4" class="p-checkbox__input" aria-describedby="exampleTickHelpMessage">
     <span class="p-checkbox__label" id="checkboxLabel4">I agree to the Terms and Conditions</span>
   </label>


### PR DESCRIPTION
## Done

- Added theme support for `Forms / Tick Elements` - radio & checkbox 


## QA

- Open [demo](insert-demo-url)
- Go to `/docs/examples/patterns/forms/tick-variants` and `/docs/examples/patterns/forms/forms-dark`
- Change body theme to light/dark/paper and see themes update accordingly

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
