### PR TITLE
Fix access to localhost server on CircleCI

### DIFF
--- a/snapshots.js
+++ b/snapshots.js
@@ -2,7 +2,7 @@ const PORT = process.env.PORT || 8101;
 
 module.exports = async () => {
   const {default: GetSiteUrls} = await import('get-site-urls');
-  let links = await GetSiteUrls(`http://localhost:${PORT}/`);
+  let links = await GetSiteUrls(`http://0.0.0.0:${PORT}/`);
   let urls = [];
 
   links = links.found


### PR DESCRIPTION
## Done

Fixes running Percy job on CircleCI by changing localhost to IP.
For some reason access by hostname stopped working 🤷 

## QA

- Make sure `circleci / percy` job on the PR passes

