### PR TITLE
Update segmented control to use new color theme variables

### DIFF
--- a/scss/_patterns_segmented-control.scss
+++ b/scss/_patterns_segmented-control.scss
@@ -27,7 +27,7 @@
         border-right: 0;
 
         &::after {
-          background-color: $colors--light-theme--border-low-contrast;
+          background-color: $colors--theme--border-low-contrast;
           bottom: 0;
           content: '';
           position: absolute;


### PR DESCRIPTION
## Done

Updates segmented control component so that the divider line between segmented control buttons uses new color theme variables.

This results in a change to the dark theme appearance of the segmented control, as previously it was always using the light theme appearance. 

Fixes [WD-11861](https://warthogs.atlassian.net/browse/WD-11861)

## QA

- Open [segmented control example](https://vanilla-framework-5111.demos.haus/docs/examples/patterns/segmented-control/dense?theme=light)
- Verify that the color of the separator bar between segmented control buttons is correct in each theme.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

Before
<img width="247" alt="Screenshot 2024-06-05 at 12 05 42 PM" src="https://github.com/canonical/vanilla-framework/assets/46915153/5751ea50-2db9-4a1b-8a44-44efd0b77e86">
After
<img width="247" alt="Screenshot 2024-06-05 at 12 06 00 PM" src="https://github.com/canonical/vanilla-framework/assets/46915153/bf4391ca-4d17-4a60-bbe5-a51f0137560a">



[WD-11861]: https://warthogs.atlassian.net/browse/WD-11861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ