### PR TITLE
Fix typo in release notes

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1,6 +1,6 @@
 - version: 4.10.0
   features:
-    - components: Navigation / Themes
+    - component: Navigation / Themes
       url: /docs/patterns/navigation
       status: Updated
       notes: We've updated the navigation to support new theming.


### PR DESCRIPTION
## Done

Fixes typo in changelog data that prevented link to appear on what's new page

## QA

- Open [demo](https://vanilla-framework-5050.demos.haus/docs/whats-new)
- Make sure that the first item in changelog links correctly to Navigation page


<img width="1353" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/a52d756a-b62e-432b-a629-b0d7ce4db243">

