### PR TITLE
Alphabetize documentation sidenav elements

### DIFF
--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -1,207 +1,207 @@
 - heading: Welcome
   subheadings:
     items:
-    - title: Get started
-      url: /docs
-    - title: Building with Vanilla
-      url: /docs/building-vanilla
-    - title: Customising Vanilla
-      url: /docs/customising-vanilla
-    - title: What's new in {version}
-      url: /docs/whats-new
-    - title: Migrating to v4
-      url: /docs/migration-guide-to-v4
+      - title: Get started
+        url: /docs
+      - title: Building with Vanilla
+        url: /docs/building-vanilla
+      - title: Customising Vanilla
+        url: /docs/customising-vanilla
+      - title: What's new in {version}
+        url: /docs/whats-new
+      - title: Migrating to v4
+        url: /docs/migration-guide-to-v4
 - heading: Base elements
   subheadings:
     ordering: alphabetical
     items:
-    - title: Code
-      url: /docs/base/code
-    - title: Forms
-      url: /docs/base/forms
-    - title: Reset
-      url: /docs/base/reset
-    - title: Separators
-      url: /docs/base/separators
-    - title: Tables
-      url: /docs/base/tables
-    - title: Typography
-      url: /docs/base/typography
-    - title: Paper background
-      url: /docs/base/paper
+      - title: Code
+        url: /docs/base/code
+      - title: Forms
+        url: /docs/base/forms
+      - title: Reset
+        url: /docs/base/reset
+      - title: Separators
+        url: /docs/base/separators
+      - title: Tables
+        url: /docs/base/tables
+      - title: Typography
+        url: /docs/base/typography
+      - title: Paper background
+        url: /docs/base/paper
 - heading: Components
   subheadings:
     ordering: alphabetical
     items:
-    - title: Accordion
-      url: /docs/patterns/accordion
-    - title: Equal height row
-      url: /docs/patterns/equal-height-row
-    - title: Badge
-      url: /docs/patterns/badge
-    - title: Breadcrumbs
-      url: /docs/patterns/breadcrumbs
-    - title: Buttons
-      url: /docs/patterns/buttons
-    - title: Cards
-      url: /docs/patterns/card
-    - title: Chips
-      url: /docs/patterns/chip
-    - title: Contextual menu
-      url: /docs/patterns/contextual-menu
-    - title: Divider
-      url: /docs/patterns/divider
-    - title: Empty state
-      url: /docs/patterns/empty-state
-    - title: Grid
-      url: /docs/patterns/grid
-    - title: Heading icon
-      url: /docs/patterns/heading-icon
-    - title: Icons
-      url: /docs/patterns/icons
-    - title: Images
-      url: /docs/patterns/images
-    - title: Links
-      url: /docs/patterns/links
-    - title: List tree
-      url: /docs/patterns/list-tree
-    - title: Lists
-      url: /docs/patterns/lists
-    - title: Logo section
-      url: /docs/patterns/logo-section
-    - title: Matrix
-      url: /docs/patterns/matrix
-    - title: Media object
-      url: /docs/patterns/media-object
-    - title: Modal
-      url: /docs/patterns/modal
-    - title: Muted heading
-      url: /docs/patterns/muted-heading
-    - title: Navigation
-      url: /docs/patterns/navigation
-    - title: Notifications
-      url: /docs/patterns/notification
-    - title: Pagination
-      url: /docs/patterns/pagination
-    - title: Quotes
-      url: /docs/patterns/pull-quote
-    - title: Rule
-      url: /docs/patterns/rule
-    - title: Search and filter
-      url: /docs/patterns/search-and-filter
-    - title: Search box
-      url: /docs/patterns/search-box
-    - title: Sections
-      url: /docs/patterns/section
-    - title: Segmented control
-      url: /docs/patterns/segmented-control
-    - title: Slider
-      url: /docs/patterns/slider
-    - title: Status labels
-      url: /docs/patterns/status-labels
-    - title: Strip
-      url: /docs/patterns/strip
-    - title: Suru
-      url: /docs/patterns/suru
-    - title: Switch
-      url: /docs/patterns/switch
-    - title: Table of contents
-      url: /docs/patterns/table-of-contents
-    - title: Tabs
-      url: /docs/patterns/tabs
-    - title: Tooltips
-      url: /docs/patterns/tooltips
+      - title: Accordion
+        url: /docs/patterns/accordion
+      - title: Equal height row
+        url: /docs/patterns/equal-height-row
+      - title: Badge
+        url: /docs/patterns/badge
+      - title: Breadcrumbs
+        url: /docs/patterns/breadcrumbs
+      - title: Buttons
+        url: /docs/patterns/buttons
+      - title: Cards
+        url: /docs/patterns/card
+      - title: Chips
+        url: /docs/patterns/chip
+      - title: Contextual menu
+        url: /docs/patterns/contextual-menu
+      - title: Divider
+        url: /docs/patterns/divider
+      - title: Empty state
+        url: /docs/patterns/empty-state
+      - title: Grid
+        url: /docs/patterns/grid
+      - title: Heading icon
+        url: /docs/patterns/heading-icon
+      - title: Icons
+        url: /docs/patterns/icons
+      - title: Images
+        url: /docs/patterns/images
+      - title: Links
+        url: /docs/patterns/links
+      - title: List tree
+        url: /docs/patterns/list-tree
+      - title: Lists
+        url: /docs/patterns/lists
+      - title: Logo section
+        url: /docs/patterns/logo-section
+      - title: Matrix
+        url: /docs/patterns/matrix
+      - title: Media object
+        url: /docs/patterns/media-object
+      - title: Modal
+        url: /docs/patterns/modal
+      - title: Muted heading
+        url: /docs/patterns/muted-heading
+      - title: Navigation
+        url: /docs/patterns/navigation
+      - title: Notifications
+        url: /docs/patterns/notification
+      - title: Pagination
+        url: /docs/patterns/pagination
+      - title: Quotes
+        url: /docs/patterns/pull-quote
+      - title: Rule
+        url: /docs/patterns/rule
+      - title: Search and filter
+        url: /docs/patterns/search-and-filter
+      - title: Search box
+        url: /docs/patterns/search-box
+      - title: Sections
+        url: /docs/patterns/section
+      - title: Segmented control
+        url: /docs/patterns/segmented-control
+      - title: Slider
+        url: /docs/patterns/slider
+      - title: Status labels
+        url: /docs/patterns/status-labels
+      - title: Strip
+        url: /docs/patterns/strip
+      - title: Suru
+        url: /docs/patterns/suru
+      - title: Switch
+        url: /docs/patterns/switch
+      - title: Table of contents
+        url: /docs/patterns/table-of-contents
+      - title: Tabs
+        url: /docs/patterns/tabs
+      - title: Tooltips
+        url: /docs/patterns/tooltips
 - heading: Utilities
   subheadings:
     ordering: alphabetical
     items:
-    - title: Align
-      url: /docs/utilities/align
-    - title: Baseline grid
-      url: /docs/utilities/baseline-grid
-    - title: Clearfix
-      url: /docs/utilities/clearfix
-    - title: Embedded media
-      url: /docs/utilities/embedded-media
-    - title: Equal height
-      url: /docs/utilities/equal-height
-    - title: Floats
-      url: /docs/utilities/floats
-    - title: Font metrics
-      url: /docs/utilities/font-metrics
-    - title: Functions
-      url: /docs/utilities/functions
-    - title: Hide
-      url: /docs/utilities/hide
-    - title: Image position
-      url: /docs/utilities/image-position
-    - title: Margin collapse
-      url: /docs/utilities/margin-collapse
-    - title: No print
-      url: /docs/utilities/no-print
-    - title: Off-screen
-      url: /docs/utilities/off-screen
-    - title: Padding collapse
-      url: /docs/utilities/padding-collapse
-    - title: Table cell padding overlap
-      url: /docs/utilities/table-cell-padding-overlap
-    - title: Text max width
-      url: /docs/utilities/text-max-width
-    - title: Text with icon
-      url: /docs/utilities/has-icon
-    - title: Truncation
-      url: /docs/utilities/truncate
-    - title: Show
-      url: /docs/utilities/show
-    - title: Vertical spacing
-      url: /docs/utilities/vertical-spacing
-    - title: Vertically center
-      url: /docs/utilities/vertically-center
+      - title: Align
+        url: /docs/utilities/align
+      - title: Baseline grid
+        url: /docs/utilities/baseline-grid
+      - title: Clearfix
+        url: /docs/utilities/clearfix
+      - title: Embedded media
+        url: /docs/utilities/embedded-media
+      - title: Equal height
+        url: /docs/utilities/equal-height
+      - title: Floats
+        url: /docs/utilities/floats
+      - title: Font metrics
+        url: /docs/utilities/font-metrics
+      - title: Functions
+        url: /docs/utilities/functions
+      - title: Hide
+        url: /docs/utilities/hide
+      - title: Image position
+        url: /docs/utilities/image-position
+      - title: Margin collapse
+        url: /docs/utilities/margin-collapse
+      - title: No print
+        url: /docs/utilities/no-print
+      - title: Off-screen
+        url: /docs/utilities/off-screen
+      - title: Padding collapse
+        url: /docs/utilities/padding-collapse
+      - title: Table cell padding overlap
+        url: /docs/utilities/table-cell-padding-overlap
+      - title: Text max width
+        url: /docs/utilities/text-max-width
+      - title: Text with icon
+        url: /docs/utilities/has-icon
+      - title: Truncation
+        url: /docs/utilities/truncate
+      - title: Show
+        url: /docs/utilities/show
+      - title: Vertical spacing
+        url: /docs/utilities/vertical-spacing
+      - title: Vertically center
+        url: /docs/utilities/vertically-center
 - heading: Layouts
   subheadings:
     ordering: alphabetical
     items:
-    - title: Application
-      url: /docs/layouts/application
-    - title: Brochure site
-      url: /docs/layouts/brochure
-    - title: Documentation
-      url: /docs/layouts/documentation
-    - title: Fluid breakout
-      url: /docs/layouts/fluid-breakout
-    - title: Full-width
-      url: /docs/layouts/full-width
-    - title: Sticky footer
-      url: /docs/layouts/sticky-footer
+      - title: Application
+        url: /docs/layouts/application
+      - title: Brochure site
+        url: /docs/layouts/brochure
+      - title: Documentation
+        url: /docs/layouts/documentation
+      - title: Fluid breakout
+        url: /docs/layouts/fluid-breakout
+      - title: Full-width
+        url: /docs/layouts/full-width
+      - title: Sticky footer
+        url: /docs/layouts/sticky-footer
 - heading: Settings
   subheadings:
     ordering: alphabetical
     items:
-    - title: Animations
-      url: /docs/settings/animation-settings
-    - title: Assets
-      url: /docs/settings/assets-settings
-    - title: Breakpoints
-      url: /docs/settings/breakpoint-settings
-    - title: Color
-      url: /docs/settings/color-settings
-    - title: Font
-      url: /docs/settings/font-settings
-    - title: Layout
-      url: /docs/settings/layout-settings
-    - title: Placeholders
-      url: /docs/settings/placeholder-settings
-    - title: Spacing
-      url: /docs/settings/spacing-settings
-    - title: Table layout
-      url: /docs/settings/table-layout
+      - title: Animations
+        url: /docs/settings/animation-settings
+      - title: Assets
+        url: /docs/settings/assets-settings
+      - title: Breakpoints
+        url: /docs/settings/breakpoint-settings
+      - title: Color
+        url: /docs/settings/color-settings
+      - title: Font
+        url: /docs/settings/font-settings
+      - title: Layout
+        url: /docs/settings/layout-settings
+      - title: Placeholders
+        url: /docs/settings/placeholder-settings
+      - title: Spacing
+        url: /docs/settings/spacing-settings
+      - title: Table layout
+        url: /docs/settings/table-layout
 - heading: Resources
   subheadings:
     ordering: alphabetical
     items:
-    - title: Component examples
-      url: /docs/examples
-    - title: Release notes for {version}
-      url: https://github.com/canonical/vanilla-framework/releases/latest
-    - title: Download Sketch UI Kit
-      url: https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch
+      - title: Component examples
+        url: /docs/examples
+      - title: Release notes for {version}
+        url: https://github.com/canonical/vanilla-framework/releases/latest
+      - title: Download Sketch UI Kit
+        url: https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch

--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -1,207 +1,201 @@
 - heading: Welcome
   subheadings:
-    items:
-      - title: Get started
-        url: /docs
-      - title: Building with Vanilla
-        url: /docs/building-vanilla
-      - title: Customising Vanilla
-        url: /docs/customising-vanilla
-      - title: What's new in {version}
-        url: /docs/whats-new
-      - title: Migrating to v4
-        url: /docs/migration-guide-to-v4
+    - title: Get started
+      url: /docs
+    - title: Building with Vanilla
+      url: /docs/building-vanilla
+    - title: Customising Vanilla
+      url: /docs/customising-vanilla
+    - title: What's new in {version}
+      url: /docs/whats-new
+    - title: Migrating to v4
+      url: /docs/migration-guide-to-v4
 - heading: Base elements
+  ordering: alphabetical
   subheadings:
-    ordering: alphabetical
-    items:
-      - title: Code
-        url: /docs/base/code
-      - title: Forms
-        url: /docs/base/forms
-      - title: Reset
-        url: /docs/base/reset
-      - title: Separators
-        url: /docs/base/separators
-      - title: Tables
-        url: /docs/base/tables
-      - title: Typography
-        url: /docs/base/typography
-      - title: Paper background
-        url: /docs/base/paper
+    - title: Code
+      url: /docs/base/code
+    - title: Forms
+      url: /docs/base/forms
+    - title: Reset
+      url: /docs/base/reset
+    - title: Separators
+      url: /docs/base/separators
+    - title: Tables
+      url: /docs/base/tables
+    - title: Typography
+      url: /docs/base/typography
+    - title: Paper background
+      url: /docs/base/paper
+
 - heading: Components
+  ordering: alphabetical
   subheadings:
-    ordering: alphabetical
-    items:
-      - title: Accordion
-        url: /docs/patterns/accordion
-      - title: Equal height row
-        url: /docs/patterns/equal-height-row
-      - title: Badge
-        url: /docs/patterns/badge
-      - title: Breadcrumbs
-        url: /docs/patterns/breadcrumbs
-      - title: Buttons
-        url: /docs/patterns/buttons
-      - title: Cards
-        url: /docs/patterns/card
-      - title: Chips
-        url: /docs/patterns/chip
-      - title: Contextual menu
-        url: /docs/patterns/contextual-menu
-      - title: Divider
-        url: /docs/patterns/divider
-      - title: Empty state
-        url: /docs/patterns/empty-state
-      - title: Grid
-        url: /docs/patterns/grid
-      - title: Heading icon
-        url: /docs/patterns/heading-icon
-      - title: Icons
-        url: /docs/patterns/icons
-      - title: Images
-        url: /docs/patterns/images
-      - title: Links
-        url: /docs/patterns/links
-      - title: List tree
-        url: /docs/patterns/list-tree
-      - title: Lists
-        url: /docs/patterns/lists
-      - title: Logo section
-        url: /docs/patterns/logo-section
-      - title: Matrix
-        url: /docs/patterns/matrix
-      - title: Media object
-        url: /docs/patterns/media-object
-      - title: Modal
-        url: /docs/patterns/modal
-      - title: Muted heading
-        url: /docs/patterns/muted-heading
-      - title: Navigation
-        url: /docs/patterns/navigation
-      - title: Notifications
-        url: /docs/patterns/notification
-      - title: Pagination
-        url: /docs/patterns/pagination
-      - title: Quotes
-        url: /docs/patterns/pull-quote
-      - title: Rule
-        url: /docs/patterns/rule
-      - title: Search and filter
-        url: /docs/patterns/search-and-filter
-      - title: Search box
-        url: /docs/patterns/search-box
-      - title: Sections
-        url: /docs/patterns/section
-      - title: Segmented control
-        url: /docs/patterns/segmented-control
-      - title: Slider
-        url: /docs/patterns/slider
-      - title: Status labels
-        url: /docs/patterns/status-labels
-      - title: Strip
-        url: /docs/patterns/strip
-      - title: Suru
-        url: /docs/patterns/suru
-      - title: Switch
-        url: /docs/patterns/switch
-      - title: Table of contents
-        url: /docs/patterns/table-of-contents
-      - title: Tabs
-        url: /docs/patterns/tabs
-      - title: Tooltips
-        url: /docs/patterns/tooltips
+    - title: Accordion
+      url: /docs/patterns/accordion
+    - title: Equal height row
+      url: /docs/patterns/equal-height-row
+    - title: Badge
+      url: /docs/patterns/badge
+    - title: Breadcrumbs
+      url: /docs/patterns/breadcrumbs
+    - title: Buttons
+      url: /docs/patterns/buttons
+    - title: Cards
+      url: /docs/patterns/card
+    - title: Chips
+      url: /docs/patterns/chip
+    - title: Contextual menu
+      url: /docs/patterns/contextual-menu
+    - title: Divider
+      url: /docs/patterns/divider
+    - title: Empty state
+      url: /docs/patterns/empty-state
+    - title: Grid
+      url: /docs/patterns/grid
+    - title: Heading icon
+      url: /docs/patterns/heading-icon
+    - title: Icons
+      url: /docs/patterns/icons
+    - title: Images
+      url: /docs/patterns/images
+    - title: Links
+      url: /docs/patterns/links
+    - title: List tree
+      url: /docs/patterns/list-tree
+    - title: Lists
+      url: /docs/patterns/lists
+    - title: Logo section
+      url: /docs/patterns/logo-section
+    - title: Matrix
+      url: /docs/patterns/matrix
+    - title: Media object
+      url: /docs/patterns/media-object
+    - title: Modal
+      url: /docs/patterns/modal
+    - title: Muted heading
+      url: /docs/patterns/muted-heading
+    - title: Navigation
+      url: /docs/patterns/navigation
+    - title: Notifications
+      url: /docs/patterns/notification
+    - title: Pagination
+      url: /docs/patterns/pagination
+    - title: Quotes
+      url: /docs/patterns/pull-quote
+    - title: Rule
+      url: /docs/patterns/rule
+    - title: Search and filter
+      url: /docs/patterns/search-and-filter
+    - title: Search box
+      url: /docs/patterns/search-box
+    - title: Sections
+      url: /docs/patterns/section
+    - title: Segmented control
+      url: /docs/patterns/segmented-control
+    - title: Slider
+      url: /docs/patterns/slider
+    - title: Status labels
+      url: /docs/patterns/status-labels
+    - title: Strip
+      url: /docs/patterns/strip
+    - title: Suru
+      url: /docs/patterns/suru
+    - title: Switch
+      url: /docs/patterns/switch
+    - title: Table of contents
+      url: /docs/patterns/table-of-contents
+    - title: Tabs
+      url: /docs/patterns/tabs
+    - title: Tooltips
+      url: /docs/patterns/tooltips
 - heading: Utilities
+  ordering: alphabetical
   subheadings:
-    ordering: alphabetical
-    items:
-      - title: Align
-        url: /docs/utilities/align
-      - title: Baseline grid
-        url: /docs/utilities/baseline-grid
-      - title: Clearfix
-        url: /docs/utilities/clearfix
-      - title: Embedded media
-        url: /docs/utilities/embedded-media
-      - title: Equal height
-        url: /docs/utilities/equal-height
-      - title: Floats
-        url: /docs/utilities/floats
-      - title: Font metrics
-        url: /docs/utilities/font-metrics
-      - title: Functions
-        url: /docs/utilities/functions
-      - title: Hide
-        url: /docs/utilities/hide
-      - title: Image position
-        url: /docs/utilities/image-position
-      - title: Margin collapse
-        url: /docs/utilities/margin-collapse
-      - title: No print
-        url: /docs/utilities/no-print
-      - title: Off-screen
-        url: /docs/utilities/off-screen
-      - title: Padding collapse
-        url: /docs/utilities/padding-collapse
-      - title: Table cell padding overlap
-        url: /docs/utilities/table-cell-padding-overlap
-      - title: Text max width
-        url: /docs/utilities/text-max-width
-      - title: Text with icon
-        url: /docs/utilities/has-icon
-      - title: Truncation
-        url: /docs/utilities/truncate
-      - title: Show
-        url: /docs/utilities/show
-      - title: Vertical spacing
-        url: /docs/utilities/vertical-spacing
-      - title: Vertically center
-        url: /docs/utilities/vertically-center
+    - title: Align
+      url: /docs/utilities/align
+    - title: Baseline grid
+      url: /docs/utilities/baseline-grid
+    - title: Clearfix
+      url: /docs/utilities/clearfix
+    - title: Embedded media
+      url: /docs/utilities/embedded-media
+    - title: Equal height
+      url: /docs/utilities/equal-height
+    - title: Floats
+      url: /docs/utilities/floats
+    - title: Font metrics
+      url: /docs/utilities/font-metrics
+    - title: Functions
+      url: /docs/utilities/functions
+    - title: Hide
+      url: /docs/utilities/hide
+    - title: Image position
+      url: /docs/utilities/image-position
+    - title: Margin collapse
+      url: /docs/utilities/margin-collapse
+    - title: No print
+      url: /docs/utilities/no-print
+    - title: Off-screen
+      url: /docs/utilities/off-screen
+    - title: Padding collapse
+      url: /docs/utilities/padding-collapse
+    - title: Table cell padding overlap
+      url: /docs/utilities/table-cell-padding-overlap
+    - title: Text max width
+      url: /docs/utilities/text-max-width
+    - title: Text with icon
+      url: /docs/utilities/has-icon
+    - title: Truncation
+      url: /docs/utilities/truncate
+    - title: Show
+      url: /docs/utilities/show
+    - title: Vertical spacing
+      url: /docs/utilities/vertical-spacing
+    - title: Vertically center
+      url: /docs/utilities/vertically-center
 - heading: Layouts
+  ordering: alphabetical
   subheadings:
-    ordering: alphabetical
-    items:
-      - title: Application
-        url: /docs/layouts/application
-      - title: Brochure site
-        url: /docs/layouts/brochure
-      - title: Documentation
-        url: /docs/layouts/documentation
-      - title: Fluid breakout
-        url: /docs/layouts/fluid-breakout
-      - title: Full-width
-        url: /docs/layouts/full-width
-      - title: Sticky footer
-        url: /docs/layouts/sticky-footer
+    - title: Application
+      url: /docs/layouts/application
+    - title: Brochure site
+      url: /docs/layouts/brochure
+    - title: Documentation
+      url: /docs/layouts/documentation
+    - title: Fluid breakout
+      url: /docs/layouts/fluid-breakout
+    - title: Full-width
+      url: /docs/layouts/full-width
+    - title: Sticky footer
+      url: /docs/layouts/sticky-footer
 - heading: Settings
+  ordering: alphabetical
   subheadings:
-    ordering: alphabetical
-    items:
-      - title: Animations
-        url: /docs/settings/animation-settings
-      - title: Assets
-        url: /docs/settings/assets-settings
-      - title: Breakpoints
-        url: /docs/settings/breakpoint-settings
-      - title: Color
-        url: /docs/settings/color-settings
-      - title: Font
-        url: /docs/settings/font-settings
-      - title: Layout
-        url: /docs/settings/layout-settings
-      - title: Placeholders
-        url: /docs/settings/placeholder-settings
-      - title: Spacing
-        url: /docs/settings/spacing-settings
-      - title: Table layout
-        url: /docs/settings/table-layout
+    - title: Animations
+      url: /docs/settings/animation-settings
+    - title: Assets
+      url: /docs/settings/assets-settings
+    - title: Breakpoints
+      url: /docs/settings/breakpoint-settings
+    - title: Color
+      url: /docs/settings/color-settings
+    - title: Font
+      url: /docs/settings/font-settings
+    - title: Layout
+      url: /docs/settings/layout-settings
+    - title: Placeholders
+      url: /docs/settings/placeholder-settings
+    - title: Spacing
+      url: /docs/settings/spacing-settings
+    - title: Table layout
+      url: /docs/settings/table-layout
 - heading: Resources
+  ordering: alphabetical
   subheadings:
-    ordering: alphabetical
-    items:
-      - title: Component examples
-        url: /docs/examples
-      - title: Release notes for {version}
-        url: https://github.com/canonical/vanilla-framework/releases/latest
-      - title: Download Sketch UI Kit
-        url: https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch
+    - title: Component examples
+      url: /docs/examples
+    - title: Release notes for {version}
+      url: https://github.com/canonical/vanilla-framework/releases/latest
+    - title: Download Sketch UI Kit
+      url: https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch

--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -16,6 +16,8 @@
       url: /docs/base/code
     - title: Forms
       url: /docs/base/forms
+    - title: Paper background
+      url: /docs/base/paper
     - title: Reset
       url: /docs/base/reset
     - title: Separators
@@ -24,14 +26,10 @@
       url: /docs/base/tables
     - title: Typography
       url: /docs/base/typography
-    - title: Paper background
-      url: /docs/base/paper
 - heading: Components
   subheadings:
     - title: Accordion
       url: /docs/patterns/accordion
-    - title: Equal height row
-      url: /docs/patterns/equal-height-row
     - title: Badge
       url: /docs/patterns/badge
     - title: Breadcrumbs
@@ -48,6 +46,8 @@
       url: /docs/patterns/divider
     - title: Empty state
       url: /docs/patterns/empty-state
+    - title: Equal height row
+      url: /docs/patterns/equal-height-row
     - title: Grid
       url: /docs/patterns/grid
     - title: Heading icon
@@ -188,7 +188,7 @@
   subheadings:
     - title: Component examples
       url: /docs/examples
-    - title: Release notes for {version}
-      url: https://github.com/canonical/vanilla-framework/releases/latest
     - title: Download Sketch UI Kit
       url: https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch
+    - title: Release notes for {version}
+      url: https://github.com/canonical/vanilla-framework/releases/latest

--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -1,5 +1,6 @@
 - heading: Welcome
   subheadings:
+    items:
     - title: Get started
       url: /docs
     - title: Building with Vanilla
@@ -12,12 +13,12 @@
       url: /docs/migration-guide-to-v4
 - heading: Base elements
   subheadings:
+    ordering: alphabetical
+    items:
     - title: Code
       url: /docs/base/code
     - title: Forms
       url: /docs/base/forms
-    - title: Paper background
-      url: /docs/base/paper
     - title: Reset
       url: /docs/base/reset
     - title: Separators
@@ -26,10 +27,16 @@
       url: /docs/base/tables
     - title: Typography
       url: /docs/base/typography
+    - title: Paper background
+      url: /docs/base/paper
 - heading: Components
   subheadings:
+    ordering: alphabetical
+    items:
     - title: Accordion
       url: /docs/patterns/accordion
+    - title: Equal height row
+      url: /docs/patterns/equal-height-row
     - title: Badge
       url: /docs/patterns/badge
     - title: Breadcrumbs
@@ -46,8 +53,6 @@
       url: /docs/patterns/divider
     - title: Empty state
       url: /docs/patterns/empty-state
-    - title: Equal height row
-      url: /docs/patterns/equal-height-row
     - title: Grid
       url: /docs/patterns/grid
     - title: Heading icon
@@ -108,6 +113,8 @@
       url: /docs/patterns/tooltips
 - heading: Utilities
   subheadings:
+    ordering: alphabetical
+    items:
     - title: Align
       url: /docs/utilities/align
     - title: Baseline grid
@@ -152,6 +159,8 @@
       url: /docs/utilities/vertically-center
 - heading: Layouts
   subheadings:
+    ordering: alphabetical
+    items:
     - title: Application
       url: /docs/layouts/application
     - title: Brochure site
@@ -166,6 +175,8 @@
       url: /docs/layouts/sticky-footer
 - heading: Settings
   subheadings:
+    ordering: alphabetical
+    items:
     - title: Animations
       url: /docs/settings/animation-settings
     - title: Assets
@@ -186,9 +197,11 @@
       url: /docs/settings/table-layout
 - heading: Resources
   subheadings:
+    ordering: alphabetical
+    items:
     - title: Component examples
       url: /docs/examples
-    - title: Download Sketch UI Kit
-      url: https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch
     - title: Release notes for {version}
       url: https://github.com/canonical/vanilla-framework/releases/latest
+    - title: Download Sketch UI Kit
+      url: https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -65,7 +65,7 @@
                   <li class="p-side-navigation__item">
                     <button class="p-side-navigation__accordion-button" aria-expanded="false">{{ item.heading | replace("{version}", version) }}</button>
                     <ul class="p-side-navigation__list">
-                      {% for subheading in item.subheadings %}
+                      {% for subheading in item.subheadings['items'] %}
                       {{ side_nav_item(subheading.url, subheading.title) }}
                       {% endfor %}
                     </ul>

--- a/templates/_layouts/docs.html
+++ b/templates/_layouts/docs.html
@@ -65,7 +65,7 @@
                   <li class="p-side-navigation__item">
                     <button class="p-side-navigation__accordion-button" aria-expanded="false">{{ item.heading | replace("{version}", version) }}</button>
                     <ul class="p-side-navigation__list">
-                      {% for subheading in item.subheadings['items'] %}
+                      {% for subheading in item.subheadings %}
                       {{ side_nav_item(subheading.url, subheading.title) }}
                       {% endfor %}
                     </ul>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -61,13 +61,10 @@ with open("side-navigation.yaml") as side_navigation_file:
 
         subheadings["items"] = subheadings_ordering_fn(subheadings["items"], by_attribute)
 
-        for item in subheadings["items"]:
-            alphabetize_heading_items(item, by_attribute)
-
         return heading
 
     for heading in SIDE_NAVIGATION:
-        alphabetize_heading_items(heading)
+        heading = alphabetize_heading_items(heading)
 
 
 app = FlaskBase(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -53,13 +53,12 @@ with open("side-navigation.yaml") as side_navigation_file:
         subheadings_ordering_identifier = None
         subheadings_ordering_fn = None
         try:
-            subheadings = heading["subheadings"]
-            subheadings_ordering_identifier = subheadings["ordering"]
+            subheadings_ordering_identifier = heading["ordering"]
             subheadings_ordering_fn = supported_orderings[subheadings_ordering_identifier]
         except KeyError:
             return heading
 
-        subheadings["items"] = subheadings_ordering_fn(subheadings["items"], by_attribute)
+        heading["subheadings"] = subheadings_ordering_fn(heading["subheadings"], by_attribute)
 
         return heading
 


### PR DESCRIPTION
## Done

@bartaz noticed today that the ordering of items in the side-nav is not alphabetical (as he was expecting it to be). This PR alphabetizes the sidenav items by title using Python, hopefully eliminating the tech debt of manually ensuring the nav items are alphabetized and preventing this sort of issue from arising in the future.

This is configurable in `side-navigation.yaml` so that only nav items with `ordering: alphabetical` have their subheadings sorted (since there are still some cases where we want fine-grain control over subheading order, such as "Welcome".

This results in a few changes to the sidenav ordering vs our current setup:

- Base elements
    - "Paper background" moved to the end
- Components
    - "Equal height row" moved to after "Empty state"
- Utilities
    - "Show" moved to after "Padding collapse"
- Resources
   - "Download Sketch UI Kit" moved to after "Component examples"

Closes [WD-11052](https://warthogs.atlassian.net/browse/WD-11052)

## QA

- Open [demo](https://vanilla-framework-5080.demos.haus/docs)
- Verify that the subheadings within all side-nav sections except "Welcome" are alphabetized.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


[WD-11052]: https://warthogs.atlassian.net/browse/WD-11052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ