### PR TITLE
Export status color variables as CSS custom properties

### DIFF
--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -226,6 +226,27 @@ $colors--theme--border-default: var(--vf-color-border-default);
 $colors--theme--border-high-contrast: var(--vf-color-border-high-contrast);
 $colors--theme--border-low-contrast: var(--vf-color-border-low-contrast);
 
+$color--theme--border-positive: var(--vf-color-border-positive);
+$color--theme--border-negative: var(--vf-color-border-negative);
+$color--theme--border-information: var(--vf-color-border-information);
+$color--theme--border-caution: var(--vf-color-border-caution);
+
+$color--theme--background--neutral--default: var(--vf-color-background-neutral-default);
+$color--theme--background--neutral--hover: var(--vf-color-background-neutral-hover);
+$color--theme--background--neutral--active: var(--vf-color-background-neutral-active);
+$color--theme--background--positive--default: var(--vf-color-background-positive-default);
+$color--theme--background--positive--hover: var(--vf-color-background-positive-hover);
+$color--theme--background--positive--active: var(--vf-color-background-positive-active);
+$color--theme--background--caution--default: var(--vf-color-background-caution-default);
+$color--theme--background--caution--hover: var(--vf-color-background-caution-hover);
+$color--theme--background--caution--active: var(--vf-color-background-caution-active);
+$color--theme--background--negative--default: var(--vf-color-background-negative-default);
+$color--theme--background--negative--hover: var(--vf-color-background-negative-hover);
+$color--theme--background--negative--active: var(--vf-color-background-negative-active);
+$color--theme--background--information--default: var(--vf-color-background-information-default);
+$color--theme--background--information--hover: var(--vf-color-background-information-hover);
+$color--theme--background--information--active: var(--vf-color-background-information-active);
+
 // Theme colors exposed as CSS custom properties
 @mixin vf-theme-light {
   // SCSS variables need to be interpolated to work in CSS custom properties
@@ -243,6 +264,27 @@ $colors--theme--border-low-contrast: var(--vf-color-border-low-contrast);
   --vf-color-border-default: #{$colors--light-theme--border-default};
   --vf-color-border-high-contrast: #{$colors--light-theme--border-high-contrast};
   --vf-color-border-low-contrast: #{$colors--light-theme--border-low-contrast};
+
+  --vf-color-border-positive: #{map-get($colors-light-theme--tinted-borders, positive)};
+  --vf-color-border-negative: #{map-get($colors-light-theme--tinted-borders, negative)};
+  --vf-color-border-information: #{map-get($colors-light-theme--tinted-borders, information)};
+  --vf-color-border-caution: #{map-get($colors-light-theme--tinted-borders, caution)};
+
+  --vf-color-background-neutral-default: #{map-get($colors-light-theme--tinted-backgrounds, neutral, default)};
+  --vf-color-background-neutral-hover: #{map-get($colors-light-theme--tinted-backgrounds, neutral, hover)};
+  --vf-color-background-neutral-active: #{map-get($colors-light-theme--tinted-backgrounds, neutral, active)};
+  --vf-color-background-positive-default: #{map-get($colors-light-theme--tinted-backgrounds, positive, default)};
+  --vf-color-background-positive-hover: #{map-get($colors-light-theme--tinted-backgrounds, positive, hover)};
+  --vf-color-background-positive-active: #{map-get($colors-light-theme--tinted-backgrounds, positive, active)};
+  --vf-color-background-caution-default: #{map-get($colors-light-theme--tinted-backgrounds, caution, default)};
+  --vf-color-background-caution-hover: #{map-get($colors-light-theme--tinted-backgrounds, caution, hover)};
+  --vf-color-background-caution-active: #{map-get($colors-light-theme--tinted-backgrounds, caution, active)};
+  --vf-color-background-negative-default: #{map-get($colors-light-theme--tinted-backgrounds, negative, default)};
+  --vf-color-background-negative-hover: #{map-get($colors-light-theme--tinted-backgrounds, negative, hover)};
+  --vf-color-background-negative-active: #{map-get($colors-light-theme--tinted-backgrounds, negative, active)};
+  --vf-color-background-information-default: #{map-get($colors-light-theme--tinted-backgrounds, information, default)};
+  --vf-color-background-information-hover: #{map-get($colors-light-theme--tinted-backgrounds, information, hover)};
+  --vf-color-background-information-active: #{map-get($colors-light-theme--tinted-backgrounds, information, active)};
 }
 
 @mixin vf-theme-dark {
@@ -261,6 +303,27 @@ $colors--theme--border-low-contrast: var(--vf-color-border-low-contrast);
   --vf-color-border-default: #{$colors--dark-theme--border-default};
   --vf-color-border-high-contrast: #{$colors--dark-theme--border-high-contrast};
   --vf-color-border-low-contrast: #{$colors--dark-theme--border-low-contrast};
+
+  --vf-color-border-positive: #{map-get($colors-dark-theme--tinted-borders, positive)};
+  --vf-color-border-negative: #{map-get($colors-dark-theme--tinted-borders, negative)};
+  --vf-color-border-information: #{map-get($colors-dark-theme--tinted-borders, information)};
+  --vf-color-border-caution: #{map-get($colors-dark-theme--tinted-borders, caution)};
+
+  --vf-color-background-neutral-default: #{map-get($colors-dark-theme--tinted-backgrounds, neutral, default)};
+  --vf-color-background-neutral-hover: #{map-get($colors-dark-theme--tinted-backgrounds, neutral, hover)};
+  --vf-color-background-neutral-active: #{map-get($colors-dark-theme--tinted-backgrounds, neutral, active)};
+  --vf-color-background-positive-default: #{map-get($colors-dark-theme--tinted-backgrounds, positive, default)};
+  --vf-color-background-positive-hover: #{map-get($colors-dark-theme--tinted-backgrounds, positive, hover)};
+  --vf-color-background-positive-active: #{map-get($colors-dark-theme--tinted-backgrounds, positive, active)};
+  --vf-color-background-caution-default: #{map-get($colors-dark-theme--tinted-backgrounds, caution, default)};
+  --vf-color-background-caution-hover: #{map-get($colors-dark-theme--tinted-backgrounds, caution, hover)};
+  --vf-color-background-caution-active: #{map-get($colors-dark-theme--tinted-backgrounds, caution, active)};
+  --vf-color-background-negative-default: #{map-get($colors-dark-theme--tinted-backgrounds, negative, default)};
+  --vf-color-background-negative-hover: #{map-get($colors-dark-theme--tinted-backgrounds, negative, hover)};
+  --vf-color-background-negative-active: #{map-get($colors-dark-theme--tinted-backgrounds, negative, active)};
+  --vf-color-background-information-default: #{map-get($colors-dark-theme--tinted-backgrounds, information, default)};
+  --vf-color-background-information-hover: #{map-get($colors-dark-theme--tinted-backgrounds, information, hover)};
+  --vf-color-background-information-active: #{map-get($colors-dark-theme--tinted-backgrounds, information, active)};
 }
 
 @mixin vf-theme-paper {

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -231,21 +231,21 @@ $color--theme--border-negative: var(--vf-color-border-negative);
 $color--theme--border-information: var(--vf-color-border-information);
 $color--theme--border-caution: var(--vf-color-border-caution);
 
-$color--theme--background--neutral--default: var(--vf-color-background-neutral-default);
-$color--theme--background--neutral--hover: var(--vf-color-background-neutral-hover);
-$color--theme--background--neutral--active: var(--vf-color-background-neutral-active);
-$color--theme--background--positive--default: var(--vf-color-background-positive-default);
-$color--theme--background--positive--hover: var(--vf-color-background-positive-hover);
-$color--theme--background--positive--active: var(--vf-color-background-positive-active);
-$color--theme--background--caution--default: var(--vf-color-background-caution-default);
-$color--theme--background--caution--hover: var(--vf-color-background-caution-hover);
-$color--theme--background--caution--active: var(--vf-color-background-caution-active);
-$color--theme--background--negative--default: var(--vf-color-background-negative-default);
-$color--theme--background--negative--hover: var(--vf-color-background-negative-hover);
-$color--theme--background--negative--active: var(--vf-color-background-negative-active);
-$color--theme--background--information--default: var(--vf-color-background-information-default);
-$color--theme--background--information--hover: var(--vf-color-background-information-hover);
-$color--theme--background--information--active: var(--vf-color-background-information-active);
+$color--theme--background--neutral-default: var(--vf-color-background-neutral-default);
+$color--theme--background--neutral-hover: var(--vf-color-background-neutral-hover);
+$color--theme--background--neutral-active: var(--vf-color-background-neutral-active);
+$color--theme--background--positive-default: var(--vf-color-background-positive-default);
+$color--theme--background--positive-hover: var(--vf-color-background-positive-hover);
+$color--theme--background--positive-active: var(--vf-color-background-positive-active);
+$color--theme--background--caution-default: var(--vf-color-background-caution-default);
+$color--theme--background--caution-hover: var(--vf-color-background-caution-hover);
+$color--theme--background--caution-active: var(--vf-color-background-caution-active);
+$color--theme--background--negative-default: var(--vf-color-background-negative-default);
+$color--theme--background--negative-hover: var(--vf-color-background-negative-hover);
+$color--theme--background--negative-active: var(--vf-color-background-negative-active);
+$color--theme--background--information-default: var(--vf-color-background-information-default);
+$color--theme--background--information-hover: var(--vf-color-background-information-hover);
+$color--theme--background--information-active: var(--vf-color-background-information-active);
 
 // Theme colors exposed as CSS custom properties
 @mixin vf-theme-light {

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -231,21 +231,21 @@ $color--theme--border-negative: var(--vf-color-border-negative);
 $color--theme--border-information: var(--vf-color-border-information);
 $color--theme--border-caution: var(--vf-color-border-caution);
 
-$color--theme--background--neutral-default: var(--vf-color-background-neutral-default);
-$color--theme--background--neutral-hover: var(--vf-color-background-neutral-hover);
-$color--theme--background--neutral-active: var(--vf-color-background-neutral-active);
-$color--theme--background--positive-default: var(--vf-color-background-positive-default);
-$color--theme--background--positive-hover: var(--vf-color-background-positive-hover);
-$color--theme--background--positive-active: var(--vf-color-background-positive-active);
-$color--theme--background--caution-default: var(--vf-color-background-caution-default);
-$color--theme--background--caution-hover: var(--vf-color-background-caution-hover);
-$color--theme--background--caution-active: var(--vf-color-background-caution-active);
-$color--theme--background--negative-default: var(--vf-color-background-negative-default);
-$color--theme--background--negative-hover: var(--vf-color-background-negative-hover);
-$color--theme--background--negative-active: var(--vf-color-background-negative-active);
-$color--theme--background--information-default: var(--vf-color-background-information-default);
-$color--theme--background--information-hover: var(--vf-color-background-information-hover);
-$color--theme--background--information-active: var(--vf-color-background-information-active);
+$color--theme--background-neutral-default: var(--vf-color-background-neutral-default);
+$color--theme--background-neutral-hover: var(--vf-color-background-neutral-hover);
+$color--theme--background-neutral-active: var(--vf-color-background-neutral-active);
+$color--theme--background-positive-default: var(--vf-color-background-positive-default);
+$color--theme--background-positive-hover: var(--vf-color-background-positive-hover);
+$color--theme--background-positive-active: var(--vf-color-background-positive-active);
+$color--theme--background-caution-default: var(--vf-color-background-caution-default);
+$color--theme--background-caution-hover: var(--vf-color-background-caution-hover);
+$color--theme--background-caution-active: var(--vf-color-background-caution-active);
+$color--theme--background-negative-default: var(--vf-color-background-negative-default);
+$color--theme--background-negative-hover: var(--vf-color-background-negative-hover);
+$color--theme--background-negative-active: var(--vf-color-background-negative-active);
+$color--theme--background-information-default: var(--vf-color-background-information-default);
+$color--theme--background-information-hover: var(--vf-color-background-information-hover);
+$color--theme--background-information-active: var(--vf-color-background-information-active);
 
 // Theme colors exposed as CSS custom properties
 @mixin vf-theme-light {


### PR DESCRIPTION
## Done

- Export status color variables as CSS custom properties

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).



