### PR TITLE
Release drafter pulls tag number from package.json automatically

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,6 +16,6 @@ template: |
   Install with NPM: https://www.npmjs.com/package/vanilla-framework
   Visit the documentation at https://vanillaframework.io/docs
 
-  ## New in Vanilla v$NEXT_PATCH_VERSION
+  ## New in Vanilla v$INPUT_VERSION
 
   $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,3 @@
-name-template: 'v$NEXT_PATCH_VERSION'
-tag-template: 'v$NEXT_PATCH_VERSION'
 categories:
   - title: '🚀 Features'
     label: 'Feature 🎁'
@@ -18,6 +16,6 @@ template: |
   Install with NPM: https://www.npmjs.com/package/vanilla-framework
   Visit the documentation at https://vanillaframework.io/docs
 
-  ## New in Vanilla v$NEXT_PATCH_VERSION
+  ## New in Vanilla $version
 
   $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,9 +27,8 @@ jobs:
         with:
           # Setting tag and name override the name-template and tag-template.
           # See https://github.com/release-drafter/release-drafter?tab=readme-ov-file#action-inputs for more
-         tag: "v${{ steps.get_version.outputs.version_number }}"
-         name: "v${{ steps.get_version.outputs.version_number }}"
-         version: ${{ steps.get_version.outputs.version_number }}
+         tag: v${{ steps.get_version.outputs.version_number }}
+         name: v${{ steps.get_version.outputs.version_number }}
          commitish: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,12 +4,33 @@ on:
   push:
     branches:
       - main
+  # temporary to allow testing the release drafter action
+  pull_request:
+    branches:
+      - main
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          # Only need package.json as it is used by the get_version step to pass tag number into release-drafter
+          sparse-checkout: package.json
+
+      - name: Get version number from package.json
+        id: get_version
+        run: |
+          set -e
+          echo "::set-output name=version_number::$(jq -r '.version' package.json)"
+
       - name: Draft release notes
         uses: release-drafter/release-drafter@v6
+        with:
+          # Setting tag and name override the name-template and tag-template.
+          # See https://github.com/release-drafter/release-drafter?tab=readme-ov-file#action-inputs for more
+         tag: v${{ steps.get_version.outputs.version_number }}
+         name: v${{ steps.get_version.outputs.version_number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -29,7 +29,7 @@ jobs:
           # See https://github.com/release-drafter/release-drafter?tab=readme-ov-file#action-inputs for more
          tag: "v${{ steps.get_version.outputs.version_number }}"
          name: "v${{ steps.get_version.outputs.version_number }}"
-         version: "v${{ steps.get_version.outputs.version_number }}"
+         version: ${{ steps.get_version.outputs.version_number }}
          commitish: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Done

Release drafter reads the version number from `package.json` and automatically populates tag and release name.

Closes [WD-11112](https://warthogs.atlassian.net/browse/WD-11112)

## QA
Due to the release drafter action being run on pushes to `main`, I tested this in my fork to avoid unnecessarily cluttering our draft releases / `main` commit history.

- View the [release](https://github.com/jmuzina/vanilla-framework/releases/tag/v4.12.0) automatically created by [this workflow run](https://github.com/jmuzina/vanilla-framework/actions/runs/9003871537) (ran by [this action](https://github.com/jmuzina/vanilla-framework/blob/2cc11acf87fb8a851c0c02aeab03097ebb307829/.github/workflows/release-drafter.yml) with [this config](https://github.com/jmuzina/vanilla-framework/blob/2cc11acf87fb8a851c0c02aeab03097ebb307829/.github/release-drafter.yml))
- Verify that the version in my [package.json](https://github.com/jmuzina/vanilla-framework/blob/2cc11acf87fb8a851c0c02aeab03097ebb307829/package.json#L3) matches the version populated into the [release](https://github.com/jmuzina/vanilla-framework/releases/tag/v4.12.0)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


[WD-11112]: https://warthogs.atlassian.net/browse/WD-11112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ