### PR TITLE
Fix bug where u-fixed-width wasn't having its padding reset when inside the new row classes

### DIFF
--- a/scss/_base_grid-definitions.scss
+++ b/scss/_base_grid-definitions.scss
@@ -23,14 +23,14 @@
     @extend %fixed-width-container--common-properties;
 
     max-width: $grid-max-width;
-  }
-
-  %vf-row {
-    @extend %fixed-width-container;
 
     & & {
       @include vf-b-row-reset;
     }
+  }
+
+  %vf-row {
+    @extend %fixed-width-container;
 
     @supports (display: grid) {
       display: grid;

--- a/scss/_utilities_layout.scss
+++ b/scss/_utilities_layout.scss
@@ -3,10 +3,10 @@
     @extend %fixed-width-container;
 
     & &,
-    [class^="row"] &,
-    [class*=" row"] &,
-    & [class^="row"],
-    & [class*=" row"] {
+    [class^='row'] &,
+    [class*=' row'] &,
+    & [class^='row'],
+    & [class*=' row'] {
       @include vf-b-row-reset;
     }
   }

--- a/scss/_utilities_layout.scss
+++ b/scss/_utilities_layout.scss
@@ -3,8 +3,10 @@
     @extend %fixed-width-container;
 
     & &,
-    .row &,
-    & .row {
+    [class^="row"] &,
+    [class*=" row"] &,
+    & [class^="row"],
+    & [class*=" row"] {
       @include vf-b-row-reset;
     }
   }

--- a/scss/_utilities_layout.scss
+++ b/scss/_utilities_layout.scss
@@ -1,14 +1,6 @@
 @mixin vf-u-layout {
   .u-fixed-width {
     @extend %fixed-width-container;
-
-    & &,
-    [class^='row'] &,
-    [class*=' row'] &,
-    & [class^='row'],
-    & [class*=' row'] {
-      @include vf-b-row-reset;
-    }
   }
 
   @if ($table-layout-fixed) {


### PR DESCRIPTION
## Done

- Use more general selectors to target all classes that start with 'row':
`[class^="row"]` for if it is the first class in the class list
`[class*=" row"]` for if it is not

Another option here is to use `[class*="row"]`, which will target any class where 'row' is a substring, however this is very general and could have some unintended targets such as 'p-navigation__row' 


Fixes https://github.com/canonical/vanilla-framework/issues/4925

## QA

- Open [demo](insert-demo-url)
- Find or create a page where there is a `u-fixed-width` contained withing one of the new 'row' patterns (ex. `row--25-75`)
- See that the padding is reset

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![image](https://github.com/canonical/vanilla-framework/assets/58276363/ef2deff6-d820-4433-a0db-9ee32154f7a4)
