### PR TITLE
Add more hero suru variants

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -76,6 +76,7 @@ patterns_buttons
 unsetting
 v3.0.
 Suru
+suru
 spec
 specs
 ×

--- a/releases.yml
+++ b/releases.yml
@@ -15,7 +15,7 @@
     - component: Suru
       url: /docs/patterns/suru
       status: Updated
-      notes: We've updated the Suru component to work as a hero section container, added new backgrounds for 25/75 and 50/50 splits, and updated the theme support.
+      notes: We've updated the Suru component to work as a hero section container, added new backgrounds for 25/75 and 50/50 splits, corner fan and pyramid surus, and updated the theme support.
 - version: 4.7.0
   features:
     - component: Navigation / 25/75 split

--- a/scss/_patterns_suru.scss
+++ b/scss/_patterns_suru.scss
@@ -77,8 +77,6 @@
     background-color: var(--vf-suru-background);
     color: $colors--theme--text-default;
 
-    min-height: $vf-suru-min-height;
-
     // same as %section-padding--default
     padding-bottom: $spv--strip-regular * 0.5;
 
@@ -96,29 +94,39 @@
     }
   }
 
-  .p-suru--fan-top,
-  .p-suru--fan-bottom {
-    background-image: var(--vf-suru-fan-top-right);
-    background-position: top right;
-    background-repeat: no-repeat;
-    background-size: 512px 385.5px; // based on image dimensions (2048x1542) scaled down by 0.25
-  }
+  // only apply suru background images on large screens
+  @media (min-width: $breakpoint-large) {
+    .p-suru--fan-top,
+    .p-suru--fan-bottom,
+    .p-suru--pyramid-left,
+    .p-suru--pyramid-right {
+      min-height: $vf-suru-min-height;
+    }
 
-  .p-suru--fan-bottom {
-    background-image: var(--vf-suru-fan-bottom-right);
-    background-position: bottom right;
-  }
+    .p-suru--fan-top,
+    .p-suru--fan-bottom {
+      background-image: var(--vf-suru-fan-top-right);
+      background-position: top right;
+      background-repeat: no-repeat;
+      background-size: 512px 385.5px; // based on image dimensions (2048x1542) scaled down by 0.25
+    }
 
-  .p-suru--pyramid-right,
-  .p-suru--pyramid-left {
-    background-image: var(--vf-suru-pyramid-top-left);
-    background-position: top left;
-    background-repeat: no-repeat;
-    background-size: 354px 258.75px; // based on image dimensions (1380x1035) scaled down by 0.25
-  }
+    .p-suru--fan-bottom {
+      background-image: var(--vf-suru-fan-bottom-right);
+      background-position: bottom right;
+    }
 
-  .p-suru--pyramid-right {
-    background-image: var(--vf-suru-pyramid-top-right);
-    background-position: top right;
+    .p-suru--pyramid-right,
+    .p-suru--pyramid-left {
+      background-image: var(--vf-suru-pyramid-top-left);
+      background-position: top left;
+      background-repeat: no-repeat;
+      background-size: 354px 258.75px; // based on image dimensions (1380x1035) scaled down by 0.25
+    }
+
+    .p-suru--pyramid-right {
+      background-image: var(--vf-suru-pyramid-top-right);
+      background-position: top right;
+    }
   }
 }

--- a/scss/_patterns_suru.scss
+++ b/scss/_patterns_suru.scss
@@ -11,12 +11,20 @@
       --vf-suru-background: #{$color-paper};
       --vf-suru-25-75: url('#{$assets-path}505636a6-0000_suru-main-25x75-light.png');
       --vf-suru-50-50: url('#{$assets-path}e66e280b-0001_suru-main-50x50-light.png');
+      --vf-suru-fan-top-right: url('#{$assets-path}ed94a429-0000_suru-corner-fan--top-right-light.jpg');
+      --vf-suru-fan-bottom-right: url('#{$assets-path}2adade55-suru-corner-fan--bottom-0000_light.jpg');
+      --vf-suru-pyramid-top-left: url('#{$assets-path}8846d6a5-suru-pyramid-top-corner_0000_light.jpg');
+      --vf-suru-pyramid-top-right: url('#{$assets-path}5d9f8cd3-suru-pyramid-top-right-corner_0000_light.jpg');
     }
 
     .is-dark {
       --vf-suru-background: #{$colors--theme--background-default};
       --vf-suru-25-75: url('#{$assets-path}7ccd4f39-0003_suru-main-25x75-dark.png');
       --vf-suru-50-50: url('#{$assets-path}70c2bbcd-0002_suru-main-50x50-dark.png');
+      --vf-suru-fan-top-right: url('#{$assets-path}fd6ef995-0001_suru-corner-fan--top-right-dark.jpg');
+      --vf-suru-fan-bottom-right: url('#{$assets-path}725af649-suru-corner-fan--bottom-0001_dark.jpg');
+      --vf-suru-pyramid-top-left: url('#{$assets-path}86ed5771-suru-pyramid-top-corner_0001_dark.jpg');
+      --vf-suru-pyramid-top-right: url('#{$assets-path}9f740811-suru-pyramid-top-right-corner_0001_dark.jpg');
     }
   }
 
@@ -24,6 +32,7 @@
   .p-suru--25-75,
   .p-suru--50-50 {
     background-color: var(--vf-suru-background);
+    color: $colors--theme--text-default;
 
     // padding top based on p-section--hero
     // bottom padding not needed (as it's covered by the suru background image)
@@ -57,5 +66,55 @@
       // aspect ratio of 50/50 background is the same, so no need to override
       background-image: var(--vf-suru-50-50);
     }
+  }
+
+  .p-suru--fan-top,
+  .p-suru--fan-bottom,
+  .p-suru--pyramid-left,
+  .p-suru--pyramid-right {
+    background-color: var(--vf-suru-background);
+    color: $colors--theme--text-default;
+
+    // same as %section-padding--default
+    padding-bottom: $spv--strip-regular * 0.5;
+
+    @media (min-width: $breakpoint-large) {
+      padding-bottom: $spv--strip-regular;
+    }
+
+    // padding top based on p-section--hero
+    // bottom padding not needed (as it's covered by the suru background image)
+    padding-top: $spv--large;
+
+    // on large screens, same as %section-padding--shallow
+    @media (min-width: $breakpoint-large) {
+      padding-top: $spv--x-large;
+    }
+  }
+
+  .p-suru--fan-top,
+  .p-suru--fan-bottom {
+    background-image: var(--vf-suru-fan-top-right);
+    background-position: top right;
+    background-repeat: no-repeat;
+    background-size: 512px 385.5px; // based on image dimensions (2048x1542) scaled down by 0.25
+  }
+
+  .p-suru--fan-bottom {
+    background-image: var(--vf-suru-fan-bottom-right);
+    background-position: bottom right;
+  }
+
+  .p-suru--pyramid-right,
+  .p-suru--pyramid-left {
+    background-image: var(--vf-suru-pyramid-top-left);
+    background-position: top left;
+    background-repeat: no-repeat;
+    background-size: 354px 258.75px; // based on image dimensions (1380x1035) scaled down by 0.25
+  }
+
+  .p-suru--pyramid-right {
+    background-image: var(--vf-suru-pyramid-top-right);
+    background-position: top right;
   }
 }

--- a/scss/_patterns_suru.scss
+++ b/scss/_patterns_suru.scss
@@ -1,6 +1,8 @@
 @import 'settings';
 
 @mixin vf-p-suru {
+  $vf-suru-min-height: 24rem;
+
   // add suru backgrounds to the themes
   @at-root {
     :root,
@@ -74,6 +76,8 @@
   .p-suru--pyramid-right {
     background-color: var(--vf-suru-background);
     color: $colors--theme--text-default;
+
+    min-height: $vf-suru-min-height;
 
     // same as %section-padding--default
     padding-bottom: $spv--strip-regular * 0.5;

--- a/templates/docs/examples/patterns/suru/fan-bottom.html
+++ b/templates/docs/examples/patterns/suru/fan-bottom.html
@@ -1,0 +1,15 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Suru / Fan bottom{% endblock %}
+
+{% block standalone_css %}patterns_suru{% endblock %}
+
+{% set is_paper = True %}
+{% block content %}
+<div class="p-suru--fan-bottom">
+    <div class="row--25-75">
+        <div class="col">
+            <h1>Suru fan bottom</h1>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/docs/examples/patterns/suru/fan-bottom.html
+++ b/templates/docs/examples/patterns/suru/fan-bottom.html
@@ -9,6 +9,7 @@
     <div class="row--25-75">
         <div class="col">
             <h1>Suru fan bottom</h1>
+            <p>Suru background is only visible on large screen.</p>
         </div>
     </div>
 </div>

--- a/templates/docs/examples/patterns/suru/fan-pyramid-left.html
+++ b/templates/docs/examples/patterns/suru/fan-pyramid-left.html
@@ -1,0 +1,15 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Suru / Pyramid left{% endblock %}
+
+{% block standalone_css %}patterns_suru{% endblock %}
+
+{% set is_paper = True %}
+{% block content %}
+<div class="p-suru--pyramid-left">
+    <div class="row--25-75">
+        <div class="col">
+            <h1>Suru pyramid left</h1>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/docs/examples/patterns/suru/fan-pyramid-left.html
+++ b/templates/docs/examples/patterns/suru/fan-pyramid-left.html
@@ -9,6 +9,7 @@
     <div class="row--25-75">
         <div class="col">
             <h1>Suru pyramid left</h1>
+            <p>Suru background is only visible on large screen.</p>
         </div>
     </div>
 </div>

--- a/templates/docs/examples/patterns/suru/fan-pyramid-right.html
+++ b/templates/docs/examples/patterns/suru/fan-pyramid-right.html
@@ -9,6 +9,7 @@
     <div class="row--25-75">
         <div class="col">
             <h1>Suru pyramid right</h1>
+            <p>Suru background is only visible on large screen.</p>
         </div>
     </div>
 </div>

--- a/templates/docs/examples/patterns/suru/fan-pyramid-right.html
+++ b/templates/docs/examples/patterns/suru/fan-pyramid-right.html
@@ -1,0 +1,15 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Suru / Pyramid right{% endblock %}
+
+{% block standalone_css %}patterns_suru{% endblock %}
+
+{% set is_paper = True %}
+{% block content %}
+<div class="p-suru--pyramid-right">
+    <div class="row--25-75">
+        <div class="col">
+            <h1>Suru pyramid right</h1>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/docs/examples/patterns/suru/fan-top.html
+++ b/templates/docs/examples/patterns/suru/fan-top.html
@@ -9,6 +9,7 @@
     <div class="row--25-75">
         <div class="col">
             <h1>Suru fan top</h1>
+            <p>Suru background is only visible on large screen.</p>
         </div>
     </div>
 </div>

--- a/templates/docs/examples/patterns/suru/fan-top.html
+++ b/templates/docs/examples/patterns/suru/fan-top.html
@@ -1,0 +1,15 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Suru / Fan top{% endblock %}
+
+{% block standalone_css %}patterns_suru{% endblock %}
+
+{% set is_paper = True %}
+{% block content %}
+<div class="p-suru--fan-top">
+    <div class="row--25-75">
+        <div class="col">
+            <h1>Suru fan top</h1>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/docs/examples/patterns/suru/variants.html
+++ b/templates/docs/examples/patterns/suru/variants.html
@@ -1,0 +1,104 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Suru / Variants{% endblock %}
+
+{% block standalone_css %}patterns_suru{% endblock %}
+
+{% set is_paper = True %}
+{% block content %}
+<div class="p-suru--25-75">
+    <div class="row--25-75">
+        <div class="col">
+            <h1>Suru 25/75</h1>
+        </div>
+    </div>
+</div>
+
+<div class="p-suru--25-75 is-dark">
+    <div class="row--25-75">
+        <div class="col">
+            <h1>Suru 25/75 Dark</h1>
+        </div>
+    </div>
+</div>
+
+<div class="p-suru--50-50">
+    <div class="row--50-50">
+        <div class="col">
+            <h1>Suru 50/50</h1>
+        </div>
+    </div>
+</div>
+
+<div class="p-suru--50-50 is-dark">
+    <div class="row--50-50">
+        <div class="col">
+            <h1>Suru 50/50 Dark</h1>
+        </div>
+    </div>
+</div>
+
+<div class="p-suru--fan-top">
+    <div class="row--25-75">
+        <div class="col">
+            <h1>Suru fan top</h1>
+        </div>
+    </div>
+</div>
+
+<div class="p-suru--fan-top is-dark">
+    <div class="row--25-75">
+        <div class="col">
+            <h1>Suru fan top Dark</h1>
+        </div>
+    </div>
+</div>
+
+<div class="p-suru--fan-bottom">
+    <div class="row--25-75">
+        <div class="col">
+            <h1>Suru fan bottom</h1>
+        </div>
+    </div>
+</div>
+
+<div class="p-suru--fan-bottom is-dark">
+    <div class="row--25-75">
+        <div class="col">
+            <h1>Suru fan bottom Dark</h1>
+        </div>
+    </div>
+</div>
+
+<div class="p-suru--pyramid-left">
+    <div class="row--25-75">
+        <div class="col">
+            <h1>Suru pyramid left</h1>
+        </div>
+    </div>
+</div>
+
+<div class="p-suru--pyramid-left is-dark">
+    <div class="row--25-75">
+        <div class="col">
+            <h1>Suru pyramid left Dark</h1>
+        </div>
+    </div>
+</div>
+
+<div class="p-suru--pyramid-right">
+    <div class="row--25-75">
+        <div class="col">
+            <h1>Suru pyramid right</h1>
+        </div>
+    </div>
+</div>
+
+<div class="p-suru--pyramid-right is-dark">
+    <div class="row--25-75">
+        <div class="col">
+            <h1>Suru pyramid right Dark</h1>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/templates/docs/patterns/suru.md
+++ b/templates/docs/patterns/suru.md
@@ -4,11 +4,13 @@ context:
   title: Suru | Components
 ---
 
-The Suru component can be used to display a visual separation between two sections of content.
+The Suru component can be used to provide a background for hero section of the page or to display a visual separation between two sections of content.
 
-By default, Suru should be used on the paper background. When used on dark background, add `is-dark` modifier class.
+## Main suru
 
-## Main 25/75
+The main variant of suru component provides a visual separation between two sections of content (usually a hero and rest of the page). It has two layout options that align with 25/75 or 50/50 splits of the grid.
+
+### Main suru 25/75
 
 Use `.p-suru--25-75` to create a hero section with the main 25/75 Suru background. Suru component provides the necessary hero padding, background colour and the Suru image.
 
@@ -16,20 +18,48 @@ Use `.p-suru--25-75` to create a hero section with the main 25/75 Suru backgroun
 View example of the main 25/75 Suru component
 </a></div>
 
-## Main 50/50
+### Main suru 50/50
 
-Use `.p-suru--50/50` to create a hero section with the main 50/50 Suru background. Suru component provides the necessary hero padding, background colour and the Suru image.
+Use `.p-suru--50/50` to create a hero section with the main 50/50 suru background. Suru component provides the necessary hero padding, background colour and the suru image.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/suru/50-50" class="js-example">
 View example of the main 50/50 Suru component
 </a></div>
 
-## Standalone
+### Standalone main suru
 
-If needed, Suru can be used as a standalone component. This is useful when you need to create a visual separation between two sections of content.
+If needed, suru can be used as a standalone component. This is useful when you need to create a visual separation between two sections of content.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/suru/standalone" class="js-example">
 View example of the default Suru component
+</a></div>
+
+## Corner suru
+
+The corner variant of suru provides the background for the hero section of the page. We provide two styles of the corner suru (a fan and a pyramid suru), both with two possible placements.
+
+### Fan suru
+
+Use `.p-suru--fan-top` or `.p-suru-fan--bottom` to create a hero section with the fan Suru background. Suru component provides the necessary hero padding, background colour and the suru image.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/suru/fan-top" class="js-example">
+View example of the top fan Suru component
+</a></div>
+
+<div class="embedded-example"><a href="/docs/examples/patterns/suru/fan-bottom" class="js-example">
+View example of the bottom fan Suru component
+</a></div>
+
+### Pyramid suru
+
+Use `.p-suru--pyramid-left` or `.p-suru--pyramid-right` to create a hero section with the pyramid suru background. Suru component provides the necessary hero padding, background colour and the suru image.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/suru/fan-top" class="js-example">
+View example of the left pyramid Suru component
+</a></div>
+
+<div class="embedded-example"><a href="/docs/examples/patterns/suru/fan-bottom" class="js-example">
+View example of the right pyramid Suru component
 </a></div>
 
 ## Theming

--- a/templates/docs/patterns/suru.md
+++ b/templates/docs/patterns/suru.md
@@ -40,6 +40,13 @@ View example of the default Suru component
 
 The corner variant of suru provides the background for the hero section of the page. We provide two styles of the corner suru (a fan and a pyramid suru), both with two possible placements.
 
+<div class="p-notification--caution">
+  <div class="p-notification__content">
+    <h3 class="p-notification__title">Responsiveness</h3>
+    <p class="p-notification__message">Corner suru backgrounds are <b>only displayed on large screens</b>, as on smaller screen sizes they would likely overlap with the content.</p>
+  </div>
+</div>
+
 ### Fan suru
 
 Use `.p-suru--fan-top` or `.p-suru--fan-bottom` to create a hero section with the fan Suru background. Suru component provides the necessary hero padding, background colour and the suru image.

--- a/templates/docs/patterns/suru.md
+++ b/templates/docs/patterns/suru.md
@@ -20,7 +20,7 @@ View example of the main 25/75 Suru component
 
 ### Main suru 50/50
 
-Use `.p-suru--50/50` to create a hero section with the main 50/50 suru background. Suru component provides the necessary hero padding, background colour and the suru image.
+Use `.p-suru--50-50` to create a hero section with the main 50/50 suru background. Suru component provides the necessary hero padding, background colour and the suru image.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/suru/50-50" class="js-example">
 View example of the main 50/50 Suru component
@@ -29,6 +29,8 @@ View example of the main 50/50 Suru component
 ### Standalone main suru
 
 If needed, suru can be used as a standalone component. This is useful when you need to create a visual separation between two sections of content.
+
+If the top section is a hero, please use the proper `p-suru--25-75` or `p-suru--50-50` section instead.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/suru/standalone" class="js-example">
 View example of the default Suru component
@@ -40,7 +42,7 @@ The corner variant of suru provides the background for the hero section of the p
 
 ### Fan suru
 
-Use `.p-suru--fan-top` or `.p-suru-fan--bottom` to create a hero section with the fan Suru background. Suru component provides the necessary hero padding, background colour and the suru image.
+Use `.p-suru--fan-top` or `.p-suru--fan-bottom` to create a hero section with the fan Suru background. Suru component provides the necessary hero padding, background colour and the suru image.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/suru/fan-top" class="js-example">
 View example of the top fan Suru component


### PR DESCRIPTION
## Done

Adds more hero suru "corner" backgrounds (fan and pyramid shaped).

Fixes [WD-8773](https://warthogs.atlassian.net/browse/WD-8773)

## QA

- Open [demo](https://vanilla-framework-4989.demos.haus/docs/examples/patterns/suru/variants)
- Review Suru examples, make sure they look as expected:
    - https://vanilla-framework-4989.demos.haus/docs/examples/patterns/suru/variants
- Review updated documentation:
  - https://vanilla-framework-4989.demos.haus/docs/patterns/suru

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

(subset of new variants)

<img width="1566" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/9683c8c9-3caa-4347-8c13-e7c8126f7b3f">



[WD-8773]: https://warthogs.atlassian.net/browse/WD-8773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ