### PR TITLE
Revert default info icon to standard colour

### DIFF
--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -122,6 +122,11 @@
 }
 
 @mixin vf-icon-info-themed {
+  @include vf-themed-icon($light-value: vf-icon-info-url($colors--light-theme--icon), $dark-value: vf-icon-info-url($colors--dark-theme--icon));
+}
+
+// for use with notifications
+@mixin vf-icon-info-coloured-themed {
   @include vf-themed-icon(
     $light-value: vf-icon-info-url(map-get($colors-light-theme--tinted-borders, information)),
     $dark-value: vf-icon-info-url(map-get($colors-dark-theme--tinted-borders, information))

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -215,7 +215,7 @@ $notification-text-margin-bottom: $spv--large - $spv-nudge;
   .p-notification {
     @extend %vf-notification;
     @include vf-highlight-bar($colors--theme--border-information, left, true);
-    @include vf-icon-info-themed;
+    @include vf-icon-info-coloured-themed;
   }
 }
 
@@ -251,6 +251,6 @@ $notification-text-margin-bottom: $spv--large - $spv-nudge;
   .p-notification--information {
     @extend %vf-notification;
     @include vf-highlight-bar($colors--theme--border-information, left, true);
-    @include vf-icon-info-themed;
+    @include vf-icon-info-coloured-themed;
   }
 }


### PR DESCRIPTION
## Done

Reverts the default info icon to standard icon colour while keeping the icon in notification coloured blue.

## QA

- Open [demo](https://vanilla-framework-5027.demos.haus/docs/examples/patterns/icons/icons-light)
- Check icons example, make sure information icon is using default icon colour: https://vanilla-framework-5027.demos.haus/docs/examples/patterns/icons/icons-light
- Verify the same in other contexts, like side navigation: https://vanilla-framework-5027.demos.haus/docs/examples/patterns/side-navigation/icons
- Check info notification, make sure the icon is blue as the left border: https://vanilla-framework-5027.demos.haus/docs/examples/patterns/notifications/information


## Screenshots

<img width="688" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/a357f1ba-0a6f-4e03-aa6f-f1c3777d1eb0">

<img width="692" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/b2e06254-829a-4edd-89c1-057aca90ef31">
