### PR TITLE
Update empty state 404 documentation example to match new branding

### DIFF
--- a/scss/standalone/patterns_empty-state.scss
+++ b/scss/standalone/patterns_empty-state.scss
@@ -16,9 +16,6 @@
 @include vf-p-icon-search;
 @include vf-u-layout;
 
-// dependencies for user action triggered empty state example
-@include vf-u-vertically-center;
-
 // Dependencies for error management empty state example
 @include vf-u-hide;
 @include vf-p-section;

--- a/scss/standalone/patterns_empty-state.scss
+++ b/scss/standalone/patterns_empty-state.scss
@@ -20,5 +20,5 @@
 @include vf-u-vertically-center;
 
 // Dependencies for error management empty state example
-@include vf-p-rule;
 @include vf-u-hide;
+@include vf-p-section;

--- a/scss/standalone/patterns_empty-state.scss
+++ b/scss/standalone/patterns_empty-state.scss
@@ -18,3 +18,7 @@
 
 // dependencies for user action triggered empty state example
 @include vf-u-vertically-center;
+
+// Dependencies for 404 / error management empty state example
+@include vf-p-rule;
+@include vf-u-hide;

--- a/scss/standalone/patterns_empty-state.scss
+++ b/scss/standalone/patterns_empty-state.scss
@@ -19,6 +19,6 @@
 // dependencies for user action triggered empty state example
 @include vf-u-vertically-center;
 
-// Dependencies for 404 / error management empty state example
+// Dependencies for error management empty state example
 @include vf-p-rule;
 @include vf-u-hide;

--- a/templates/docs/examples/patterns/empty-state/error-management.html
+++ b/templates/docs/examples/patterns/empty-state/error-management.html
@@ -5,16 +5,19 @@
 
 {% block content %}
 <section class="p-strip">
-  <div class="row">
-    <div class="col-6 col-medium-3 u-vertically-center u-align--center">
-      <img src="https://assets.ubuntu.com/v1/03c7318e-image-404.svg" alt="Page not found" width="360" height="365">
+    <div class="row">
+        <hr class="p-rule">
+        <div class="col-3 col-medium-2 col-medium-3 u-hide--small">
+            <p class="p-heading--1">404</p>
+        </div>
+        <div class="col-9 col-medium-4">
+            <h1><span class="u-hide--medium u-hide--large">404: </span>Page not found</h1>
+            <p class="p-heading--2">
+                We can't find the page you're looking for.
+            </p>
+        </div>
     </div>
-    <div class="col-6 col-medium-3 u-vertically-center">
-      <div>
-        <h1>404: Page not found</h1>
-        <p class="p-heading--4">Sorry, we couldn’t find that page.</p>
-      </div>
-    </div>
-  </div>
 </section>
 {% endblock %}
+
+

--- a/templates/docs/examples/patterns/empty-state/error-management.html
+++ b/templates/docs/examples/patterns/empty-state/error-management.html
@@ -5,12 +5,12 @@
 
 {% block content %}
 <section class="p-strip">
-  <div class="row">
+  <div class="row--25-75">
     <hr class="p-rule">
-    <div class="col-3 col-medium-2 col-medium-3 u-hide--small">
+    <div class="col u-hide--small">
       <p class="p-heading--1">404</p>
     </div>
-    <div class="col-9 col-medium-4">
+    <div class="col">
       <h1><span class="u-hide--medium u-hide--large">404: </span>Page not found</h1>
       <p class="p-heading--2">
         We can't find the page you're looking for.

--- a/templates/docs/examples/patterns/empty-state/error-management.html
+++ b/templates/docs/examples/patterns/empty-state/error-management.html
@@ -4,9 +4,8 @@
 {% block standalone_css %}patterns_empty-state{% endblock %}
 
 {% block content %}
-<section class="p-strip">
+<section class="p-section--hero">
   <div class="row--25-75">
-    <hr class="p-rule">
     <div class="col u-hide--small">
       <p class="p-heading--1">404</p>
     </div>

--- a/templates/docs/examples/patterns/empty-state/error-management.html
+++ b/templates/docs/examples/patterns/empty-state/error-management.html
@@ -5,18 +5,18 @@
 
 {% block content %}
 <section class="p-strip">
-    <div class="row">
-        <hr class="p-rule">
-        <div class="col-3 col-medium-2 col-medium-3 u-hide--small">
-            <p class="p-heading--1">404</p>
-        </div>
-        <div class="col-9 col-medium-4">
-            <h1><span class="u-hide--medium u-hide--large">404: </span>Page not found</h1>
-            <p class="p-heading--2">
-                We can't find the page you're looking for.
-            </p>
-        </div>
+  <div class="row">
+    <hr class="p-rule">
+    <div class="col-3 col-medium-2 col-medium-3 u-hide--small">
+      <p class="p-heading--1">404</p>
     </div>
+    <div class="col-9 col-medium-4">
+      <h1><span class="u-hide--medium u-hide--large">404: </span>Page not found</h1>
+      <p class="p-heading--2">
+        We can't find the page you're looking for.
+      </p>
+    </div>
+  </div>
 </section>
 {% endblock %}
 

--- a/templates/docs/patterns/empty-state.md
+++ b/templates/docs/patterns/empty-state.md
@@ -60,8 +60,8 @@ To import either or all of these components into your project, copy the snippets
 @include vf-u-vertically-center;
 
 // Dependencies for error management empty state example
-@include vf-p-rule;
 @include vf-u-hide;
+@include vf-p-section;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.

--- a/templates/docs/patterns/empty-state.md
+++ b/templates/docs/patterns/empty-state.md
@@ -42,7 +42,8 @@ To import either or all of these components into your project, copy the snippets
 @import 'vanilla-framework';
 @include vf-base;
 
-// dependencies for the no content empty state example
+// dependencies for no content empty state example
+@include vf-p-headings;
 @include vf-p-grid;
 @include vf-u-align;
 @include vf-p-buttons;
@@ -55,9 +56,6 @@ To import either or all of these components into your project, copy the snippets
 @include vf-p-icons-common;
 @include vf-p-icon-search;
 @include vf-u-layout;
-
-// dependencies for user action triggered empty state example
-@include vf-u-vertically-center;
 
 // Dependencies for error management empty state example
 @include vf-u-hide;

--- a/templates/docs/patterns/empty-state.md
+++ b/templates/docs/patterns/empty-state.md
@@ -58,6 +58,10 @@ To import either or all of these components into your project, copy the snippets
 
 // dependencies for user action triggered empty state example
 @include vf-u-vertically-center;
+
+// Dependencies for error management empty state example
+@include vf-p-rule;
+@include vf-u-hide;
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.


### PR DESCRIPTION
## Done

Updates the empty state error management pattern to match the updated branding / copy seen on [c.com](https://canonical.com/404_example).

Fixes [WD-7904](https://warthogs.atlassian.net/browse/WD-7904)

## QA

- Open [demo](https://vanilla-framework-5079.demos.haus/docs/examples/patterns/empty-state/error-management)
- Open [c.com 404](https://canonical.com/404_example)
- Verify that the branding / copy matches between the error management empty state example and the c.com 404 page.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![image](https://github.com/canonical/vanilla-framework/assets/46915153/49594fc5-51d9-460d-ab7e-a31056f4811f)



[WD-7904]: https://warthogs.atlassian.net/browse/WD-7904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ