### PR TITLE
Add theme support for search box

### DIFF
--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -38,12 +38,32 @@
       }
     }
 
+    // Theme set on body element
     .p-search-box__input {
+      background-color: $colors--theme--background-inputs;
+      border-color: $colors--theme--border-high-contrast;
+
+      color: $colors--theme--text-default;
       flex: 1 1 100%;
       margin-bottom: 0;
       padding-right: calc(2 * (2 * $spv-nudge + map-get($line-heights, default-text)));
       position: absolute;
       right: 0;
+
+      &:hover,
+      &:-webkit-autofill:hover {
+        background-color: $colors--theme--background-hover !important;
+      }
+
+      &:active,
+      &:focus,
+      &:-internal-autofill-selected,
+      &:-webkit-autofill,
+      &:-webkit-autofill:focus {
+        // XXX: remove important once the button {} selector is refactored to use themeing. At the moment, it trumps these.
+        background-color: $colors--theme--background-active !important;
+        border-color: $colors--theme--border-high-contrast !important;
+      }
 
       &::-webkit-search-cancel-button {
         -webkit-appearance: none; // stylelint-disable-line property-no-vendor-prefix
@@ -64,7 +84,6 @@
     }
   }
 
-  // Theming
   %transparent-button {
     &,
     &:active,
@@ -74,102 +93,4 @@
       border-width: 0;
     }
   }
-
-  @if ($theme-default-p-search-box == 'dark') {
-    .p-search-box__input {
-      @include vf-search-box-dark-theme;
-    }
-  } @else {
-    .p-search-box {
-      .p-search-box__input {
-        @include vf-search-box-light-theme;
-      }
-    }
-  }
-
-  // beware that the order of the following classes is important
-  // as they are used to override the default theme
-  .is-paper .p-search-box {
-    .p-search-box__input {
-      @include vf-search-box-paper-theme;
-    }
-  }
-
-  .p-search-box.is-light {
-    .p-search-box__input {
-      @include vf-search-box-light-theme;
-    }
-  }
-
-  .p-search-box.is-dark {
-    .p-search-box__input {
-      @include vf-search-box-dark-theme;
-    }
-  }
-}
-
-@mixin vf-search-box-theme(
-  $color-search-box-background,
-  $color-search-box-background-hover,
-  $color-search-box-background-active,
-  $color-search-box-border,
-  $color-search-box-text
-) {
-  //XXX: This should inherit from input color theming. Once that becomes available, delete this.
-  background-color: $color-search-box-background;
-  border-color: $color-search-box-border;
-  color: $color-search-box-text;
-
-  &:hover,
-  &:-webkit-autofill:hover {
-    background-color: $color-search-box-background-hover !important;
-  }
-
-  &:active,
-  &:focus,
-  &:-internal-autofill-selected,
-  &:-webkit-autofill,
-  &:-webkit-autofill:focus {
-    // XXX: remove important once the button {} selector is refactored to use themeing. At the moment, it trumps these.
-    background-color: $color-search-box-background-active !important;
-    border-color: $color-search-box-border !important;
-  }
-}
-
-@mixin vf-search-box-light-theme {
-  @include vf-search-box-theme(
-    $color-search-box-background: $colors--light-theme--background-inputs,
-    $color-search-box-background-hover: $colors--light-theme--background-hover,
-    $color-search-box-background-active: $colors--light-theme--background-active,
-    $color-search-box-border: $colors--light-theme--border-high-contrast,
-    $color-search-box-text: $colors--light-theme--text-default
-  );
-}
-
-@mixin vf-search-box-dark-theme {
-  @include vf-search-box-theme(
-    $color-search-box-background: lighten($colors--dark-theme--background-default, 10%),
-    $color-search-box-background-hover: $colors--dark-theme--background-hover,
-    $color-search-box-background-active: $colors--dark-theme--background-active,
-    $color-search-box-border: $color-x-light,
-    $color-search-box-text: $colors--dark-theme--text-default
-  );
-
-  &::placeholder {
-    color: $colors--dark-theme--text-default;
-  }
-}
-
-@mixin vf-search-box-paper-theme {
-  // XXX: currently these colours are transparent,
-  // so they work both on paper and white backgrounds.
-  // We may need later to add a specific override for
-  // a white background within paper themed pages.
-  @include vf-search-box-theme(
-    $color-search-box-background: $colors--paper-theme--background-inputs,
-    $color-search-box-background-hover: $colors--paper-theme--background-hover,
-    $color-search-box-background-active: $colors--paper-theme--background-active,
-    $color-search-box-border: $colors--light-theme--border-high-contrast,
-    $color-search-box-text: $colors--light-theme--text-default
-  );
 }

--- a/templates/docs/examples/patterns/search-box/default-dark.html
+++ b/templates/docs/examples/patterns/search-box/default-dark.html
@@ -3,18 +3,19 @@
 
 {% block standalone_css %}patterns_search-box{% endblock %}
 
+{% set is_dark = true %}
 {% block content %}
-<form class="p-search-box is-dark">
+<form class="p-search-box">
   <label class="u-off-screen" for="search">Search</label>
   <input id="search" type="search" class="p-search-box__input" placeholder="Search" name="search" autocomplete="on" required>
-  <button type="reset" class="p-search-box__reset"><i class="p-icon--close is-light">Close</i></button>
+  <button type="reset" class="p-search-box__reset"><i class="p-icon--close {% if is_dark %}is-light{% endif %}">Close</i></button>
   <button type="submit" class="p-search-box__button"><i class="p-icon--search is-light">Search</i></button>
 </form>
-<form class="p-search-box is-dark">
+<form class="p-search-box">
   <label class="u-off-screen" for="search-disabled">Search</label>
   <input type="search" id="search-disabled" class="p-search-box__input" name="search" placeholder="Search" autocomplete="on" required disabled>
-  <button type="reset" class="p-search-box__reset" disabled><i class="p-icon--close is-light">Close</i></button>
-  <button type="submit" class="p-search-box__button" disabled><i class="p-icon--search is-light">Search</i></button>
+  <button type="reset" class="p-search-box__reset" disabled><i class="p-icon--close {% if is_dark %}is-light{% endif %}">Close</i></button>
+  <button type="submit" class="p-search-box__button" disabled><i class="p-icon--search {% if is_dark %}is-light{% endif %}">Search</i></button>
 </form>
 
 <script>


### PR DESCRIPTION
## Done

- Add theme support for search box

Fixes [WD-7597](https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/970?selectedIssue=WD-7597)

## QA

- Open [demo](insert-demo-url)
- Go to `/docs/examples/patterns/search-box/default` and `/docs/examples/patterns/search-box/default-dark`
- Search boxes should be styled according to their themes

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]


[WD-7597]: https://warthogs.atlassian.net/browse/WD-7597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ