### PR TITLE
Add theme support for active pagination button

### DIFF
--- a/scss/_patterns_pagination.scss
+++ b/scss/_patterns_pagination.scss
@@ -7,8 +7,8 @@
 
     &.is-active,
     &[aria-current='page'] {
-      background-color: scale-color($color-x-light, $lightness: -$active-background-opacity-amount * 100%);
-      color: $colors--light-theme--text-default;
+      background-color: $colors--theme--background-active;
+      color: $colors--theme--text-default;
       text-decoration: none;
     }
   }
@@ -42,15 +42,6 @@
 
     &--truncation {
       padding: $input-vertical-padding 0;
-    }
-
-    a {
-      &.is-active,
-      &[aria-current='page'] {
-        background-color: $colors--theme--background-active;
-        color: $colors--theme--text-default;
-        text-decoration: none;
-      }
     }
   }
 

--- a/scss/_patterns_pagination.scss
+++ b/scss/_patterns_pagination.scss
@@ -43,6 +43,15 @@
     &--truncation {
       padding: $input-vertical-padding 0;
     }
+
+    a {
+      &.is-active,
+      &[aria-current='page'] {
+        background-color: $colors--theme--background-active;
+        color: $colors--theme--text-default;
+        text-decoration: none;
+      }
+    }
   }
 
   .p-pagination__link {


### PR DESCRIPTION
## Done

* Add theme support for active pagination button

Fixes [WD-10537](https://warthogs.atlassian.net/browse/WD-10537)

## QA

- Open [demo](insert-demo-url)
- Go to `/docs/examples/patterns/pagination/pagination`
- Switch themes and see active pagination button's styles update correctly

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]


[WD-10537]: https://warthogs.atlassian.net/browse/WD-10537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ