### PR TITLE
Fix regression that caused wrong success icon being used in lists

### DIFF
--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -286,7 +286,7 @@
 }
 
 @mixin vf-icon-success-grey($color) {
-  background-image: vf-icon-success-url($color);
+  background-image: vf-icon-success-grey-url($color);
 }
 
 @mixin vf-icon-success-grey-themed {

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -208,7 +208,7 @@ $list-step-bullet-margin: $sph--x-large;
 
     &::before {
       @extend %vf-list-item-state-base;
-      @include vf-icon-success-grey($color-mid-dark);
+      @include vf-icon-success-grey-themed;
     }
   }
 
@@ -217,7 +217,7 @@ $list-step-bullet-margin: $sph--x-large;
 
     &::before {
       @extend %vf-list-item-state-base;
-      @include vf-icon-error-grey($color-mid-dark);
+      @include vf-icon-error-grey-themed;
     }
   }
 


### PR DESCRIPTION

## Done

Fixes a regression issue caused by icon theming where success "tick" icon in lists got replaced with "filled" version instead of lined one.

This fixes the typo that caused this, reverting back to correct icon and switches lists to use themed icons as well.

## QA

- Open [demo](https://vanilla-framework-5028.demos.haus/docs/examples/patterns/lists/lists-dividers-ticked)
- Check ticked list example: https://vanilla-framework-5028.demos.haus/docs/examples/patterns/lists/lists-dividers-ticked
  - make sure it uses correct lined tick icons, not filled ones
  - switch the theme (with buttons on the bottom), check if icon colour adjusts accordingly on dark
- Check other examples with tick icons in lists:
  - https://vanilla-framework-5028.demos.haus/docs/examples/patterns/lists/lists-status

## Screenshots

Before (wrong): https://vanillaframework.io/docs/examples/patterns/lists/lists-dividers-ticked

<img width="472" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/49396b0c-1699-47cd-b22b-262e1bb2e114">

After (expected): 

<img width="562" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/da363cd9-e0ec-4b0f-83de-a75f3e1c211d">
