### PR TITLE
fix height difference in search and search-and-filter

### DIFF
--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -123,7 +123,6 @@
     }
 
     .p-search-and-filter__input {
-      border: 0;
       box-shadow: none;
       flex-grow: 1;
       margin-bottom: 0;


### PR DESCRIPTION
## Done
- Fix height difference in search and search-and-filter

Fixes [list issues/bugs if needed] https://github.com/canonical/vanilla-framework/issues/4984

## QA
- Go to [search and filter](http://localhost:8101/docs/examples/patterns/search-box/default/docs/examples/patterns/search-and-filter/default) and [search](http://localhost:8101/docs/examples/patterns/search-box/default/docs/examples/patterns/search-box/default), inspect both components and ensure the heights are the same
- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
### Before
![image](https://github.com/canonical/vanilla-framework/assets/47438585/52b00c20-9e00-41d2-9d32-3330a319695b)
### After
![image](https://github.com/canonical/vanilla-framework/assets/47438585/5fda59fe-2b49-4619-9b4a-685a3ecdfd9b)

[if relevant, include a screenshot or screen capture]
