### PR TITLE
Don't name hero a pattern

### DIFF
--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -52,7 +52,7 @@
       url: /docs/patterns/grid
     - title: Heading icon
       url: /docs/patterns/heading-icon
-    - title: Hero pattern
+    - title: Hero
       url: /docs/patterns/hero
     - title: Icons
       url: /docs/patterns/icons

--- a/templates/docs/patterns/hero.md
+++ b/templates/docs/patterns/hero.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/docs.html'
 context:
-  title: Hero pattern | Components
+  title: Hero | Components
 ---
 
 This article explains how to design and build hero sections on brochure sites:


### PR DESCRIPTION
## Done

Update Hero documentation by removing "pattern" from page title.

## QA

- Open [demo](https://vanilla-framework-5082.demos.haus/docs/patterns/hero)
- Make sure "Hero" is not called pattern in side nav or title
