### PR TITLE
Update skiplink example docs to match new branding

### DIFF
--- a/templates/docs/examples/patterns/links/links-skip.html
+++ b/templates/docs/examples/patterns/links/links-skip.html
@@ -7,7 +7,7 @@
 <a href="#main" class="p-link--skip">Jump to main content</a>
 
 <header id="navigation" class="p-navigation is-dark">
-  <div class="p-navigation__row">
+  <div class="p-navigation__row--25-75">
     <div class="p-navigation__banner">
       <div class="p-navigation__tagged-logo">
         <a class="p-navigation__link" href="#">

--- a/templates/docs/examples/patterns/links/links-skip.html
+++ b/templates/docs/examples/patterns/links/links-skip.html
@@ -6,12 +6,15 @@
 {% block content %}
 <a href="#main" class="p-link--skip">Jump to main content</a>
 
-<header id="navigation" class="p-navigation">
+<header id="navigation" class="p-navigation is-dark">
   <div class="p-navigation__row">
     <div class="p-navigation__banner">
-      <div class="p-navigation__logo">
-        <a class="p-navigation__item" href="#">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" width="95" />
+      <div class="p-navigation__tagged-logo">
+        <a class="p-navigation__link" href="#">
+          <div class="p-navigation__logo-tag">
+            <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="">
+          </div>
+          <span class="p-navigation__logo-title">Canonical</span>
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>


### PR DESCRIPTION
## Done

- Updates the logo used in the [skip-link example](https://vanillaframework.io/docs/examples/standalone/patterns/links/links-skip) to the new CoF logo.
- Updates the skip-link nav example to follow new default nav layout.

Fixes [WD-11267](https://warthogs.atlassian.net/browse/WD-11267)

## QA

- Open [demo](https://vanilla-framework-5091.demos.haus/docs/examples/standalone/patterns/links/links-skip)
- Verify that the navigation on the skip-link component matches the updated branding. Compare it to the [navigation pattern](https://vanillaframework.io/docs/examples/standalone/patterns/navigation/default). 
- Verify that the skip-link functionality still works (appears on keyboard focus, & skips to main content on activation)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

Before:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/6e6bd3fc-5cb3-4a15-92bc-c3b0ae5d53c5)

After:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/59826d84-f17f-44b4-8e5e-e9478230eed8)




[WD-11267]: https://warthogs.atlassian.net/browse/WD-11267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ