### PR TITLE
Move active/hover button opacity variables to settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -1,6 +1,4 @@
 @import 'settings';
-$active-background-opacity-percentage: $active-background-opacity-amount * 100%;
-$hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
 
 // Default button styling
 @mixin vf-p-buttons {

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -50,6 +50,9 @@ $active-background-opacity-amount: 0.08;
 $muted-text-opacity-amount: 0.6;
 $inactive-text-opacity-amount: 0.75;
 
+$active-background-opacity-percentage: $active-background-opacity-amount * 100%;
+$hover-background-opacity-percentage: $hover-background-opacity-amount * 100%;
+
 // NON-SEMANTIC COLOURS
 $color-label-validated: #006b75;
 $color-code-background: rgba($color-x-dark, 0.03);


### PR DESCRIPTION
## Done

Moved active and hover button background variables to colour settings (where they are needed), so that button pattern file does not need to be imported for settings to work.


## QA

- Just make sure CI is good (all builds and tests pass)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)


