### PR TITLE
Update link to Accessibility Alphabet

### DIFF
--- a/templates/accessibility.html
+++ b/templates/accessibility.html
@@ -119,7 +119,7 @@
           <li class="p-list__item"><a href="https://developer.chrome.com/docs/devtools/accessibility/reference/">Chrome Accessibility Developer Tools</a></li>
           <li class="p-list__item"><a href="https://webaim.org/resources/contrastchecker/">Contrast checker tool</a></li>
           <li class="p-list__item"><a href="http://www.chromevox.com/">ChromeVox: a screen reader for Chrome</a></li>
-          <li class="p-list__item"><a href="https://the-pastry-box-project.net/anne-gibson/2014-july-31">Accessibility Alphabet</a></li>
+          <li class="p-list__item"><a href="http://web.archive.org/web/20230307004829/https://the-pastry-box-project.net/anne-gibson/2014-july-31">Accessibility Alphabet</a></li>
           <li class="p-list__item"><a href="https://webaim.org/">Web Accessibility in Mind</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Done

Fixes an outdated link to accessibility resources.

Fixes #5017

## QA

- Check the [accessibility page](https://vanilla-framework-5020.demos.haus/accessibility), make sure link to Accessibility Alphabet links (in Useful tools section) to (archived) version of the article
