### PR TITLE
Label line-height on large breakpoint fix

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -101,6 +101,7 @@
   label {
     cursor: pointer;
     display: inline-block;
+    line-height: map-get($line-heights, default-text);
     margin-bottom: $spv--large - $spv-nudge;
     margin-top: 0;
     max-width: $text-max-width;


### PR DESCRIPTION
## Done
On the largest breakpoint the labels line-height wasn't set correctly. It was `30.375px` when it should be 1.5rem with 18px as 1rem, so 27px. This made the base line drift on large view ports.

## QA

- Open demo
- Check labels line-height on largest view port

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
### Before
![Screenshot 2024-05-02 at 10 21 07](https://github.com/canonical/vanilla-framework/assets/68336485/843e8057-6c16-4345-a83a-c22279f04fd3)

### After
![Screenshot 2024-05-02 at 10 21 28](https://github.com/canonical/vanilla-framework/assets/68336485/45f13181-fbf3-42f8-b997-ae6049578c14)