### PR TITLE
Add a fourth level of nesting to the side navigation component

### DIFF
--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -509,6 +509,22 @@
         @include vf-side-navigation-spacing-left($multiplier: 2, $offset: $sp-sidenav--accordion-offset);
       }
     }
+
+    // nested 4th level of navigation
+    .p-side-navigation__item--title .p-side-navigation__item .p-side-navigation__item .p-side-navigation__item &,
+    .p-side-navigation__item .p-side-navigation__item .p-side-navigation__item .p-side-navigation__item & {
+      @include vf-side-navigation-spacing-left($multiplier: 4);
+
+      // add spacing for variant with right side icons
+      .p-side-navigation--icons & {
+        @include vf-side-navigation-spacing-left($multiplier: 5, $offset: $sp-sidenav--icon-width);
+      }
+
+      // add spacing for variant with accordions
+      .p-side-navigation--accordion & {
+        @include vf-side-navigation-spacing-left($multiplier: 3, $offset: $sp-sidenav--accordion-offset);
+      }
+    }
   }
 
   .p-side-navigation--icons {

--- a/templates/docs/examples/patterns/side-navigation/_accordion.html
+++ b/templates/docs/examples/patterns/side-navigation/_accordion.html
@@ -53,6 +53,17 @@
               <button class="p-side-navigation__accordion-button" aria-expanded="false">Hardware testing with long text wrapped to the next line</button>
               <ul class="p-side-navigation__list" aria-expanded="false">
                 <li class="p-side-navigation__item">
+                  <button class="p-side-navigation__accordion-button" aria-expanded="false">A fourth level of nesting</button>
+                  <ul class="p-side-navigation__list" aria-expanded="false">
+                    <li class="p-side-navigation__item">
+                      <a class="p-side-navigation__link" href="#">Our scientists were so preoccupied with whether or not they could</a>
+                    </li>
+                    <li class="p-side-navigation__item">
+                      <a class="p-side-navigation__link" href="#">They didn't stop to thing if we should</a>
+                    </li>
+                  </ul> 
+                </li>
+                <li class="p-side-navigation__item">
                   <a class="p-side-navigation__link" href="#">We need to go deeper</a>
                 </li>
                 <li class="p-side-navigation__item">

--- a/templates/docs/examples/patterns/side-navigation/_expandable.html
+++ b/templates/docs/examples/patterns/side-navigation/_expandable.html
@@ -44,6 +44,18 @@
               <button class="p-side-navigation__expand"  aria-label="show submenu for Hardware testing with long text wrapped to the next line" aria-expanded="false"></button>
               <ul class="p-side-navigation__list" aria-expanded="false">
                 <li class="p-side-navigation__item">
+                  <span class="p-side-navigation__text is-expandable">A fourth level of nesting</span>
+                  <button class="p-side-navigation__expand"  aria-label="show submenu for Hardware testing with long text wrapped to the next line" aria-expanded="false"></button>
+                  <ul class="p-side-navigation__list" aria-expanded="false">
+                    <li class="p-side-navigation__item">
+                      <a class="p-side-navigation__link" href="#">Our scientists were so preoccupied with whether or not they could</a>
+                    </li>
+                    <li class="p-side-navigation__item">
+                      <a class="p-side-navigation__link" href="#">They didn't stop to thing if we should</a>
+                    </li>
+                  </ul> 
+                </li>
+                <li class="p-side-navigation__item">
                   <a class="p-side-navigation__link" href="#">We need to go deeper</a>
                 </li>
                 <li class="p-side-navigation__item">

--- a/templates/docs/patterns/navigation/index.md
+++ b/templates/docs/patterns/navigation/index.md
@@ -73,7 +73,7 @@ On small screens the search box and menu items can be expanded individually as t
 
 The side navigation pattern can be used to provide more detailed navigation alongside your content.
 
-It allows grouping the links into navigation sections and nesting them up to three levels.
+It allows grouping the links into navigation sections and nesting them up to four levels.
 
 Current page in the side navigation should be highlighted by adding `aria-current="page"` attribute to the corresponding `p-side-navigation__link` element. Alternatively, if `aria-current` attribute cannot be set, the `is-active` class can be used instead.
 


### PR DESCRIPTION
## Done

- Adds a fourth level of nesting to the side navigation component

Fixes https://warthogs.atlassian.net/browse/WD-9262

## QA

- Open [accordion demo](https://vanilla-framework-5010.demos.haus/docs/examples/patterns/side-navigation/accordion)
- Open [expandable demo](https://vanilla-framework-5010.demos.haus/docs/examples/patterns/side-navigation/expandable)
- See that the fourth level of nesting works
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
