### PR TITLE
Update rule component to use new theme variables

### DIFF
--- a/scss/_patterns_rule.scss
+++ b/scss/_patterns_rule.scss
@@ -8,19 +8,11 @@
   }
 
   .p-rule--muted {
-    background-color: $colors--light-theme--border-low-contrast;
-
-    &.is-dark {
-      background-color: $colors--dark-theme--border-low-contrast;
-    }
+    background-color: $colors--theme--border-low-contrast;
   }
 
   .p-rule--highlight {
-    @include vf-highlight-bar($colors--light-theme--text-default);
-
-    &.is-dark {
-      @include vf-highlight-bar($colors--dark-theme--text-default);
-    }
+    @include vf-highlight-bar($colors--theme--text-default);
 
     &.is-accent {
       @include vf-highlight-bar($color-accent);


### PR DESCRIPTION
## Done

Update rule component to use new theme colours

## QA

- Open [demo](https://vanilla-framework-5064.demos.haus/docs/examples/patterns/rule/muted)
- Check rule component example (with muted rules): https://vanilla-framework-5064.demos.haus/docs/examples/patterns/rule/muted
- Make sure it works fine across themes
- Check inspector if the lines use CSS variables


## Screenshots

<img width="970" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/9335edb5-08c8-43b9-8aa2-9a3873dbb75f">

