### PR TITLE
Add text-wrap: pretty to _base_typography.scss

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.11.0",
+  "version": "4.12.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.12.0
+  features:
+    - component: Typography
+      url: /docs/base/typography
+      status: New
+      notes: "We've added the new text-wrap: pretty value to avoid text widows on all elements."
 - version: 4.11.0
   features:
     - component: Suru / Divider

--- a/releases.yml
+++ b/releases.yml
@@ -3,7 +3,7 @@
     - component: Typography
       url: /docs/base/typography
       status: New
-      notes: "We've added the new text-wrap: pretty value to avoid text widows on all elements."
+      notes: "We've added the new <code>text-wrap: pretty</code> value to avoid text widows on all elements."
 - version: 4.11.0
   features:
     - component: Suru / Divider

--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -16,6 +16,7 @@
     font-weight: $font-weight-regular-text;
     // set default line height to match p
     line-height: map-get($line-heights, default-text);
+    text-wrap: pretty;
 
     @if ($increase-font-size-on-larger-screens) {
       font-size: map-get($base-font-sizes, base);


### PR DESCRIPTION
## Done

- Added `text-wrap: pretty` to _base_typography.scss in order to prevent text widows on browsers that support the `pretty` value.

- Open [demo](https://vanilla-framework-5090.demos.haus/)
- QA: Examine text elements across documentation site and see that no text widows should exist

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [X] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [X] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [X] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

## Screenshots

See below comments for any edge case scenario screenshots.
