### PR TITLE
Fix misleading icon import documentation

### DIFF
--- a/templates/docs/patterns/icons/index.md
+++ b/templates/docs/patterns/icons/index.md
@@ -26,6 +26,28 @@ context:
 
 {% set social_icons = ['facebook', 'instagram', 'twitter', 'linkedin', 'youtube', 'github', 'rss', 'email'] %}
 
+<!--
+    'chevron-up' and 'chevron-down' are class names, not mixin names; instead use 'chevron' for mixin import
+    TODO We should fix this icon-mixin naming discrepancy in the next major version.
+    See https://github.com/canonical/vanilla-framework/pull/5100
+-->
+
+{% set standard_icon_mixin_names = standard_icons | map('replace', 'chevron-down', 'chevron') | map('replace', 'chevron-up', 'chevron') | list %}
+
+<!--
+  'information' is a class name, not a mixin name; instead use 'info' for mixin import
+  TODO We should fix this icon-mixin naming discrepancy in the next major version.
+  See https://github.com/canonical/vanilla-framework/pull/5100
+-->
+
+{% set status_icon_mixin_names = status_icons | map('replace', 'information', 'info') | list %}
+
+<!--
+  Remove duplicates from the list of mixin names; otherwise there would be two 'chevron' entries
+-->
+
+{% set base_icon_mixin_names = (standard_icon_mixin_names + status_icon_mixin_names + social_icons) | unique %}
+
 Icons provide visual context and enhance usability, they can be added via an `<i>` element like so: `<i class="p-icon--{name}"></i>`.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/icons/icons-light" class="js-example">
@@ -131,9 +153,8 @@ If you use a limited set of icons you may want to include them individually to r
 @include vf-p-icons-common;
 
 // include only the icons that you use in your project
-{% for icon in standard_icons + status_icons + social_icons %}@include vf-p-icon-{{ icon }};
+{% for mixin_name in base_icon_mixin_names %}@include vf-p-icon-{{ mixin_name }};
 {% endfor %}
-
 // additional icons
 {% for icon in additional_icons %}@include vf-p-icon-{{ icon }};
 {% endfor %}

--- a/templates/docs/patterns/icons/index.md
+++ b/templates/docs/patterns/icons/index.md
@@ -27,12 +27,18 @@ context:
 {% set social_icons = ['facebook', 'instagram', 'twitter', 'linkedin', 'youtube', 'github', 'rss', 'email'] %}
 
 <!--
-    'chevron-up' and 'chevron-down' are class names, not mixin names; instead use 'chevron' for mixin import
+    'chevron-up', 'chevron-down', 'chevron-left', 'chevron-right' are class names, not mixin names; instead use 'chevron' for mixin import
     TODO We should fix this icon-mixin naming discrepancy in the next major version.
     See https://github.com/canonical/vanilla-framework/pull/5100
 -->
 
-{% set standard_icon_mixin_names = standard_icons | map('replace', 'chevron-down', 'chevron') | map('replace', 'chevron-up', 'chevron') | list %}
+{% set standard_icon_mixin_names = standard_icons
+  | map('replace', 'chevron-down', 'chevron')
+  | map('replace', 'chevron-up', 'chevron')
+  | map('replace', 'chevron-left', 'chevron')
+  | map('replace', 'chevron-right', 'chevron')
+  | list
+%}
 
 <!--
   'information' is a class name, not a mixin name; instead use 'info' for mixin import

--- a/templates/docs/patterns/icons/index.md
+++ b/templates/docs/patterns/icons/index.md
@@ -26,11 +26,11 @@ context:
 
 {% set social_icons = ['facebook', 'instagram', 'twitter', 'linkedin', 'youtube', 'github', 'rss', 'email'] %}
 
-<!--
-    'chevron-up', 'chevron-down', 'chevron-left', 'chevron-right' are class names, not mixin names; instead use 'chevron' for mixin import
-    TODO We should fix this icon-mixin naming discrepancy in the next major version.
-    See https://github.com/canonical/vanilla-framework/pull/5100
--->
+{#
+'chevron-up', 'chevron-down', 'chevron-left', 'chevron-right' are class names, not mixin names; instead use 'chevron' for mixin import
+TODO We should fix this icon-mixin naming discrepancy in the next major version.
+See https://github.com/canonical/vanilla-framework/pull/5100
+#}
 
 {% set standard_icon_mixin_names = standard_icons
   | map('replace', 'chevron-down', 'chevron')
@@ -40,17 +40,17 @@ context:
   | list
 %}
 
-<!--
-  'information' is a class name, not a mixin name; instead use 'info' for mixin import
-  TODO We should fix this icon-mixin naming discrepancy in the next major version.
-  See https://github.com/canonical/vanilla-framework/pull/5100
--->
+{#
+'information' is a class name, not a mixin name; instead use 'info' for mixin import
+TODO We should fix this icon-mixin naming discrepancy in the next major version.
+See https://github.com/canonical/vanilla-framework/pull/5100
+#}
 
 {% set status_icon_mixin_names = status_icons | map('replace', 'information', 'info') | list %}
 
-<!--
-  Remove duplicates from the list of mixin names; otherwise there would be two 'chevron' entries
--->
+{#
+Remove duplicates from the list of mixin names; otherwise there would be two 'chevron' entries
+#}
 
 {% set base_icon_mixin_names = (standard_icon_mixin_names + status_icon_mixin_names + social_icons) | unique %}
 


### PR DESCRIPTION
## Done
Fixes misleading documentation for importing icon mixins. The [current documentation](https://vanillaframework.io/docs/patterns/icons#import) directs users to import 3 mixins that do not exist (and would cause build errors if used):

- `vf-p-icon-chevron-up`
- `vf-p-icon-chevron-down`
- `vf-p-icon-information`

This updates the documentation to direct users to import `vf-p-icon-chevron` and `vf-p-icon-info` instead.
  
Fixes #5094, [WD-11768](https://warthogs.atlassian.net/browse/WD-11768)

### Problem
The [icons page](https://vanillaframework.io/docs/patterns/icons) uses the same [array of icon names](https://github.com/canonical/vanilla-framework/blob/d0197b27f5733789d6d23536eabe68356e045ae1/templates/docs/patterns/icons/index.md?plain=1#L21) to do two different things:

- Generate the icons sections that render the example icons to the page. These are rendered using a macro that uses the values from the array to [**create the class name**](https://github.com/canonical/vanilla-framework/blob/d0197b27f5733789d6d23536eabe68356e045ae1/templates/docs/patterns/icons/index.md?plain=1#L14) for the icon by prepending `p-icon--`.
- Generate the import instructions. Jinja loops over the elements in the icons array and [recreates mixin names](https://github.com/canonical/vanilla-framework/blob/d0197b27f5733789d6d23536eabe68356e045ae1/templates/docs/patterns/icons/index.md?plain=1#L134) by prepending `vf-p-icon--`.

The code is making the assumption that mixin names and icon class names are exactly the same except for the prefix `vf-` for mixins and `p-` for icons, and that each icon has its own dedicated mixin that matches this naming convention. This is mostly true, but is incorrect in three cases:
- `vf-p-icon-chevron-up` (mixin does not exist; class `p-icon--chevron-up` is generated by mixin `vf-p-icon-chevron`) ([src](https://github.com/canonical/vanilla-framework/blob/d0197b27f5733789d6d23536eabe68356e045ae1/scss/_patterns_icons.scss#L132))
- `vf-p-icon-chevron-down` (mixin does not exist; class `p-icon--chevron-down` is generated by mixin `vf-p-icon-chevron`) ([src](https://github.com/canonical/vanilla-framework/blob/d0197b27f5733789d6d23536eabe68356e045ae1/scss/_patterns_icons.scss#L136))
- `vf-p-icon-information` (mixin does not exist; class `p-icon--information` is generated by mixin `vf-p-icon-info`) ([src](https://github.com/canonical/vanilla-framework/blob/d0197b27f5733789d6d23536eabe68356e045ae1/scss/_patterns_icons.scss#L159))

### Solutions
#### Creating the missing mixins; deprecate the old ones (alternate / more permanent solution)
We could create mixins to match the import instructions. These would create duplicate CSS to the current mixins but would fix the incorrect documentation without editing the Jinja template. While **this PR does not do this**, we should probably change the mixin names at some point in the future (next major version perhaps) in the interest of consistency.

#### Altering the Jinja template to fix the imports (PR / temporary solution)
A much simpler fix that does not alter our SCSS would be to update the icons Jinja template to fix the import instructions. This makes the Jinja template a bit uglier but has no effect on our users' SCSS (besides pointing them towards the right mixins to import).

Note that my first approach for this solution was simply hard-coding the correct mixins. However this is a bit brittle for my taste so I added some logic to the standard imports loop in Jinja to solve the problem.

## QA

- Open [demo icons page](https://vanilla-framework-5100.demos.haus/docs/patterns/icons#import)
- Verify that imports for `vf-p-icon-chevron-up`, `vf-p-icon-chevron-down`, and `vf-p-icon-information` have been removed.
- Verify that imports for `vf-p-icon-chevron` and `vf-p-icon-info` have been added.
- Copy-paste the imports block into an IDE with SCSS support in a project that has Vanilla installed. Verify that all mixins are importable and your project builds.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

Before:
<img width="926" alt="Screenshot 2024-05-24 at 4 28 02 PM" src="https://github.com/canonical/vanilla-framework/assets/46915153/2720998b-5448-4544-b72e-c66ed47840ba">

After:
<img width="926" alt="Screenshot 2024-05-24 at 4 27 51 PM" src="https://github.com/canonical/vanilla-framework/assets/46915153/b1382a41-10e5-4d78-9a78-a9d8212f2fc9">


[WD-11768]: https://warthogs.atlassian.net/browse/WD-11768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ