### PR TITLE
Update accordion accessibility documentation

### DIFF
--- a/templates/docs/patterns/accordion/accessibility.md
+++ b/templates/docs/patterns/accordion/accessibility.md
@@ -6,7 +6,7 @@ context:
 
 ## How it works
 
-Accordions are a vertically stacked list of headings. They reduce the need for users to scroll through a lot of content, as the headings act as interactive elements which show or hide the related content.
+Accordions are a vertically stacked list of headings. They reduce scrolling with interactive headings that show or hide the related content.
 
 `Tab` and `Shift-Tab` are used to navigate forward and backward through each accordion header and all focusable elements in the accordion should be included in the tab order. `Enter` or `Space` expand and collapse each accordion panel.
 
@@ -17,9 +17,10 @@ The two main components are:
 
 ## Considerations
 
-This component strives to follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/), and care must be taken to ensure this effort is maintained when the component is implemented across other projects. This section offers advice to that effect:
+This component should follow [WCAG 2.1 (level AA) guidelines](https://www.w3.org/TR/WCAG21/). Make sure this effort is maintained when the component is implemented across other projects.
 
-- Accordion titles should be descriptive; it should be obvious what information the content will contain.
+- Accordion headings should clearly describe what is in that accordion section.
+- Don’t use an accordion if it hides important information the user needs to complete actions on the page.
 - Ensure each tab button element is wrapped by a `div` element with a `p-accordion__heading` class and the `role=heading` attribute. This heading should have an appropriate `aria-level` label, depending on its position in the hierarchy of the page.
 - If the accordion panel associated with the heading is visible, then the button within the heading div must have `aria-expanded=”true”`
 - The heading button should have an `aria-controls` attribute set to the ID of the related accordion panel.


### PR DESCRIPTION
## Done

Updates accessibility docs for accordions

Fixes [WD-5698](https://warthogs.atlassian.net/browse/WD-5698)

## QA

- Open [demo](https://vanilla-framework-5083.demos.haus/docs/patterns/accordion/accessibility)
- Open [copy doc](https://warthogs.atlassian.net/browse/WD-5698)
- Verify that accessiblity documentation matches copy doc

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![Screenshot 2024-05-07 at 10 45 24 AM](https://github.com/canonical/vanilla-framework/assets/46915153/30aa0ebe-1998-45e1-ba21-dda0eb06e2f9)



[WD-5698]: https://warthogs.atlassian.net/browse/WD-5698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ