### PR TITLE
Buttons themes

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -4,6 +4,14 @@
       url: /docs/patterns/images#media-element-with-spacing
       status: New
       notes: We've introduced a way to add spacing above a media element.
+    - component: Buttons / Themes
+      url: /docs/patterns/buttons#theming
+      status: Updated
+      notes: Buttons have been updated to support new theming.
+    - component: Buttons / Brand
+      url: /docs/patterns/buttons#brand
+      status: Deprecated
+      notes: We've deprecated the brand buttons. Use other button styles instead.
 - version: 4.8.0
   features:
     - component: Themes

--- a/scss/_base_button.scss
+++ b/scss/_base_button.scss
@@ -100,15 +100,15 @@
 }
 
 @mixin vf-button-pattern(
-  $button-background-color: $colors--light-theme--background-default,
-  $button-text-color: $colors--light-theme--text-default,
+  $button-background-color: $colors--theme--background-default,
+  $button-text-color: $colors--theme--text-default,
   $button-disabled-background-color: $color-transparent,
-  $button-disabled-border-color: $colors--light-theme--border-high-contrast,
-  $button-border-color: $colors--light-theme--border-high-contrast,
-  $button-hover-background-color: $colors--light-theme--background-hover,
-  $button-hover-border-color: $colors--light-theme--border-high-contrast,
-  $button-active-background-color: $colors--light-theme--background-active,
-  $button-active-border-color: $colors--light-theme--border-high-contrast
+  $button-disabled-border-color: $colors--theme--border-high-contrast,
+  $button-border-color: $colors--theme--border-high-contrast,
+  $button-hover-background-color: $colors--theme--background-hover,
+  $button-hover-border-color: $colors--theme--border-high-contrast,
+  $button-active-background-color: $colors--theme--background-active,
+  $button-active-border-color: $colors--theme--border-high-contrast
 ) {
   background-color: $button-background-color;
   border-color: $button-border-color;

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -18,6 +18,7 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 @mixin vf-button-plain {
   .p-button {
     @extend %vf-button-base;
+    @include vf-button-pattern;
   }
 }
 

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -16,41 +16,8 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 }
 
 @mixin vf-button-plain {
-  %p-button-light {
-    @include vf-button-pattern();
-  }
-
-  %p-button-dark {
-    @include vf-button-pattern(
-      $button-background-color: $colors--dark-theme--background-default,
-      $button-text-color: $colors--dark-theme--text-default,
-      $button-disabled-background-color: $color-transparent,
-      $button-disabled-border-color: $colors--dark-theme--border-high-contrast,
-      $button-border-color: $colors--dark-theme--border-high-contrast,
-      $button-hover-background-color: $colors--dark-theme--background-hover,
-      $button-hover-border-color: $colors--dark-theme--border-high-contrast,
-      $button-active-background-color: $colors--dark-theme--background-active,
-      $button-active-border-color: $colors--dark-theme--border-high-contrast
-    );
-  }
-
   .p-button {
     @extend %vf-button-base;
-
-    // Theming
-    @if ($theme-default-p-button == 'dark') {
-      @extend %p-button-dark;
-
-      &.is-light {
-        @extend %p-button-light;
-      }
-    } @else {
-      @extend %p-button-light;
-
-      &.is-dark {
-        @extend %p-button-dark;
-      }
-    }
   }
 }
 
@@ -216,47 +183,17 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 }
 
 @mixin vf-button-base {
-  %p-button--base-light {
-    @include vf-button-pattern(
-      $button-background-color: $color-transparent,
-      $button-border-color: $color-transparent,
-      $button-hover-border-color: $color-transparent,
-      $button-active-border-color: $color-transparent,
-      $button-disabled-border-color: $color-transparent
-    );
-  }
-
-  %p-button--base-dark {
-    @include vf-button-pattern(
-      $button-background-color: $color-transparent,
-      $button-text-color: $colors--dark-theme--text-default,
-      $button-disabled-background-color: $color-transparent,
-      $button-hover-background-color: $colors--dark-theme--background-hover,
-      $button-active-background-color: $colors--dark-theme--background-active,
-      $button-border-color: $color-transparent,
-      $button-hover-border-color: $color-transparent,
-      $button-active-border-color: $color-transparent,
-      $button-disabled-border-color: $color-transparent
-    );
-  }
-
   .p-button--base {
     @extend %vf-button-base;
 
-    // Theming
-    @if ($theme-default-p-button == 'dark') {
-      @extend %p-button--base-dark;
-
-      &.is-light {
-        @extend %p-button--base-light;
-      }
-    } @else {
-      @extend %p-button--base-light;
-
-      &.is-dark {
-        @extend %p-button--base-dark;
-      }
-    }
+    // override default button styles with transparent background and border
+    @include vf-button-pattern(
+      $button-background-color: $color-transparent,
+      $button-border-color: $color-transparent,
+      $button-hover-border-color: $color-transparent,
+      $button-active-border-color: $color-transparent,
+      $button-disabled-border-color: $color-transparent
+    );
   }
 }
 
@@ -272,18 +209,18 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
     padding-left: 0;
     padding-right: 0;
 
+    // stylelint-disable-next-line selector-max-type -- buttons should not affect paragraph spacing
+    p & {
+      margin-bottom: 0;
+      padding-top: 0;
+    }
+
     &:hover {
       background: transparent;
     }
 
     &.u-no-margin--bottom {
       @extend %u-no-margin--bottom--default-text;
-    }
-
-    // stylelint-disable-next-line selector-max-type -- buttons should not affect paragraph spacing
-    p & {
-      margin-bottom: 0;
-      padding-top: 0;
     }
   }
 }

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -21,6 +21,7 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
   }
 }
 
+// DEPRECATED: brand coloured button is deprecated, please use other type of button instead
 @mixin vf-button-brand {
   %p-button--brand-light {
     @include vf-button-pattern(
@@ -73,112 +74,41 @@ $hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 }
 
 @mixin vf-button-positive {
-  %p-button--positive-light {
-    @include vf-button-pattern(
-      $button-background-color: $color-positive,
-      $button-hover-background-color: adjust-color($color-positive, $lightness: -$hover-background-opacity-percentage),
-      $button-active-background-color: adjust-color($color-positive, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-background-color: $color-positive,
-      $button-border-color: $color-positive,
-      $button-hover-border-color: adjust-color($color-positive, $lightness: -$hover-background-opacity-percentage),
-      $button-active-border-color: adjust-color($color-positive, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-border-color: $color-positive,
-      $button-text-color: vf-contrast-text-color($color-positive)
-    );
-
-    @include vf-focus($color-focus-positive);
-  }
-
-  %p-button--positive-dark {
-    @include vf-button-pattern(
-      $button-background-color: $color-positive-dark,
-      $button-hover-background-color: adjust-color($color-positive-dark, $lightness: -$hover-background-opacity-percentage),
-      $button-active-background-color: adjust-color($color-positive-dark, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-background-color: $color-positive-dark,
-      $button-border-color: $color-positive-dark,
-      $button-hover-border-color: adjust-color($color-positive-dark, $lightness: -$hover-background-opacity-percentage),
-      $button-active-border-color: adjust-color($color-positive-dark, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-border-color: $color-positive-dark,
-      $button-text-color: vf-contrast-text-color($color-positive-dark)
-    );
-
-    @include vf-focus($color-focus-positive);
-  }
-
   .p-button--positive {
     @extend %vf-button-base;
-
-    // Theming
-    @if ($theme-default-p-button == 'dark') {
-      @extend %p-button--positive-dark;
-
-      &.is-light {
-        @extend %p-button--positive-light;
-      }
-    } @else {
-      @extend %p-button--positive-light;
-
-      &.is-dark {
-        @extend %p-button--positive-dark;
-      }
-    }
-
     @extend %vf-button-white-success-icon;
+
+    @include vf-button-pattern(
+      $button-background-color: $colors--theme--button-positive-default,
+      $button-hover-background-color: $colors--theme--button-positive-hover,
+      $button-active-background-color: $colors--theme--button-positive-active,
+      $button-disabled-background-color: $colors--theme--button-positive-default,
+      $button-border-color: $colors--theme--button-positive-default,
+      $button-hover-border-color: $colors--theme--button-positive-hover,
+      $button-active-border-color: $colors--theme--button-positive-active,
+      $button-disabled-border-color: $colors--theme--button-positive-default,
+      $button-text-color: $colors--theme--button-positive-text
+    );
+    @include vf-focus($color-focus-positive);
   }
 }
 
 @mixin vf-button-negative {
-  %p-button--negative-light {
-    @include vf-button-pattern(
-      $button-background-color: $color-negative,
-      $button-hover-background-color: adjust-color($color-negative, $lightness: -$hover-background-opacity-percentage),
-      $button-active-background-color: adjust-color($color-negative, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-background-color: $color-negative,
-      $button-border-color: $color-negative,
-      $button-hover-border-color: adjust-color($color-negative, $lightness: -$hover-background-opacity-percentage),
-      $button-active-border-color: adjust-color($color-negative, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-border-color: $color-negative,
-      $button-text-color: vf-contrast-text-color($color-negative)
-    );
-
-    @include vf-focus($color-focus-negative);
-  }
-
-  %p-button--negative-dark {
-    @include vf-button-pattern(
-      $button-background-color: $color-negative-dark,
-      $button-hover-background-color: adjust-color($color-negative-dark, $lightness: -$hover-background-opacity-percentage),
-      $button-active-background-color: adjust-color($color-negative-dark, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-background-color: $color-negative-dark,
-      $button-border-color: $color-negative-dark,
-      $button-hover-border-color: adjust-color($color-negative-dark, $lightness: -$hover-background-opacity-percentage),
-      $button-active-border-color: adjust-color($color-negative-dark, $lightness: -$active-background-opacity-percentage),
-      $button-disabled-border-color: $color-negative-dark,
-      $button-text-color: vf-contrast-text-color($color-negative-dark)
-    );
-
-    @include vf-focus($color-focus-negative);
-  }
-
   .p-button--negative {
     @extend %vf-button-base;
-
-    // Theming
-    @if ($theme-default-p-button == 'dark') {
-      @extend %p-button--negative-dark;
-
-      &.is-light {
-        @extend %p-button--negative-light;
-      }
-    } @else {
-      @extend %p-button--negative-light;
-
-      &.is-dark {
-        @extend %p-button--negative-dark;
-      }
-    }
-
     @extend %vf-button-white-success-icon;
+
+    @include vf-button-pattern(
+      $button-background-color: $colors--theme--button-negative-default,
+      $button-hover-background-color: $colors--theme--button-negative-hover,
+      $button-active-background-color: $colors--theme--button-negative-active,
+      $button-disabled-background-color: $colors--theme--button-negative-default,
+      $button-border-color: $colors--theme--button-negative-default,
+      $button-hover-border-color: $colors--theme--button-negative-hover,
+      $button-active-border-color: $colors--theme--button-negative-active,
+      $button-disabled-border-color: $colors--theme--button-negative-default,
+      $button-text-color: $colors--theme--button-negative-text
+    );
   }
 }
 

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -204,13 +204,11 @@
     }
   }
 
-  // toggle to open side navigation is supposed to be in main content (on light background)
-  // it's using default 'neutral' button look regardless of the theme used by side navigation
   .p-side-navigation__toggle {
     @include vf-button-pattern;
 
     &::before {
-      @include vf-icon-chevron; // this icon is not themed, as it's on a default 'neutral' button regardless of the theme
+      @include vf-icon-chevron-themed;
       transform: rotate(-90deg);
     }
   }

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -268,6 +268,16 @@ $colors--theme--background-information-default: var(--vf-color-background-inform
 $colors--theme--background-information-hover: var(--vf-color-background-information-hover);
 $colors--theme--background-information-active: var(--vf-color-background-information-active);
 
+$colors--theme--button-positive-default: var(--vf-color-button-positive-default);
+$colors--theme--button-positive-hover: var(--vf-color-button-positive-hover);
+$colors--theme--button-positive-active: var(--vf-color-button-positive-active);
+$colors--theme--button-positive-text: var(--vf-color-button-positive-text);
+
+$colors--theme--button-negative-default: var(--vf-color-button-negative-default);
+$colors--theme--button-negative-hover: var(--vf-color-button-negative-hover);
+$colors--theme--button-negative-active: var(--vf-color-button-negative-active);
+$colors--theme--button-negative-text: var(--vf-color-button-negative-text);
+
 // Theme colors exposed as CSS custom properties
 @mixin vf-theme-light--colors {
   // SCSS variables need to be interpolated to work in CSS custom properties
@@ -311,6 +321,16 @@ $colors--theme--background-information-active: var(--vf-color-background-informa
   --vf-color-background-information-default: #{map-get($colors-light-theme--tinted-backgrounds, information, default)};
   --vf-color-background-information-hover: #{map-get($colors-light-theme--tinted-backgrounds, information, 'hover')};
   --vf-color-background-information-active: #{map-get($colors-light-theme--tinted-backgrounds, information, active)};
+
+  --vf-color-button-positive-default: #{$color-positive};
+  --vf-color-button-positive-hover: #{adjust-color($color-positive, $lightness: -$hover-background-opacity-percentage)};
+  --vf-color-button-positive-active: #{adjust-color($color-positive, $lightness: -$active-background-opacity-percentage)};
+  --vf-color-button-positive-text: #{vf-contrast-text-color($color-positive)};
+
+  --vf-color-button-negative-default: #{$color-negative};
+  --vf-color-button-negative-hover: #{adjust-color($color-negative, $lightness: -$hover-background-opacity-percentage)};
+  --vf-color-button-negative-active: #{adjust-color($color-negative, $lightness: -$active-background-opacity-percentage)};
+  --vf-color-button-negative-text: #{vf-contrast-text-color($color-negative)};
 }
 
 @mixin vf-theme-dark--colors {
@@ -355,6 +375,16 @@ $colors--theme--background-information-active: var(--vf-color-background-informa
   --vf-color-background-information-default: #{map-get($colors-dark-theme--tinted-backgrounds, information, default)};
   --vf-color-background-information-hover: #{map-get($colors-dark-theme--tinted-backgrounds, information, hover)};
   --vf-color-background-information-active: #{map-get($colors-dark-theme--tinted-backgrounds, information, active)};
+
+  --vf-color-button-positive-default: #{$color-positive-dark};
+  --vf-color-button-positive-hover: #{adjust-color($color-positive-dark, $lightness: -$hover-background-opacity-percentage)};
+  --vf-color-button-positive-active: #{adjust-color($color-positive-dark, $lightness: -$active-background-opacity-percentage)};
+  --vf-color-button-positive-text: #{vf-contrast-text-color($color-positive-dark)};
+
+  --vf-color-button-negative-default: #{$color-negative-dark};
+  --vf-color-button-negative-hover: #{adjust-color($color-negative-dark, $lightness: -$hover-background-opacity-percentage)};
+  --vf-color-button-negative-active: #{adjust-color($color-negative-dark, $lightness: -$active-background-opacity-percentage)};
+  --vf-color-button-negative-text: #{vf-contrast-text-color($color-negative-dark)};
 }
 
 @mixin vf-theme-paper--colors {

--- a/templates/docs/examples/patterns/buttons/dark.html
+++ b/templates/docs/examples/patterns/buttons/dark.html
@@ -3,12 +3,10 @@
 
 {% block standalone_css %}patterns_buttons{% endblock %}
 
+{% set is_dark = True %}
 {% block content %}
-<div class="p-strip is-dark is-shallow" style="background: #111">
-    <button class="p-button is-dark">Default button</button>
-    <button class="p-button--base is-dark">Base button</button>
-    <button class="p-button--positive is-dark">Positive button</button>
-    <button class="p-button--negative is-dark">Negative button</button>
-    <button class="p-button--brand is-dark">Brand button</button>
-</div>
+<button class="p-button">Default button</button>
+<button class="p-button--base">Base button</button>
+<button class="p-button--positive">Positive button</button>
+<button class="p-button--negative">Negative button</button>
 {% endblock %}

--- a/templates/docs/examples/patterns/contextual-menu/dark.html
+++ b/templates/docs/examples/patterns/contextual-menu/dark.html
@@ -3,10 +3,11 @@
 
 {% block standalone_css %}patterns_contextual-menu{% endblock %}
 
+{% set is_dark = True %}
 {% block content %}
-<span class="p-contextual-menu--left is-dark">
+<span class="p-contextual-menu--left">
   <button class="p-contextual-menu__toggle" aria-controls="menu-3" aria-expanded="false" aria-haspopup="true">Take action&hellip;</button>
-  <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true">
+  <span class="p-contextual-menu__dropdown is-dark" id="menu-3" aria-hidden="true">
     <span class="p-contextual-menu__group">
       <button class="p-contextual-menu__link">Commission</button>
       <button class="p-contextual-menu__link">Aquire</button>
@@ -20,7 +21,7 @@
   </span>
 </span>
 
-<p>Lorem ipsum dolor sit amet consectetur adipiscing elit <span class="p-contextual-menu--left is-dark">
+<p>Lorem ipsum dolor sit amet consectetur adipiscing elit <span class="p-contextual-menu--left">
     <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-4" aria-expanded="true" aria-haspopup="true">take action left</a>
     <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="false">
         <span class="p-contextual-menu__group">
@@ -34,7 +35,7 @@
           <a href="#" class="p-contextual-menu__link">Mark broken</a>
         </span>
     </span>
-</span> nunc dolor. Arcu molestie non arcu porttitor <span class="p-contextual-menu--center is-dark">
+</span> nunc dolor. Arcu molestie non arcu porttitor <span class="p-contextual-menu--center">
     <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-5" aria-expanded="false" aria-haspopup="true">take action center</a>
     <span class="p-contextual-menu__dropdown" id="menu-5" aria-hidden="true">
         <span class="p-contextual-menu__group">
@@ -48,7 +49,7 @@
           <a href="#" class="p-contextual-menu__link">Mark broken</a>
         </span>
     </span>
-</span> volutpat rutrum ipsum nunc lacus ligula ornare et diam <span class="p-contextual-menu is-dark">
+</span> volutpat rutrum ipsum nunc lacus ligula ornare et diam <span class="p-contextual-menu">
     <a href="#" class="p-contextual-menu__toggle" aria-controls="menu-6" aria-expanded="false" aria-haspopup="true">take action right</a>
     <span class="p-contextual-menu__dropdown" id="menu-6" aria-hidden="true">
         <span class="p-contextual-menu__group">

--- a/templates/docs/patterns/buttons/index.md
+++ b/templates/docs/patterns/buttons/index.md
@@ -45,14 +45,6 @@ A negative button can be used to indicate a negative action that is destructive 
 View example of the negative button pattern
 </a></div>
 
-## Brand
-
-You can use the brand button with the main color of your brand.
-
-<div class="embedded-example"><a href="/docs/examples/patterns/buttons/brand/" class="js-example">
-View example of the brand button pattern
-</a></div>
-
 ## Link
 
 In some contexts you may need a button to look visually identical to a link.
@@ -105,14 +97,20 @@ View example of the processing button pattern
 
 ## Theming
 
-The buttons use Vanilla's light theme by default. There are two ways to switch between the light and the dark themes:
-
-- Override the default by adding a state to `p-button`: `is-dark` when the default navigation is light, or `is-light` when the default has been changed to dark:
-- Change the default: go to `_settings_themes.scss` and set `$theme-default-p-button` to `dark`
+The buttons use Vanilla's theme colours. You can switch the theme by adding `is-dark`, `is-light` or `is-paper` class name on any parent element or the button itself.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/buttons/dark" class="js-example">
 View example of the buttons with an is-dark class
 </a></div>
+
+## Brand
+
+<div class="p-notification--caution">
+  <div class="p-notification__content">
+    <h3 class="p-notification__title">Deprecated</h3>
+    <p class="p-notification__message">Brand-coloured buttons are deprecated since Vanilla 4.9.0 and will be removed in future version of Vanilla. Please use another type of button instead.</p>
+  </div>
+</div>
 
 ## Import
 


### PR DESCRIPTION
## Done

Updates buttons to use new theming.
Deprecates brand buton.

Fixes [WD-7595](https://warthogs.atlassian.net/browse/WD-7595)

## QA

- Open [demo](https://vanilla-framework-5024.demos.haus/docs/examples/patterns/buttons/dark)
- Check if dark buttons look as expected
- Change class on body to `is-light` or `is-paper`, make sure buttons adjust accordingly
- Review updated documentation:
  - https://vanilla-framework-5024.demos.haus/docs/patterns/buttons#theming

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="647" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/b57d0261-ea0d-46d6-9016-f5fdf04e69ec">



[WD-7595]: https://warthogs.atlassian.net/browse/WD-7595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ