### PR TITLE
Fix link icon

### DIFF
--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -369,7 +369,7 @@
 }
 
 @mixin vf-icon-get-link($color) {
-  background-image: vf-icon-chevron-url($color);
+  background-image: vf-icon-get-link-url($color);
 }
 
 @mixin vf-icon-get-link-themed {


### PR DESCRIPTION
## Done

Reverts a regression that caused link icon to be replaced by chevron (possibly during theming refactor).


## QA

- Open [demo](https://vanilla-framework-5046.demos.haus/docs/patterns/icons)
- Find `p-icon--get-link`, make sure it's showing link icon (chain) instead of chevron


## Screenshots

<img width="370" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/3c3a4967-7ba3-43e7-beb4-ee68aa505709">

