### PR TITLE
Fix Percy on CircleCI performance issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ defaults: &defaults
 jobs:
   percy:
     <<: *defaults
+    resource_class: large
     steps:
       - checkout
       - run:

--- a/snapshots.js
+++ b/snapshots.js
@@ -1,15 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
 const PORT = process.env.PORT || 8101;
 
-module.exports = async () => {
-  const {default: GetSiteUrls} = await import('get-site-urls');
-  let links = await GetSiteUrls(`http://0.0.0.0:${PORT}/`);
-  let urls = [];
+async function getExampleFiles() {
+  //
+  let files = await fs.promises.readdir(path.join(process.cwd(), 'templates/docs/examples'), {recursive: true});
 
-  links = links.found
-    // only snapshot examples, not the whole site
-    .filter((url) => url.includes('/docs/examples/'))
-    // remove standalone examples listing from screenshots
-    .filter((url) => !url.match(/examples\/standalone$/));
+  files = files.filter((file) => path.dirname(file) !== '.' && file.endsWith('.html') && !path.basename(file).startsWith('_'));
+
+  return files;
+}
+
+const DOCS_URL = `http://localhost:${PORT}/docs/examples/`;
+
+function getExampleUrls(files) {
+  return files.map((file) => {
+    file = file.replace('.html', '');
+    return DOCS_URL + file;
+  });
+}
+
+async function run() {
+  let links = getExampleUrls(await getExampleFiles());
+  let urls = [];
 
   for (var i = 0; i < links.length; i++) {
     const url = links[i];
@@ -25,4 +39,8 @@ module.exports = async () => {
   }
 
   return urls;
+}
+
+module.exports = async () => {
+  return await run();
 };

--- a/snapshots.js
+++ b/snapshots.js
@@ -2,26 +2,32 @@ const fs = require('fs');
 const path = require('path');
 
 const PORT = process.env.PORT || 8101;
+const DOCS_URL = `http://localhost:${PORT}/docs/examples/`;
 
 async function getExampleFiles() {
-  //
+  // get all example files from templates folder
   let files = await fs.promises.readdir(path.join(process.cwd(), 'templates/docs/examples'), {recursive: true});
 
+  // filter only HTML example files in subfolders that are not partials
   files = files.filter((file) => path.dirname(file) !== '.' && file.endsWith('.html') && !path.basename(file).startsWith('_'));
 
   return files;
 }
 
-const DOCS_URL = `http://localhost:${PORT}/docs/examples/`;
-
 function getExampleUrls(files) {
+  // add standalone versions of the examples in base and patterns folders
+  const standaloneFiles = files.filter((file) => file.startsWith('base/') || file.startsWith('patterns/')).map((file) => path.join('standalone', file));
+
+  files = files.concat(standaloneFiles);
+
+  // map the file paths to URLs
   return files.map((file) => {
     file = file.replace('.html', '');
     return DOCS_URL + file;
   });
 }
 
-async function run() {
+async function getPercyConfigURLs() {
   let links = getExampleUrls(await getExampleFiles());
   let urls = [];
 
@@ -42,5 +48,5 @@ async function run() {
 }
 
 module.exports = async () => {
-  return await run();
+  return await getPercyConfigURLs();
 };


### PR DESCRIPTION
## Done

On Thursday 04.04 CircleCI builds for Percy started to timeout.
For some reason we don't fully understand yet, the process of crawling example links out of the website started to be very slow and time consuming which in the end led to timeout.

To remedy the issue this PR replaces the process of crawling the website (to get example URLs) to simply getting list of example files from file system and constructing URLs out of the file names (because they are jinja templates and there is 1:1 relation between the file paths and URLs).

We also increase CircleCI resources (as suggested by CircleCI itself) to use environment with more CPU cores and RAM.

## QA

- Make sure CircleCI Percy job is passing

<img width="1467" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/0c5db8d4-595a-45eb-9565-24494ea9f96d">
