### PR TITLE
Fix overlap issues with sticky app layout panel headers

### DIFF
--- a/scss/_layouts_application-panels.scss
+++ b/scss/_layouts_application-panels.scss
@@ -21,7 +21,7 @@
     background: $colors--light-theme--background-default;
     position: sticky;
     top: 0;
-    z-index: 1;
+    z-index: 5;
 
     .p-panel.is-dark & {
       background: $colors--dark-theme--background-default;


### PR DESCRIPTION
## Done

Increases z-index of sticky application layout panel headers (to avoid overlap with notifications and possibly other elements on z-index 1).

Fixes #4990

## QA

- Open [demo](https://vanilla-framework-4991.demos.haus/docs/examples/layouts/application/JAAS)
- Find `p-panel__header` add `is-sticky` class to it, check if it has z-index of 5
- 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1455" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/c36b17b0-af45-45c1-b115-bd38e1171011">

