### PR TITLE
Navigation "back" button chevron points left instead of right

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -872,51 +872,55 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
   }
   /* stylelint-enable max-nesting-depth */
 
-  .p-navigation--sliding .p-navigation__item--dropdown-toggle {
-    position: initial;
+  .p-navigation--sliding {
+    // Default positioning for nested dropdown buttons. Overridden by subsequent styles.
+    .p-navigation__item--dropdown-toggle {
+      position: initial;
 
-    &::after {
-      content: none;
-    }
+      &::after {
+        content: none;
+      }
 
-    .p-navigation__link::after {
-      @include vf-icon-chevron-themed;
+      .p-navigation__link::after {
+        @include vf-icon-chevron-themed;
 
-      background-position: center;
-      background-repeat: no-repeat;
-      background-size: contain;
-      content: '';
-      display: block;
-      height: $spv--large;
-      pointer-events: none;
-      position: absolute;
-      right: map-get($grid-margin-widths, small);
-      text-indent: calc(100% + 10rem);
-      top: 1rem;
-      transform: rotate(-90deg);
-      width: map-get($icon-sizes, default);
+        background-position: center;
+        background-repeat: no-repeat;
+        background-size: contain;
+        content: '';
+        display: block;
+        height: $spv--large;
+        pointer-events: none;
+        position: absolute;
+        right: map-get($grid-margin-widths, small);
+        text-indent: calc(100% + 10rem);
+        top: 1rem;
+        transform: rotate(-90deg);
+        width: map-get($icon-sizes, default);
 
-      @media (min-width: $breakpoint-navigation-threshold) {
-        right: 0.5rem;
-        top: 1.2rem;
-        transform: none;
+        @media (min-width: $breakpoint-navigation-threshold) {
+          right: 0.5rem;
+          top: 1.2rem;
+          transform: none;
+        }
+      }
+
+      &.is-active > .p-navigation__link::after {
+        @media (min-width: $breakpoint-navigation-threshold) {
+          transform: rotate(180deg);
+        }
       }
     }
 
-    &.is-active > .p-navigation__link::after {
-      @media (min-width: $breakpoint-navigation-threshold) {
-        transform: rotate(180deg);
+    // Style for the "go back" button that closes the current level of the sidenav dropdown. Overrides base style from above
+    .p-navigation__item--dropdown-close {
+      .p-navigation__link::after {
+        left: 1rem;
+        transform: rotate(90deg);
       }
-    }
-  }
-
-  .p-navigation--sliding .p-navigation__item--dropdown-close {
-    .p-navigation__link::after {
-      left: 1rem;
-      transform: rotate(90deg);
-    }
-    @media (min-width: $breakpoint-navigation-threshold) {
-      display: none;
+      @media (min-width: $breakpoint-navigation-threshold) {
+        display: none;
+      }
     }
   }
 }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -872,16 +872,6 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
   }
   /* stylelint-enable max-nesting-depth */
 
-  .p-navigation--sliding .p-navigation__item--dropdown-close {
-    .p-navigation__link::after {
-      left: 1rem;
-      transform: rotate(90deg);
-    }
-    @media (min-width: $breakpoint-navigation-threshold) {
-      display: none;
-    }
-  }
-
   .p-navigation--sliding .p-navigation__item--dropdown-toggle {
     position: initial;
 
@@ -917,6 +907,16 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
       @media (min-width: $breakpoint-navigation-threshold) {
         transform: rotate(180deg);
       }
+    }
+  }
+
+  .p-navigation--sliding .p-navigation__item--dropdown-close {
+    .p-navigation__link::after {
+      left: 1rem;
+      transform: rotate(90deg);
+    }
+    @media (min-width: $breakpoint-navigation-threshold) {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
## Done

- Fixes a suspected regression in the navigation pattern that causes the "back" button in smaller breakpoints to point right instead of left.

Fixes #5059 

## QA

- Open [demo](insert-demo-url)
- Reduce screen size to the medium breakpoint such that the mobile version of the nav appears.
- Tap `Menu`
- Select any sub-menu (such as LXD). Verify that its chevron to open the nested navigation is pointing to the right, indicating drilling into the navigation.
- Open the sub-menu.
- Verify that the back button is visible and its chevron points left.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

Before:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/682e281c-52c6-4549-853c-af1a5780ba77)

After:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/af91ffae-45e3-4697-ba60-e70c577c4a9f)

## Cause
The pseudoelement for the close button needs to have a `transform:rotate(90deg)` applied to point left. However, it was being overridden by the base style for `p-navigation__link::after`, which was moved to further down in the `_patterns_navigation.scss` by [this commit](https://github.com/canonical/vanilla-framework/commit/46b46888caec20d6d5df29923bf9832c1de73385), causing the button to be rotated to the right (`transform: rotate(-90deg)`) instead of the left.