### PR TITLE
Fix table mobile card top border

### DIFF
--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -71,6 +71,6 @@
   // stylelint-enable selector-max-type
 
   %table-row-border {
-    border-top: 1px solid $colors--theme--border-default;
+    border-top: 1px solid $colors--theme--border-low-contrast;
   }
 }

--- a/scss/_base_tables.scss
+++ b/scss/_base_tables.scss
@@ -71,6 +71,6 @@
   // stylelint-enable selector-max-type
 
   %table-row-border {
-    border-top: 1px solid $colors--theme--border-low-contrast;
+    border-top: 1px solid $colors--theme--border-default;
   }
 }

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -24,7 +24,8 @@
           width: 100%;
         }
 
-        tr {
+        // tbody selector needed to override the default table styles
+        tbody tr {
           border: 1px solid $colors--theme--border-default;
           display: block;
           margin-bottom: $spv--x-large;
@@ -64,7 +65,7 @@
           }
 
           &:not(:first-child)::after {
-            background-color: $colors--theme--border-default;
+            background-color: $colors--theme--border-low-contrast;
             content: '';
             height: 1px;
             left: 0;

--- a/scss/_patterns_table-mobile-card.scss
+++ b/scss/_patterns_table-mobile-card.scss
@@ -25,7 +25,7 @@
         }
 
         tr {
-          border: $border;
+          border: 1px solid $colors--theme--border-default;
           display: block;
           margin-bottom: $spv--x-large;
           padding: 0 $sph--large;
@@ -64,7 +64,7 @@
           }
 
           &:not(:first-child)::after {
-            background-color: $colors--theme--border-low-contrast;
+            background-color: $colors--theme--border-default;
             content: '';
             height: 1px;
             left: 0;


### PR DESCRIPTION
## Done

- Fixed the issue where top border wasn't consistent with the other border sides

Fixes https://github.com/canonical/vanilla-framework/issues/5001, [WD-9104](https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?selectedIssue=WD-9104)

## QA

- Open [demo](https://vanilla-framework-5005.demos.haus/)
- Go to https://vanilla-framework-5005.demos.haus/docs/examples/patterns/tables/table-mobile-card or https://vanilla-framework-5005.demos.haus/docs/examples/patterns/tables/table-mobile-card-dark
- Make sure border sides are all equal size and same colour

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![0 0 0 0_8101_docs_examples_patterns_tables_table-mobile-card](https://github.com/canonical/vanilla-framework/assets/62298176/15648be5-3e50-4445-8c67-ba4c96c8da40)

![0 0 0 0_8101_docs_examples_patterns_tables_table-mobile-card-dark](https://github.com/canonical/vanilla-framework/assets/62298176/834fcf0d-896d-4792-84cf-ab77db8d7e5f)


[WD-9104]: https://warthogs.atlassian.net/browse/WD-9104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ