### PR TITLE
Update full-width documentation layout typo

### DIFF
--- a/templates/docs/examples/layouts/docs.html
+++ b/templates/docs/examples/layouts/docs.html
@@ -135,7 +135,7 @@
     </nav>
   </aside>
 
-  <div class="l-docs__title" id="main-content">
+  <div class="l-docs__title">
     <div class="p-section--shallow">
       <div class="row">
         <div class="col-12">
@@ -163,7 +163,7 @@
     </div>
   </div>
 
-  <main class="l-docs__main">
+  <main class="l-docs__main" id="main-content">
       <div class="row">
         <div class="col-12">
           <p>Main documentation content block is contained in grid <code>col-9</code>. Any standard base elements or Vanilla components can be used in the documentation pages.</p>


### PR DESCRIPTION
## Done

- Moves `id="main-content"` to be on the main content

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
