### PR TITLE
Update strip component to new theming system

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -16,6 +16,18 @@
       url: /docs/patterns/icons#dark-theme
       status: Deprecated
       notes: We're deprecating the <code>is-light</code> class for icons. Use <code>is-dark</code> instead.
+    - component: Strip / Themes
+      url: /docs/patterns/strip#themes
+      status: Updated
+      notes: We've updated the strip component to support new theming via <code>is-dark</code> class.
+    - component: Strip / Highlighted
+      url: /docs/patterns/strip#highlighted-strip
+      status: New
+      notes: We've introduced a new highlighted strip component for more consistent use of alternative background colours across the themes.
+    - component: Strip / Deprecations
+      url: /docs/patterns/strip#deprecated
+      status: Deprecated
+      notes: We are deprecating a variety of legacy strip variants in favour of the new themed and highlighted strip.
     - component: Section / Hero
       url: /docs/patterns/section#hero-sections
       status: New

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -64,7 +64,7 @@
 
   // Bars and borders
   %vf-pseudo-border {
-    background-color: $color-mid-light;
+    background-color: $colors--theme--border-default;
     content: '';
     height: 1px;
     left: 0;

--- a/scss/_global_functions.scss
+++ b/scss/_global_functions.scss
@@ -50,6 +50,16 @@
   }
 }
 
+// Includes the theme variables based on the background color passed as an argument.
+// This is currently only used in the deprecated p-strip--accent.
+@mixin vf-determine-theme-from-background($background-color) {
+  @if (lightness($background-color) > 50) {
+    @include vf-theme-light;
+  } @else {
+    @include vf-theme-dark;
+  }
+}
+
 // Adds visual focus to elements on :focus-visible,
 // or :focus if the browser doesn't support the former
 @mixin vf-focus($color: $color-focus, $width: $bar-thickness, $has-validation: false) {

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -20,59 +20,84 @@
 }
 
 @mixin vf-p-strip-default {
+  // default strip is theme-agnostic, it doesn't change the theme
+  // unless the theme class is specifically applied to it,
+  // in which case it will set the background and text colours
   .p-strip {
     @extend %vf-strip;
 
     background-color: transparent;
+
+    // themed versions of the strip should set the background and text colours
+    &.is-light,
+    &.is-paper,
+    &.is-dark {
+      background-color: $colors--theme--background-default;
+      color: $colors--theme--text-default;
+    }
   }
 
+  // highligted version if the strip is using the alternative background colour
+  // this is the recommended replacement for the deprecated .p-strip--white,
+  // .p-strip--light and .p-strip--accent
+  .p-strip--highlighted {
+    @extend %vf-strip;
+
+    background-color: $colors--theme--background-alt;
+    color: $colors--theme--text-default;
+  }
+
+  // DEPRECATED: use any other available p-strip instead
   .p-strip--light {
     @extend %vf-strip;
+    @include vf-theme-light;
 
-    background-color: $color-light;
+    background-color: $colors--theme--background-alt;
+    color: $colors--theme--text-default;
   }
 
+  // DEPRECATED: use .p-strip .is-dark instead
   .p-strip--dark {
     @extend %vf-strip;
+    @include vf-theme-dark;
 
-    background-color: $colors--dark-theme--background-default;
-    color: $colors--dark-theme--text-default;
+    background-color: $colors--theme--background-default;
+    color: $colors--theme--text-default;
   }
 
+  // DEPRECATED: use .p-strip--highlighted instead
   .p-strip--white {
     @extend %vf-strip;
+    @include vf-theme-light;
 
     background-color: $color-x-light;
-    color: $colors--light-theme--text-default;
+    color: $colors--theme--text-default;
   }
 }
 
+// DEPRECATED: use other available strip variants instead
 @mixin vf-p-strip-accent {
   .p-strip--accent {
     @extend %vf-strip;
+    @include vf-determine-theme-from-background($color-accent-background);
 
     background-color: $color-accent-background;
-    color: vf-determine-text-color($color-accent-background);
+    color: $colors--theme--text-default;
   }
 }
 
+// DEPRECATED: use other available strip variants or suru component instead
 @mixin vf-p-strip-image {
   .p-strip--image {
     @extend %vf-strip;
 
     background-repeat: no-repeat;
     background-size: cover;
-
-    &.is-light {
-      color: $colors--light-theme--text-default;
-    }
-
-    &.is-dark {
-      color: $color-x-light;
-    }
+    color: $colors--theme--text-default;
   }
 }
 
+// DEPRECATED: use other available strip variants instead
 @mixin vf-p-strip-bordered {
   [class*='p-strip'].is-bordered {
     @extend %vf-pseudo-border--bottom;
@@ -91,6 +116,7 @@
   }
 }
 
+// DEPRECATED:
 // gradient of the main suru slant
 $color-suru-start: lighten($color-brand, 10%) !default;
 $color-suru-middle: $color-brand !default;
@@ -107,6 +133,7 @@ $color-suru-slant-left: rgba(205, 205, 205, 0.55) !default;
 $color-suru-slant-right-fallback: rgba(205, 205, 205, 0.14) !default;
 $color-suru-slant-left-fallback: rgba(205, 205, 205, 0.14) !default;
 
+// DEPRECATED: use new .p-suru components instead
 @mixin vf-p-strip-suru {
   .p-strip--suru {
     @extend %vf-strip;
@@ -188,6 +215,7 @@ $color-suru-slant-left-fallback: rgba(205, 205, 205, 0.14) !default;
   }
 }
 
+// DEPRECATED: use new .p-suru components instead
 @mixin vf-p-strip-suru-topped {
   .p-strip--suru-topped {
     @extend %vf-strip;

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -362,6 +362,7 @@ $colors--theme--background-information-active: var(--vf-color-background-informa
 
   // SCSS variables need to be interpolated to work in CSS custom properties
   --vf-color-background-default: #{$color-paper};
+  --vf-color-background-alt: #{$color-x-light};
 
   --vf-color-background-inputs: #{$colors--paper-theme--background-inputs};
   --vf-color-background-active: #{$colors--paper-theme--background-active};

--- a/scss/standalone/patterns_chip.scss
+++ b/scss/standalone/patterns_chip.scss
@@ -2,5 +2,6 @@
 @include vf-base;
 
 @include vf-p-chip;
-@include vf-p-icons-common;
-@include vf-p-icon-close;
+
+// needed for dark background examples
+@include vf-p-strip;

--- a/templates/_layouts/_footer.html
+++ b/templates/_layouts/_footer.html
@@ -1,5 +1,5 @@
 {% if is_docs %}
-<footer class="l-footer--sticky p-strip--dark">
+<footer class="l-footer--sticky p-strip is-dark">
   <div class="l-docs__subgrid">
     <div class="l-docs__sidebar u-fixed-width">
       <p class="u-no-margin--bottom">&copy; {{ now("%Y") }} Canonical Ltd.</p>
@@ -33,7 +33,7 @@
   </div>
 </footer>
 {% else %}
-<footer class="p-strip--dark">
+<footer class="p-strip is-dark">
   <div class="row">
     <div class="col-3">
       <p class="u-no-margin--bottom">&copy; {{ now("%Y") }} Canonical Ltd.</p>

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -19,7 +19,7 @@
 
         <nav class="p-side-navigation--accordion is-sticky is-drawer-hidden" id="side-navigation-drawer" aria-label="Side">
 
-          <div class="u-hide--large p-strip--light is-shallow">
+          <div class="u-hide--large p-strip--highlighted is-shallow">
             <div class="u-fixed-width">
               <a href="#side-navigation-drawer" class="p-button has-icon u-no-margin js-drawer-toggle" aria-expanded="false"><i class="p-icon--menu"></i><span>Contents</span></a>
             </div>

--- a/templates/docs/building-vanilla.md
+++ b/templates/docs/building-vanilla.md
@@ -141,10 +141,12 @@ Now run the command with `yarn build`, which will bundle the code and put in a a
   <title>Vanilla using Webpack</title>
 </head>
 <body>
-  <section class="p-strip--light is-bordered">
-    <div class="row">
-      <h1>Hello Vanilla!</h1>
-      <p>This page has been built using Webpack!</p>
+  <section class="p-strip">
+    <div class="row--25-75">
+      <div class="col">
+        <h1>Hello Vanilla!</h1>
+        <p>This page has been built using Webpack!</p>
+      </div>
     </div>
   </section>
   <script src="./dist/bundle.js"></script>

--- a/templates/docs/examples/base/code-inline-dark.html
+++ b/templates/docs/examples/base/code-inline-dark.html
@@ -4,10 +4,10 @@
 {% block standalone_css %}base{% endblock %}
 
 {% block content %}
-<div class="p-strip--dark" style="background: #111">
+<div class="p-strip is-dark" style="background: #111">
   <div class="row">
     <div class="col-12">
-      <p style="color: #fff;">The quick brown <code>fox&nbsp;jumps</code> over the lazy dog</p>
+      <p style="color: #fff;">The quick brown <code class="is-dark">fox&nbsp;jumps</code> over the lazy dog</p>
     </div>
   </div>
 </div>

--- a/templates/docs/examples/brochure/_25-75-offset.html
+++ b/templates/docs/examples/brochure/_25-75-offset.html
@@ -1,4 +1,4 @@
-<div class="p-strip--white is-deep">
+<div class="p-strip--highlighted is-deep">
     <div class="row--25-75">
         <div class="col">
             <h1>Company culture</h1>

--- a/templates/docs/examples/layouts/docs.html
+++ b/templates/docs/examples/layouts/docs.html
@@ -312,7 +312,7 @@
   </main>
 
   <div class="l-docs__footer">
-    <footer class="p-strip--dark l-docs__subgrid">
+    <footer class="p-strip is-dark l-docs__subgrid">
       <div class="l-docs__sidebar">
         <p style="padding-left: 1.5rem">© 2020 Canonical Ltd.</p>
       </div>

--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -40,7 +40,7 @@
   </div>
 </header>
 
-<section id="search-docs" class="p-strip--light is-shallow">
+<section id="search-docs" class="p-strip--highlighted is-shallow">
   <div class="row">
     <form class="p-search-box u-no-margin--bottom">
       <input type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="" autocomplete="on"/>
@@ -259,7 +259,7 @@
   </div>
 </div>
 
-<footer class="p-strip--light">
+<footer class="p-strip--highlighted">
   <nav class="row" aria-label="Footer">
     <div class="has-cookie">
       <p>© 2020 Canonical Ltd. <a href="#">Ubuntu</a> and <a href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>

--- a/templates/docs/examples/layouts/full-width/default.html
+++ b/templates/docs/examples/layouts/full-width/default.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Full width / Default{% endblock %}
+{% block title %}Full width (deprecated){% endblock %}
 
 {% block style %}
 <style>
@@ -77,7 +77,7 @@
 <div class="l-full-width__sidebar">
 
   <div class="p-side-navigation is-sticky" id="side-navigation-drawer" aria-label="Side">
-    <div class="u-hide--large p-strip--light is-shallow">
+    <div class="u-hide--large p-strip--highlighted is-shallow">
       <div class="u-fixed-width">
         <button class="p-button has-icon u-no-margin js-drawer-toggle"><i class="p-icon--menu"></i><span>Contents</span></button>
       </div>
@@ -132,7 +132,7 @@
   </div>
 </div>
 
-<div class="p-strip--light is-shallow l-full-width">
+<div class="p-strip--highlighted is-shallow l-full-width">
   <div class="l-main">
     <div class="row">
       <div class="col-6 col-medium-3"><h1 class="p-heading--2">Get started</h1></div>
@@ -190,7 +190,7 @@
   </div>
 </div>
 
-<div class="p-strip--light is-shallow l-full-width">
+<div class="p-strip--highlighted is-shallow l-full-width">
   <div class="l-main">
     <div class="row">
       <div class="col-6 col-medium-3"><h2>Download</h2></div>

--- a/templates/docs/examples/layouts/full-width/no-sidebar.html
+++ b/templates/docs/examples/layouts/full-width/no-sidebar.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Full width / No sidebar{% endblock %}
+{% block title %}Full width / No sidebar (deprecated){% endblock %}
 
 {% block style %}
 <style>
@@ -75,7 +75,7 @@
   <div class="p-navigation__search-overlay"></div>
 </header>
 
-<div class="p-strip--light is-shallow l-full-width">
+<div class="p-strip--highlighted is-shallow l-full-width">
   <div class="l-main">
     <div class="row">
       <div class="col-6 col-medium-3"><h1 class="p-heading--2">Get started</h1></div>
@@ -133,7 +133,7 @@
   </div>
 </div>
 
-<div class="p-strip--light is-shallow l-full-width">
+<div class="p-strip--highlighted is-shallow l-full-width">
   <div class="l-main">
     <div class="row">
       <div class="col-6 col-medium-3"><h2>Download</h2></div>

--- a/templates/docs/examples/layouts/sticky-footer.html
+++ b/templates/docs/examples/layouts/sticky-footer.html
@@ -25,7 +25,7 @@
     <p>Some short page content.</p>
   </div>
 
-  <footer class="l-footer--sticky p-strip--light">
+  <footer class="l-footer--sticky p-strip--highlighted">
     <nav class="row" aria-label="Footer">
       <div class="has-cookie">
         <p>© 2020 Canonical Ltd. <a href="#">Ubuntu</a> and <a href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>

--- a/templates/docs/examples/patterns/buttons/dark.html
+++ b/templates/docs/examples/patterns/buttons/dark.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_buttons{% endblock %}
 
 {% block content %}
-<div class="p-strip--dark is-shallow" style="background: #111">
+<div class="p-strip is-dark is-shallow" style="background: #111">
     <button class="p-button is-dark">Default button</button>
     <button class="p-button--base is-dark">Base button</button>
     <button class="p-button--positive is-dark">Positive button</button>

--- a/templates/docs/examples/patterns/card/overlay.html
+++ b/templates/docs/examples/patterns/card/overlay.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Card / Overlay{% endblock %}
+{% block title %}Card / Overlay (deprecated){% endblock %}
 
 {% block standalone_css %}patterns_card{% endblock %}
 

--- a/templates/docs/examples/patterns/chip/variants.html
+++ b/templates/docs/examples/patterns/chip/variants.html
@@ -366,313 +366,313 @@
 
 </p>
 
-<div class="p-strip--dark" style="background: #2B2B2B">
+<div class="p-strip is-dark">
 
-  <button class="p-chip is-dark">
+  <button class="p-chip">
     <span class="p-chip__value">21.10</span>
   </button>
 
-  <span class="p-chip is-dark">
+  <span class="p-chip">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
+      Dismiss
     </button>
   </span>
 
-  <button class="p-chip is-dark">
+  <button class="p-chip">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </button>
 
-  <span class="p-chip is-dark">
+  <span class="p-chip">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
-    </button>
-  </span>
-
-  <br>
-
-  <button class="p-chip--positive is-dark">
-    <span class="p-chip__value">21.10</span>
-  </button>
-
-  <span class="p-chip--positive is-dark">
-    <span class="p-chip__value">21.10</span>
-    <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
-    </button>
-  </span>
-
-  <button class="p-chip--positive is-dark">
-    <span class="p-chip__lead">Owner</span>
-    <span class="p-chip__value">Bob</span>
-  </button>
-
-  <span class="p-chip--positive is-dark">
-    <span class="p-chip__lead">Owner</span>
-    <span class="p-chip__value">Bob</span>
-    <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
+      Dismiss
     </button>
   </span>
 
   <br>
 
-  <button class="p-chip--caution is-dark">
+  <button class="p-chip--positive">
     <span class="p-chip__value">21.10</span>
   </button>
 
-  <span class="p-chip--caution is-dark">
+  <span class="p-chip--positive">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
+      Dismiss
     </button>
   </span>
 
-  <button class="p-chip--caution is-dark">
+  <button class="p-chip--positive">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </button>
 
-  <span class="p-chip--caution is-dark">
+  <span class="p-chip--positive">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
-    </button>
-  </span>
-
-  <br>
-
-  <button class="p-chip--negative is-dark">
-    <span class="p-chip__value">21.10</span>
-  </button>
-
-  <span class="p-chip--negative is-dark">
-    <span class="p-chip__value">21.10</span>
-    <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
-    </button>
-  </span>
-
-  <button class="p-chip--negative is-dark">
-    <span class="p-chip__lead">Owner</span>
-    <span class="p-chip__value">Bob</span>
-  </button>
-
-  <span class="p-chip--negative is-dark">
-    <span class="p-chip__lead">Owner</span>
-    <span class="p-chip__value">Bob</span>
-    <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
+      Dismiss
     </button>
   </span>
 
   <br>
 
-  <button class="p-chip--information is-dark">
+  <button class="p-chip--caution">
     <span class="p-chip__value">21.10</span>
   </button>
 
-  <span class="p-chip--information is-dark">
+  <span class="p-chip--caution">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
+      Dismiss
     </button>
   </span>
 
-  <button class="p-chip--information is-dark">
+  <button class="p-chip--caution">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </button>
 
-  <span class="p-chip--information is-dark">
+  <span class="p-chip--caution">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
-    </button>
-  </span>
-
-  <br>
-
-  <button class="p-chip is-dark is-dense">
-    <span class="p-chip__value">21.10</span>
-  </button>
-
-  <span class="p-chip is-dark is-dense">
-    <span class="p-chip__value">21.10</span>
-    <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
-    </button>
-  </span>
-
-  <button class="p-chip is-dark is-dense">
-    <span class="p-chip__lead">Owner</span>
-    <span class="p-chip__value">Bob</span>
-  </button>
-
-  <span class="p-chip is-dark is-dense">
-    <span class="p-chip__lead">Owner</span>
-    <span class="p-chip__value">Bob</span>
-    <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
+      Dismiss
     </button>
   </span>
 
   <br>
 
-  <button class="p-chip--positive is-dark is-dense">
+  <button class="p-chip--negative">
     <span class="p-chip__value">21.10</span>
   </button>
 
-  <span class="p-chip--positive is-dark is-dense">
+  <span class="p-chip--negative">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
+      Dismiss
     </button>
   </span>
 
-  <button class="p-chip--positive is-dark is-dense">
+  <button class="p-chip--negative">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </button>
 
-  <span class="p-chip--positive is-dark is-dense">
+  <span class="p-chip--negative">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
-    </button>
-  </span>
-
-  <br>
-
-  <button class="p-chip--caution is-dark is-dense">
-    <span class="p-chip__value">21.10</span>
-  </button>
-
-  <span class="p-chip--caution is-dark is-dense">
-    <span class="p-chip__value">21.10</span>
-    <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
-    </button>
-  </span>
-
-  <button class="p-chip--caution is-dark is-dense">
-    <span class="p-chip__lead">Owner</span>
-    <span class="p-chip__value">Bob</span>
-  </button>
-
-  <span class="p-chip--caution is-dark is-dense">
-    <span class="p-chip__lead">Owner</span>
-    <span class="p-chip__value">Bob</span>
-    <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
+      Dismiss
     </button>
   </span>
 
   <br>
 
-  <button class="p-chip--negative is-dark is-dense">
+  <button class="p-chip--information">
     <span class="p-chip__value">21.10</span>
   </button>
 
-  <span class="p-chip--negative is-dark is-dense">
+  <span class="p-chip--information">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
+      Dismiss
     </button>
   </span>
 
-  <button class="p-chip--negative is-dark is-dense">
+  <button class="p-chip--information">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </button>
 
-  <span class="p-chip--negative is-dark is-dense">
+  <span class="p-chip--information">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
-    </button>
-  </span>
-
-  <br>
-
-  <button class="p-chip--information is-dark is-dense">
-    <span class="p-chip__value">21.10</span>
-  </button>
-
-  <span class="p-chip--information is-dark is-dense">
-    <span class="p-chip__value">21.10</span>
-    <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
-    </button>
-  </span>
-
-  <button class="p-chip--information is-dark is-dense">
-    <span class="p-chip__lead">Owner</span>
-    <span class="p-chip__value">Bob</span>
-  </button>
-
-  <span class="p-chip--information is-dark is-dense">
-    <span class="p-chip__lead">Owner</span>
-    <span class="p-chip__value">Bob</span>
-    <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
+      Dismiss
     </button>
   </span>
 
   <br>
 
-  <button class="p-chip is-dark is-dense">
+  <button class="p-chip is-dense">
     <span class="p-chip__value">21.10</span>
   </button>
 
-  <button class="p-chip is-dark">
-    <span class="p-chip__value">21.10</span>
-  </button>
-
-  <span class="p-chip--positive is-dark is-dense">
+  <span class="p-chip is-dense">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
+      Dismiss
     </button>
   </span>
 
-  <span class="p-chip--positive is-dark">
+  <button class="p-chip is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
+  <span class="p-chip is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      Dismiss
+    </button>
+  </span>
+
+  <br>
+
+  <button class="p-chip--positive is-dense">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <span class="p-chip--positive is-dense">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
+      Dismiss
     </button>
   </span>
 
-  <button class="p-chip--caution is-dark is-dense">
+  <button class="p-chip--positive is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </button>
 
-  <button class="p-chip--caution is-dark">
+  <span class="p-chip--positive is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      Dismiss
+    </button>
+  </span>
+
+  <br>
+
+  <button class="p-chip--caution is-dense">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <span class="p-chip--caution is-dense">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      Dismiss
+    </button>
+  </span>
+
+  <button class="p-chip--caution is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </button>
 
-  <span class="p-chip--negative is-dark is-dense">
+  <span class="p-chip--caution is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
+      Dismiss
     </button>
   </span>
 
-  <span class="p-chip--negative is-dark">
+  <br>
+
+  <button class="p-chip--negative is-dense">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <span class="p-chip--negative is-dense">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      Dismiss
+    </button>
+  </span>
+
+  <button class="p-chip--negative is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
+  <span class="p-chip--negative is-dense">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
-      <i class="p-icon--close is-light">Dismiss</i>
+      Dismiss
+    </button>
+  </span>
+
+  <br>
+
+  <button class="p-chip--information is-dense">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <span class="p-chip--information is-dense">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      Dismiss
+    </button>
+  </span>
+
+  <button class="p-chip--information is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
+  <span class="p-chip--information is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      Dismiss
+    </button>
+  </span>
+
+  <br>
+
+  <button class="p-chip is-dense">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <button class="p-chip">
+    <span class="p-chip__value">21.10</span>
+  </button>
+
+  <span class="p-chip--positive is-dense">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      Dismiss
+    </button>
+  </span>
+
+  <span class="p-chip--positive ">
+    <span class="p-chip__value">21.10</span>
+    <button class="p-chip__dismiss">
+      Dismiss
+    </button>
+  </span>
+
+  <button class="p-chip--caution is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
+  <button class="p-chip--caution ">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+  </button>
+
+  <span class="p-chip--negative is-dense">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      Dismiss
+    </button>
+  </span>
+
+  <span class="p-chip--negative ">
+    <span class="p-chip__lead">Owner</span>
+    <span class="p-chip__value">Bob</span>
+    <button class="p-chip__dismiss">
+      Dismiss
     </button>
   </span>
 
@@ -680,50 +680,50 @@
 
   <p style="color: #fff">Inline
 
-    <button class="p-chip is-dark is-inline"><span class="p-chip__value">21.10</span></button>
+    <button class="p-chip is-inline"><span class="p-chip__value">21.10</span></button>
 
-    <span class="p-chip--positive is-dark is-inline">
+    <span class="p-chip--positive is-inline">
       <span class="p-chip__value">21.10</span>
       <button class="p-chip__dismiss">
-        <i class="p-icon--close is-light">Dismiss</i>
+        Dismiss
       </button>
     </span>
 
-    <button class="p-chip--caution is-dark is-inline">
+    <button class="p-chip--caution is-inline">
       <span class="p-chip__lead">Owner</span>
       <span class="p-chip__value">Bob</span>
     </button>
 
-    <span class="p-chip--negative is-dark is-inline">
+    <span class="p-chip--negative is-inline">
       <span class="p-chip__lead">Owner</span>
       <span class="p-chip__value">Bob</span>
       <button class="p-chip__dismiss">
-        <i class="p-icon--close is-light">Dismiss</i>
+        Dismiss
       </button>
     </span>
   </p>
 
   <p style="color: #fff">Inline
 
-    <button class="p-chip is-dark is-dense is-inline"><span class="p-chip__value">21.10</span></button>
+    <button class="p-chip is-dense is-inline"><span class="p-chip__value">21.10</span></button>
 
-    <span class="p-chip--positive is-dark is-dense is-inline">
+    <span class="p-chip--positive is-dense is-inline">
       <span class="p-chip__value">21.10</span>
       <button class="p-chip__dismiss">
-        <i class="p-icon--close is-light">Dismiss</i>
+        Dismiss
       </button>
     </span>
 
-    <button class="p-chip--caution is-dark is-dense is-inline">
+    <button class="p-chip--caution is-dense is-inline">
       <span class="p-chip__lead">Owner</span>
       <span class="p-chip__value">Bob</span>
     </button>
 
-    <span class="p-chip--negative is-dark is-dense is-inline">
+    <span class="p-chip--negative is-dense is-inline">
       <span class="p-chip__lead">Owner</span>
       <span class="p-chip__value">Bob</span>
       <button class="p-chip__dismiss">
-        <i class="p-icon--close is-light">Dismiss</i>
+        Dismiss
       </button>
     </span>
   </p>

--- a/templates/docs/examples/patterns/chip/variants.html
+++ b/templates/docs/examples/patterns/chip/variants.html
@@ -1,4 +1,4 @@
-{% extends "_layouts/examples.html" %}
+{% extends"_layouts/examples.html" %}
 {% block title %}Chip / Variants{% endblock %}
 
 {% block standalone_css %}patterns_chip{% endblock %}
@@ -643,7 +643,7 @@
     </button>
   </span>
 
-  <span class="p-chip--positive ">
+  <span class="p-chip--positive">
     <span class="p-chip__value">21.10</span>
     <button class="p-chip__dismiss">
       Dismiss
@@ -655,7 +655,7 @@
     <span class="p-chip__value">Bob</span>
   </button>
 
-  <button class="p-chip--caution ">
+  <button class="p-chip--caution">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
   </button>
@@ -668,7 +668,7 @@
     </button>
   </span>
 
-  <span class="p-chip--negative ">
+  <span class="p-chip--negative">
     <span class="p-chip__lead">Owner</span>
     <span class="p-chip__value">Bob</span>
     <button class="p-chip__dismiss">
@@ -678,7 +678,7 @@
 
   <br>
 
-  <p style="color: #fff">Inline
+  <p>Inline
 
     <button class="p-chip is-inline"><span class="p-chip__value">21.10</span></button>
 
@@ -703,7 +703,7 @@
     </span>
   </p>
 
-  <p style="color: #fff">Inline
+  <p>Inline
 
     <button class="p-chip is-dense is-inline"><span class="p-chip__value">21.10</span></button>
 

--- a/templates/docs/examples/patterns/icons/icons-social.html
+++ b/templates/docs/examples/patterns/icons/icons-social.html
@@ -15,7 +15,7 @@
     <i class="p-icon--email"></i>
 
 </div>
-<div class="p-strip--dark is-shallow">
+<div class="p-strip is-dark is-shallow">
     <i class="p-icon--facebook"></i>
     <i class="p-icon--twitter is-dark"></i>
     <i class="p-icon--instagram"></i>

--- a/templates/docs/examples/patterns/lists/lists-stepped-dark.html
+++ b/templates/docs/examples/patterns/lists/lists-stepped-dark.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_lists{% endblock %}
 
 {% block content %}
-<div class="p-strip--dark">
+<div class="p-strip is-dark">
 
   <ol class="p-stepped-list">
     <li class="p-stepped-list__item">
@@ -13,21 +13,21 @@
       </h3>
       <p class="p-stepped-list__content">Ensure you have an Ubuntu SSO account before contacting JAAS. Log in to JAAS now.</p>
     </li>
-  
+
     <li class="p-stepped-list__item">
       <h3 class="p-stepped-list__title">
         Configure a model
       </h3>
       <p class="p-stepped-list__content">Applications are contained within models and are installed via charms. Configure your model by pressing the "Start a new model" button.</p>
     </li>
-  
+
     <li class="p-stepped-list__item">
       <h3 class="p-stepped-list__title">
         Credentials and SSH keys
       </h3>
       <p class="p-stepped-list__content">After having selected a cloud, a form will appear for submitting your credentials to JAAS. The below resources are available if you need help with gathering credentials.</p>
     </li>
-  
+
     <li class="p-stepped-list__item">
       <h3 class="p-stepped-list__title">
         Design and&nbsp;<strong>build</strong>
@@ -35,7 +35,7 @@
       <p class="p-stepped-list__content">Together, we design your Kubernetes cluster based on your hardware, scale, roadmap, applications and monitoring system. We'll guide you through the hardware specification process to maximise the efficiency of your CAPEX, and we'll tailor the architecture of your cloud to meet your application, security, regulatory and integration requirements.</p>
     </li>
   </ol>
-  
+
   <ol class="p-stepped-list">
     <li class="p-stepped-list__item">
       <h4 class="p-stepped-list__title">
@@ -43,21 +43,21 @@
       </h4>
       <p class="p-stepped-list__content">Ensure you have an Ubuntu SSO account before contacting JAAS. Log in to JAAS now.</p>
     </li>
-  
+
     <li class="p-stepped-list__item">
       <h4 class="p-stepped-list__title">
         Configure a model
       </h4>
       <p class="p-stepped-list__content">Applications are contained within models and are installed via charms. Configure your model by pressing the "Start a new model" button.</p>
     </li>
-  
+
     <li class="p-stepped-list__item">
       <h4 class="p-stepped-list__title">
         Credentials and SSH keys
       </h4>
       <p class="p-stepped-list__content">After having selected a cloud, a form will appear for submitting your credentials to JAAS. The below resources are available if you need help with gathering credentials.</p>
     </li>
-  
+
     <li class="p-stepped-list__item">
       <h4 class="p-stepped-list__title">
         Design and&nbsp;<strong>build</strong>

--- a/templates/docs/examples/patterns/rule/dark.html
+++ b/templates/docs/examples/patterns/rule/dark.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-<div class="p-strip--dark">
+<div class="p-strip is-dark">
     <div class="u-fixed-width p-section--shallow">
       <hr class="p-rule--highlight is-dark">
       <h2>

--- a/templates/docs/examples/patterns/strips/accent.html
+++ b/templates/docs/examples/patterns/strips/accent.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Strip / Accent{% endblock %}
+{% block title %}Strip / Accent (deprecated){% endblock %}
 
 {% block standalone_css %}patterns_strip{% endblock %}
 

--- a/templates/docs/examples/patterns/strips/dark.html
+++ b/templates/docs/examples/patterns/strips/dark.html
@@ -1,0 +1,15 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Strips / Dark{% endblock %}
+
+{% block standalone_css %}patterns_strip{% endblock %}
+
+{% set is_paper = true %}
+{% block content %}
+<div class="p-strip is-dark">
+    <div class="row--25-75">
+        <div class="col">
+            <h2>Dark strip</h2>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/docs/examples/patterns/strips/deep.html
+++ b/templates/docs/examples/patterns/strips/deep.html
@@ -3,15 +3,16 @@
 
 {% block standalone_css %}patterns_strip{% endblock %}
 
+{% set is_paper = True %}
 {% block content %}
-<section class="p-strip--light is-deep">
-  <div class="row u-vertically-center">
-    <div class="col-8">
+<section class="p-strip is-deep">
+  <div class="row--25-75 u-vertically-center">
+    <div class="col u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/808a4e5b-iot.png?h=300" alt="" />
+    </div>
+    <div class="col">
       <h2>The fastest way to go from development to production in IoT</h2>
       <p>Learn about how Ubuntu Core and snaps can help you build your connected devices.</p>
-    </div>
-    <div class="col-4 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/808a4e5b-iot.png?h=300" alt="" />
     </div>
   </div>
 </section>

--- a/templates/docs/examples/patterns/strips/highlighted.html
+++ b/templates/docs/examples/patterns/strips/highlighted.html
@@ -1,0 +1,16 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Strips / Highlighted{% endblock %}
+
+{% block standalone_css %}patterns_strip{% endblock %}
+
+{% set is_paper = true %}
+{% block content %}
+<div class="p-strip--highlighted">
+    <div class="row--25-75">
+        <div class="col">
+            <h2>Highlighted strip</h2>
+            <p>With an alternative light version of background colour.</p>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/docs/examples/patterns/strips/image.html
+++ b/templates/docs/examples/patterns/strips/image.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Strip / Image{% endblock %}
+{% block title %}Strip / Image (deprecated){% endblock %}
 
 {% block standalone_css %}patterns_strip{% endblock %}
 

--- a/templates/docs/examples/patterns/strips/is-bordered.html
+++ b/templates/docs/examples/patterns/strips/is-bordered.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Strip / Bordered{% endblock %}
+{% block title %}Strip / Bordered (deprecated){% endblock %}
 
 {% block standalone_css %}patterns_strip{% endblock %}
 

--- a/templates/docs/examples/patterns/strips/shallow.html
+++ b/templates/docs/examples/patterns/strips/shallow.html
@@ -3,15 +3,13 @@
 
 {% block standalone_css %}patterns_strip{% endblock %}
 
+{% set is_paper = True %}
 {% block content %}
-<section class="p-strip--light is-shallow">
-  <div class="row u-vertically-center">
-    <div class="col-8">
+<section class="p-strip is-shallow">
+  <div class="row--25-75">
+    <div class="col">
       <h2>The fastest way to go from development to production in IoT</h2>
       <p>Learn about how Ubuntu Core and snaps can help you build your connected devices.</p>
-    </div>
-    <div class="col-4 u-hide--small u-align--center">
-      <img src="https://assets.ubuntu.com/v1/808a4e5b-iot.png?h=300" alt="" />
     </div>
   </div>
 </section>

--- a/templates/docs/examples/patterns/strips/strips-dark.html
+++ b/templates/docs/examples/patterns/strips/strips-dark.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Strips / Dark{% endblock %}
+{% block title %}Strips / Dark (deprecated){% endblock %}
 
 {% block standalone_css %}patterns_strip{% endblock %}
 

--- a/templates/docs/examples/patterns/strips/strips-light.html
+++ b/templates/docs/examples/patterns/strips/strips-light.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Strips / Light{% endblock %}
+{% block title %}Strips / Light (deprecated){% endblock %}
 
 {% block standalone_css %}patterns_strip{% endblock %}
 

--- a/templates/docs/examples/patterns/strips/suru-topped.html
+++ b/templates/docs/examples/patterns/strips/suru-topped.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Strips / Suru-topped{% endblock %}
+{% block title %}Strips / Suru-topped (deprecated){% endblock %}
 
 {% block standalone_css %}patterns_strip{% endblock %}
 

--- a/templates/docs/examples/patterns/strips/suru.html
+++ b/templates/docs/examples/patterns/strips/suru.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Strips / Suru{% endblock %}
+{% block title %}Strips / Suru (deprecated){% endblock %}
 
 {% block standalone_css %}patterns_strip{% endblock %}
 

--- a/templates/docs/examples/patterns/strips/white.html
+++ b/templates/docs/examples/patterns/strips/white.html
@@ -6,6 +6,13 @@
 {% set is_paper = true %}
 {% block content %}
 
-{% include "/docs/examples/brochure/_25-75-offset.html" %}
+<div class="p-strip--white is-deep">
+    <div class="row--25-75">
+        <div class="col">
+            <h1>Company culture</h1>
+            <h2>We believe that talent is evenly distributed around the world.&nbsp; Diversity is part of our strength. What unifies us isn’t our background,&nbsp; it’s our mission to amplify open source.</h2>
+        </div>
+    </div>
+</div>
 
 {% endblock %}

--- a/templates/docs/examples/patterns/strips/white.html
+++ b/templates/docs/examples/patterns/strips/white.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Strips / White (on paper){% endblock %}
+{% block title %}Strips / White (deprecated){% endblock %}
 
 {% block standalone_css %}patterns_strip{% endblock %}
 

--- a/templates/docs/examples/templates/maas-docs-grid.html
+++ b/templates/docs/examples/templates/maas-docs-grid.html
@@ -42,7 +42,7 @@
   </div>
 </header>
 
-<section id="search-docs" class="p-strip--image is-shallow" style="background-image: url('https://assets.ubuntu.com/v1/e54487e2-maas-docs-suru.png')">
+<section id="search-docs" class="p-strip--highlighted is-shallow">
   <div class="row">
     <form class="p-search-box u-no-margin--bottom">
       <input aria-label="search" type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="" autocomplete="on">

--- a/templates/docs/examples/templates/maas-layout.html
+++ b/templates/docs/examples/templates/maas-layout.html
@@ -45,7 +45,7 @@
     </nav>
   </div>
 </header>
-<div class="p-strip--light is-shallow">
+<div class="p-strip--highlighted is-shallow">
   <div class="row">
     <div class="col-8">
       <h1 class="p-heading--3">Machines</h1>

--- a/templates/docs/examples/templates/snapcraft-publicise.html
+++ b/templates/docs/examples/templates/snapcraft-publicise.html
@@ -299,7 +299,7 @@
   </div>
 </div>
 
-<footer class="p-strip--light p-sticky-footer" id="footer">
+<footer class="p-strip--highlighted p-sticky-footer" id="footer">
   <div class="row">
     <div class="col-9">
       <p>

--- a/templates/docs/examples/templates/typographic-spacing.html
+++ b/templates/docs/examples/templates/typographic-spacing.html
@@ -693,7 +693,7 @@
 </div>
 <hr />
 <!-- <p>Headings preceding block level element</p> -->
-<div class="p-strip--light is-shallow">
+<div class="p-strip--highlighted is-shallow">
   <div class="row" style="max-width: 100%">
     <p>Headings preceding block level element</p>
   </div>
@@ -1077,42 +1077,42 @@
 <div class="row">
   <div class="col-2">
     <h1>Heading</h1>
-    <div class="p-strip--dark">
+    <div class="p-strip is-dark">
       <h1>This is an h1 heading inside a dark strip</h1>
       <img src="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg" alt="">
     </div>
   </div>
   <div class="col-2">
     <h2>Heading</h2>
-    <div class="p-strip--dark">
+    <div class="p-strip is-dark">
       <h2>This is an h2 heading inside a dark strip</h2>
       <img src="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg" alt="">
     </div>
   </div>
   <div class="col-2">
     <h3>Heading</h3>
-    <div class="p-strip--dark">
+    <div class="p-strip is-dark">
       <h3>This is an h3 heading inside a dark strip</h3>
       <img src="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg" alt="">
     </div>
   </div>
   <div class="col-2">
     <h4>Heading</h4>
-    <div class="p-strip--dark">
+    <div class="p-strip is-dark">
       <h4>This is an h4 heading inside a dark strip</h4>
       <img src="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg" alt="">
     </div>
   </div>
   <div class="col-2">
     <h5>Heading</h5>
-    <div class="p-strip--dark">
+    <div class="p-strip is-dark">
       <h5>This is an h5 heading inside a dark strip</h5>
       <img src="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg" alt="">
     </div>
   </div>
   <div class="col-2">
     <h6>Heading</h6>
-    <div class="p-strip--dark">
+    <div class="p-strip is-dark">
       <h6>This is an h6 heading inside a dark strip</h6>
       <img src="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg" alt="">
     </div>

--- a/templates/docs/examples/templates/vertical-spacing.html
+++ b/templates/docs/examples/templates/vertical-spacing.html
@@ -24,7 +24,7 @@
     </div>
   </div>
 </div>
-<section class="p-strip--dark">
+<section class="p-strip is-dark">
   <div class="row">
     <div class="col-12">
       <h2>Title</h2>

--- a/templates/docs/patterns/lists/index.md
+++ b/templates/docs/patterns/lists/index.md
@@ -127,9 +127,7 @@ View example of the stepped list without headings
 
 ## Horizontal stepped
 
-The stepped list should be used for step by step instructions. This pattern is best
-used on a `.p-strip--light` as the description sections are displayed in a white
-box.
+The stepped list should be used for step by step instructions.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-stepped-detailed/" class="js-example">
 View example of the pattern stepped list detailed

--- a/templates/docs/patterns/strip/deprecated.md
+++ b/templates/docs/patterns/strip/deprecated.md
@@ -1,0 +1,152 @@
+---
+wrapper_template: '_layouts/docs.html'
+context:
+  title: Deprecated strips | Components
+---
+
+<div class="p-notification--negative">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Deprecated</h5>
+    <p class="p-notification__message">This page contains legacy documentation of the deprecated variants of the strip component and is only meant for reference until these variants are removed in future version of Vanilla.</p>
+  </div>
+</div>
+
+## Light and dark
+
+The strip pattern provides a full width strip container in which to wrap a row. A strip can have light (`.p-strip--light`) or dark (`.p-strip--dark`) grey background.
+
+<div class="p-notification--negative">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Deprecated</h5>
+    <p class="p-notification__message">Light strips are now deprecated. Use the new <a href="/docs/patterns/strip#highlighted-strip">highlighted strip</a> instead.</p>
+  </div>
+</div>
+
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/strips-light/" class="js-example">
+View example of the strip light pattern
+</a></div>
+
+<div class="p-notification--negative">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Deprecated</h5>
+    <p class="p-notification__message">Dark strips (<code>.p-strip--dark</code>) are now deprecated. Use the <a href="/docs/patterns/strip#themes">new theming</a> by applying <code>is-dark</code> class name to the strip instead.</p>
+  </div>
+</div>
+
+<p></p>
+
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/strips-dark/" class="js-example">
+View example of the strip dark pattern
+</a></div>
+
+## White strip
+
+<div class="p-notification--negative">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Deprecated</h5>
+    <p class="p-notification__message">White strips (<code>.p-strip--white</code>) are now deprecated. Use the new <a href="/docs/patterns/strip#highlighted-strip">highlighted strip</a> instead.</p>
+  </div>
+</div>
+
+The purpose of the white strip is to display some highlighted content on white background when page background is non-white (for when using paper page background).
+
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/white/" class="js-example">
+View example of the white strip
+</a></div>
+
+## Accent strip
+
+<div class="p-notification--negative">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Deprecated</h5>
+    <p class="p-notification__message">Accent strips (<code>.p-strip--accent</code>) are now deprecated. Use the new <a href="/docs/patterns/strip#highlighted-strip">highlighted strip</a> instead.</p>
+  </div>
+</div>
+
+The purpose of the strip accent pattern is to display content with a
+highlighted strip using the accent colour.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/accent/" class="js-example">
+View example of the pattern strip accent
+</a></div>
+
+## Image strip
+
+<div class="p-notification--negative">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Deprecated</h5>
+    <p class="p-notification__message">Image strips (<code>.p-strip--image</code>) are now deprecated. For a hero section with a background use the new <a href="/docs/patterns/suru">Suru component</a> instead.</p>
+  </div>
+</div>
+
+This pattern allows for an image background to be appear as a background on a strip.
+
+<div class="p-notification--information">
+  <p class="p-notification__content">
+    <span class="p-notification__title">Note:</span>
+    <span class="p-notification__message">Declare the background-image as an inline style attribute in the HTML.</span>
+  </p>
+</div>
+
+You can also add the classes '.is-light' and '.is-dark' to the strips to describe the background image.
+These classes will then override the text color to ensure it remains visible.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/image/" class="js-example">
+View example of the pattern strip image
+</a></div>
+
+## Bordered strip
+
+<div class="p-notification--negative">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Deprecated</h5>
+    <p class="p-notification__message">Bordered strips are now deprecated. If a horizontal line is needed to separate parts of content use standard <a href="/docs/patterns/section">sections</a> and <a href="/docs/patterns/rule">the rule component</a> instead.</p>
+  </div>
+</div>
+
+This pattern is used to add a dividing border at the bottom of the strip.
+
+<div class="p-notification--information">
+  <p class="p-notification__content">
+    <span class="p-notification__title">Note:</span>
+    <span class="p-notification__message">This should be used when two strips of the same type are used after each other.</span>
+  </p>
+</div>
+
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/is-bordered/" class="js-example">
+View example of the pattern strip is-bordered
+</a></div>
+
+## Suru strip
+
+<div class="p-notification--negative">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Deprecated</h5>
+    <p class="p-notification__message">Strips with old style of the Suru are now deprecated and should not be used on any new pages. Use a blank strip or <a href="/docs/patterns/suru">new Suru component</a> instead.</p>
+  </div>
+</div>
+
+This is a patterned strip that is ideal for overview or main pages, and can be used with images.
+
+The colours of the solid gradient are based on `$color-brand` by default. The gradient colours can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables. A dark colour scheme is recommended, as the text colour is light by default.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/suru/" class="js-example">
+View example of the Suru strip pattern
+</a></div>
+
+## Topped Suru strip
+
+<div class="p-notification--negative">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Deprecated</h5>
+    <p class="p-notification__message">Strips with old style of the Suru are now deprecated and should not be used on any new pages. Use a blank strip or <a href="/docs/patterns/suru">new Suru component</a> instead.</p>
+  </div>
+</div>
+
+This is a patterned strip that is ideal for content pages.
+
+The colours of the solid gradient are based on `$color-brand` by default. The gradient colours can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/suru-topped/" class="js-example">
+View example of the topped Suru strip pattern
+</a></div>

--- a/templates/docs/patterns/strip/index.md
+++ b/templates/docs/patterns/strip/index.md
@@ -73,11 +73,11 @@ The following strip variants are now deprecated and should not be used on any ne
 
 Instead of deprecated [Suru strip](/docs/examples/patterns/strips/suru/) (`.p-strip--suru`) and [topped Suru strip](/docs/examples/patterns/strips/suru-topped/) (`.p-strip--suru-topped`) use the new [Suru component](/docs/patterns/suru) instead.
 
-[Strips with arbitrary image backrounds](/docs/examples/patterns/strips/image/) (`.p-strip--image`) are now also deprecated. For a hero section with a background use the new Suru component instead.
+[Strips with arbitrary image backgrounds](/docs/examples/patterns/strips/image/) (`.p-strip--image`) are now also deprecated. For a hero section with a background use the new Suru component instead.
 
 [Bordered strip](/docs/examples/patterns/strips/is-bordered/) (`.p-strip--bordered`) is now deprecated. If a horizontal line is needed to separate parts of content use standard [sections](/docs/patterns/section) and [the rule component](/docs/patterns/rule) instead.
 
-[Light strips](/docs/examples/patterns/strips/strips-light) (`.p-strip--light`), [white strips](/docs/examples/patterns/strips/white) (`.p-strip--white`) and [accent strips](/docs/examples/patterns/strips/accent) (`.p-strip--accent`) are now deprecated. Use the new [highlighted strip](#highligted-strip) instead.
+[Light strips](/docs/examples/patterns/strips/strips-light) (`.p-strip--light`), [white strips](/docs/examples/patterns/strips/white) (`.p-strip--white`) and [accent strips](/docs/examples/patterns/strips/accent) (`.p-strip--accent`) are now deprecated. Use the new [highlighted strip](#highlighted-strip) instead.
 
 [Dark strip](/docs/examples/patterns/strips/strips-dark) (`.p-strip--dark`) is now deprecated. Use the [new theming](#themes) by applying `is-dark` class name to the strip instead.
 

--- a/templates/docs/patterns/strip/index.md
+++ b/templates/docs/patterns/strip/index.md
@@ -73,13 +73,15 @@ The following strip variants are now deprecated and should not be used on any ne
 
 Instead of deprecated [Suru strip](/docs/examples/patterns/strips/suru/) (`.p-strip--suru`) and [topped Suru strip](/docs/examples/patterns/strips/suru-topped/) (`.p-strip--suru-topped`) use the new [Suru component](/docs/patterns/suru) instead.
 
-[Strips with arbitrary image backgrounds](/docs/examples/patterns/strips/image/) (`.p-strip--image`) are now also deprecated. For a hero section with a background use the new Suru component instead.
+[Strips with arbitrary image backgrounds](/docs/examples/patterns/strips/image/) (`.p-strip--image`) are now also deprecated. For a hero section with a background use the new [Suru component](/docs/patterns/suru) instead.
 
 [Bordered strip](/docs/examples/patterns/strips/is-bordered/) (`.p-strip--bordered`) is now deprecated. If a horizontal line is needed to separate parts of content use standard [sections](/docs/patterns/section) and [the rule component](/docs/patterns/rule) instead.
 
 [Light strips](/docs/examples/patterns/strips/strips-light) (`.p-strip--light`), [white strips](/docs/examples/patterns/strips/white) (`.p-strip--white`) and [accent strips](/docs/examples/patterns/strips/accent) (`.p-strip--accent`) are now deprecated. Use the new [highlighted strip](#highlighted-strip) instead.
 
 [Dark strip](/docs/examples/patterns/strips/strips-dark) (`.p-strip--dark`) is now deprecated. Use the [new theming](#themes) by applying `is-dark` class name to the strip instead.
+
+Legacy documentation of the [deprecated strip variants](/docs/patterns/strip/deprecated/) is available for reference until they are removed in the next major release of Vanilla.
 
 ## Import
 

--- a/templates/docs/patterns/strip/index.md
+++ b/templates/docs/patterns/strip/index.md
@@ -4,69 +4,45 @@ context:
   title: Strip | Components
 ---
 
-The strip pattern provides a full width strip container in which to wrap a row. A strip can have light (`.p-strip--light`) or dark (`.p-strip--dark`) grey background.
+The strip pattern provides a full width strip container in which to wrap a grid. It is an alternative to the section component, that surrounds its content with a padding both on the top and bottom, and is used usually when a change of the background is needed or to separate different sections of the page.
 
 A `.p-strip` container should always be the parent of a `.row` (from the [Grid pattern](/docs/patterns/grid/)) and never the other way around.
 
-<div class="embedded-example"><a href="/docs/examples/patterns/strips/strips-light/" class="js-example">
-View example of the strip light pattern
-</a></div>
+## Regular strip
 
-<div class="embedded-example"><a href="/docs/examples/patterns/strips/strips-dark/" class="js-example">
+The strip component is rarely used on its own as a container with just `.p-strip` class name. It is usually combined with other variants described below to provide a specific visual style.
+
+## Themes
+
+The strip component can be used to change the background colour of the section, by applying one of the theme class names, such as `is-dark`, `is-light` or `is-paper`.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/dark/" class="js-example">
 View example of the strip dark pattern
 </a></div>
 
-## White strip
+<div class="p-notification--caution">
+  <div class="p-notification__content">
+    <h3 class="p-notification__title">Deprecated</h3>
+    <p class="p-notification__message">In Vanilla 4.8.0 with the introduction of new theming system the old <code>p-strip--dark</code> is deprecated. Use a strip is <code>is-dark</code> class instead.</p>
+  </div>
+</div>
+
+## Highlighted strip
 
 <span class="p-status-label--positive">New</span>
 
-The purpose of the white strip is to display some highlighted content on white background when page background is non-white (for when using paper page background).
+The purpose of the highlighted strip (`.p-strip--highlighted`) is to display content with a lighter version of the background colour based on the current theme.
 
-<div class="embedded-example"><a href="/docs/examples/patterns/strips/white/" class="js-example">
-View example of the white strip
+<div class="embedded-example"><a href="/docs/examples/patterns/strips/highlighted/" class="js-example">
+View example of the highlighted strip
 </a></div>
 
-## Accent strip
-
-The purpose of the strip accent pattern is to display content with a
-highlighted strip using the accent colour.
-
-<div class="embedded-example"><a href="/docs/examples/patterns/strips/accent/" class="js-example">
-View example of the pattern strip accent
-</a></div>
-
-## Image strip
-
-This pattern allows for an image background to be appear as a background on a strip.
-
-<div class="p-notification--information">
-  <p class="p-notification__content">
-    <span class="p-notification__title">Note:</span>
-    <span class="p-notification__message">Declare the background-image as an inline style attribute in the HTML.</span>
-  </p>
+<div class="p-notification--caution">
+  <div class="p-notification__content">
+    <h3 class="p-notification__title">Deprecated</h3>
+    <p class="p-notification__message">In Vanilla 4.8.0 with the introduction of new theming system and highlighted strip, the old <code>p-strip--light</code>, <code>p-strip--accent</code> are deprecated. Use a highlighted strip <code>p-strip--highlighted</code> instead.</p>
+  </div>
 </div>
-
-You can also add the classes '.is-light' and '.is-dark' to the strips to describe the background image.
-These classes will then override the text color to ensure it remains visible.
-
-<div class="embedded-example"><a href="/docs/examples/patterns/strips/image/" class="js-example">
-View example of the pattern strip image
-</a></div>
-
-## Bordered strip
-
-This pattern is used to add a dividing border at the bottom of the strip.
-
-<div class="p-notification--information">
-  <p class="p-notification__content">
-    <span class="p-notification__title">Note:</span>
-    <span class="p-notification__message">This should be used when two strips of the same type are used after each other.</span>
-  </p>
-</div>
-
-<div class="embedded-example"><a href="/docs/examples/patterns/strips/is-bordered/" class="js-example">
-View example of the pattern strip is-bordered
-</a></div>
 
 ## Deep strip
 
@@ -84,43 +60,26 @@ This state gives the strip smaller vertical padding.
 View example of the pattern strip is-shallow
 </a></div>
 
-## Suru strip
+## Deprecated
 
-<span class="p-status-label--negative">Deprecated</span>
-
-<div class="p-notification--negative">
+<div class="p-notification--caution">
   <div class="p-notification__content">
-    <h5 class="p-notification__title">Deprecated</h5>
-    <p class="p-notification__message">Strips with old style of the Suru are now deprecated and should not be used on any new pages. Use a blank strip or <a href="/docs/patterns/suru">new Suru component</a> instead.</p>
+    <h3 class="p-notification__title">Deprecated</h3>
+    <p class="p-notification__message">In Vanilla 4.8.0 with the introduction of new theming system and updated Suru component various legacy strip variants have been deprecated.</p>
   </div>
 </div>
 
-This is a patterned strip that is ideal for overview or main pages, and can be used with images.
+The following strip variants are now deprecated and should not be used on any new pages:
 
-The colours of the solid gradient are based on `$color-brand` by default. The gradient colours can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables. A dark colour scheme is recommended, as the text colour is light by default.
+Instead of deprecated [Suru strip](/docs/examples/patterns/strips/suru/) (`.p-strip--suru`) and [topped Suru strip](/docs/examples/patterns/strips/suru-topped/) (`.p-strip--suru-topped`) use the new [Suru component](/docs/patterns/suru) instead.
 
-<div class="embedded-example"><a href="/docs/examples/patterns/strips/suru/" class="js-example">
-View example of the Suru strip pattern
-</a></div>
+[Strips with arbitrary image backrounds](/docs/examples/patterns/strips/image/) (`.p-strip--image`) are now also deprecated. For a hero section with a background use the new Suru component instead.
 
-## Topped Suru strip
+[Bordered strip](/docs/examples/patterns/strips/is-bordered/) (`.p-strip--bordered`) is now deprecated. If a horizontal line is needed to separate parts of content use standard [sections](/docs/patterns/section) and [the rule component](/docs/patterns/rule) instead.
 
-<span class="p-status-label--negative">Deprecated</span>
+[Light strips](/docs/examples/patterns/strips/strips-light) (`p-strip--light`), [white strips](/docs/examples/patterns/strips/white) (`.p-strip--white`) and [accent strips](/docs/examples/patterns/strips/accent) (`.p-strip--accent`) are now deprecated. Use the new [highlighted strip](#highligted-strip) instead.
 
-<div class="p-notification--negative">
-  <div class="p-notification__content">
-    <h5 class="p-notification__title">Deprecated</h5>
-    <p class="p-notification__message">Strips with old style of the Suru are now deprecated and should not be used on any new pages. Use a blank strip or <a href="/docs/patterns/suru">new Suru component</a> instead.</p>
-  </div>
-</div>
-
-This is a patterned strip that is ideal for content pages.
-
-The colours of the solid gradient are based on `$color-brand` by default. The gradient colours can be customised by overriding the `$color-suru-start`, `$color-suru-middle` and `$color-suru-end` variables.
-
-<div class="embedded-example"><a href="/docs/examples/patterns/strips/suru-topped/" class="js-example">
-View example of the topped Suru strip pattern
-</a></div>
+[Dark strip](/docs/examples/patterns/strips/strips-dark) (`.p-strip--dark`) is now deprecated. Use the [new theming](#themes) by applying `is-dark` class name to the strip instead.
 
 ## Import
 

--- a/templates/docs/patterns/strip/index.md
+++ b/templates/docs/patterns/strip/index.md
@@ -77,7 +77,7 @@ Instead of deprecated [Suru strip](/docs/examples/patterns/strips/suru/) (`.p-st
 
 [Bordered strip](/docs/examples/patterns/strips/is-bordered/) (`.p-strip--bordered`) is now deprecated. If a horizontal line is needed to separate parts of content use standard [sections](/docs/patterns/section) and [the rule component](/docs/patterns/rule) instead.
 
-[Light strips](/docs/examples/patterns/strips/strips-light) (`p-strip--light`), [white strips](/docs/examples/patterns/strips/white) (`.p-strip--white`) and [accent strips](/docs/examples/patterns/strips/accent) (`.p-strip--accent`) are now deprecated. Use the new [highlighted strip](#highligted-strip) instead.
+[Light strips](/docs/examples/patterns/strips/strips-light) (`.p-strip--light`), [white strips](/docs/examples/patterns/strips/white) (`.p-strip--white`) and [accent strips](/docs/examples/patterns/strips/accent) (`.p-strip--accent`) are now deprecated. Use the new [highlighted strip](#highligted-strip) instead.
 
 [Dark strip](/docs/examples/patterns/strips/strips-dark) (`.p-strip--dark`) is now deprecated. Use the [new theming](#themes) by applying `is-dark` class name to the strip instead.
 

--- a/templates/docs/patterns/strip/index.md
+++ b/templates/docs/patterns/strip/index.md
@@ -6,11 +6,17 @@ context:
 
 The strip pattern provides a full width strip container in which to wrap a grid. It is an alternative to the section component, that surrounds its content with a padding both on the top and bottom, and is used usually when a change of the background is needed or to separate different sections of the page.
 
+Strips, similarly to sections, come in 3 sizes: regular (`.p-strip`), [deep](#deep-strip) (`.p-strip is-deep`) and [shallow](#shallow-strip) (`.p-strip is-shallow`).
+
+They fully support [theming](#themes). Changing the theme on the strip component itself will apply the background colour to the entire strip, and affect the theme of the strip content. You can choose between regular strip (with default background of the theme), or highlighted strip (with am alternative lighter version of the background colour).
+
 A `.p-strip` container should always be the parent of a `.row` (from the [Grid pattern](/docs/patterns/grid/)) and never the other way around.
 
 ## Regular strip
 
 The strip component is rarely used on its own as a container with just `.p-strip` class name. It is usually combined with other variants described below to provide a specific visual style.
+
+If you believe you need a plain `.p-strip` container, you likely want to use a [section](/docs/patterns/section) instead.
 
 ## Themes
 
@@ -23,7 +29,7 @@ View example of the strip dark pattern
 <div class="p-notification--caution">
   <div class="p-notification__content">
     <h3 class="p-notification__title">Deprecated</h3>
-    <p class="p-notification__message">In Vanilla 4.8.0 with the introduction of new theming system the old <code>p-strip--dark</code> is deprecated. Use a strip is <code>is-dark</code> class instead.</p>
+    <p class="p-notification__message">In Vanilla 4.8.0 with the introduction of new theming system the old <code>p-strip--dark</code> is deprecated. Use a strip with <code>is-dark</code> class instead.</p>
   </div>
 </div>
 


### PR DESCRIPTION
## Done

- Updates strips to use new theming system with `is-light` `is-dark` `is-paper` class names.
- Introduces new `p-strip--highlighted` to replace a variety of strip colour variants with a single themed version of a strip with an alternative backround colour
- Deprecates a number of old strips that are not meant for new designs: `p-strip--dark` `p-strip--light` `p-strip--white` `p-strip--image` `p-strip--suru`, etc. They should be replaced by new themed versions.
- Updates all the necessary docs and examples.

Fixes [WD-8473](https://warthogs.atlassian.net/browse/WD-8473)

## QA

- Open [demo](https://vanilla-framework-4996.demos.haus/docs/patterns/strip)
- Check the dark strip example: https://vanilla-framework-4996.demos.haus/docs/examples/patterns/strips/dark
  - verify in inspector that it takes colors from CSS variables
  - change the theme to `is-light`, `is-paper` to check if it adjusts
- Check the highlighted strip example: https://vanilla-framework-4996.demos.haus/docs/examples/patterns/strips/highlighted
  - change the theme class (on body or on strip)
  - make sure the colour changes: on dark theme it should use a "lighter" dark, on paper it should use white, on light it should use light grey
- Verify that old deprecated versions are still supported
  - [white](https://vanilla-framework-4996.demos.haus/docs/examples/patterns/strips/white)
  - [suru](https://vanilla-framework-4996.demos.haus/docs/examples/patterns/strips/suru)
  - [light](https://vanilla-framework-4996.demos.haus/docs/examples/patterns/strips/strips-light)
  - [dark](https://vanilla-framework-4996.demos.haus/docs/examples/patterns/strips/strips-dark)
  - [bordered](https://vanilla-framework-4996.demos.haus/docs/examples/patterns/strips/is-bordered)
  - [image](https://vanilla-framework-4996.demos.haus/docs/examples/patterns/strips/image)
  - [accent](https://vanilla-framework-4996.demos.haus/docs/examples/patterns/strips/accent)
- Review updated documentation:
  - https://vanilla-framework-4996.demos.haus/docs/patterns/strip

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1420" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/5c867ff2-0925-4e2b-908c-78d8fca849c2">



[WD-8473]: https://warthogs.atlassian.net/browse/WD-8473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ