### PR TITLE
Update card pattern to support color themes

### DIFF
--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -25,6 +25,11 @@
     border: $border;
   }
 
+  %vf-bg-themed {
+    background-color: $colors--theme--background-default;
+    color: $colors--theme--text-default;
+  }
+
   // deprecated -- use the theme colour variables
   %vf-bg--light {
     background-color: $color-light;
@@ -43,7 +48,7 @@
   }
 
   %vf-card {
-    @extend %vf-bg--x-light;
+    @extend %vf-bg-themed;
     @extend %vf-card-padding;
 
     margin-bottom: $spv--x-large;

--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -12,7 +12,6 @@
   .p-card {
     @extend %vf-card;
     @extend %vf-is-bordered;
-
     padding: calc($spv--large - 1px);
   }
 }
@@ -30,8 +29,8 @@
 
 @mixin vf-p-card-overlay {
   .p-card--overlay {
-    background: transparentize($color-x-light, 0.1);
-    color: $colors--light-theme--text-default;
+    background: $colors--theme--background-alt;
+    color: $colors--theme--text-default;
     margin-bottom: $spv--x-large;
     overflow: auto;
     padding: $spv--large;
@@ -42,8 +41,8 @@
   .p-card--muted {
     @extend %vf-has-box-shadow;
 
-    background-color: $color-light;
-    color: $colors--light-theme--text-default;
+    background-color: $colors--theme--background-default;
+    color: $colors--theme--text-default;
     margin-bottom: $spv--x-large;
     overflow: auto;
     padding: $spv--large;
@@ -61,7 +60,7 @@
   }
 
   .p-card__header {
-    border-bottom: 1px solid $color-mid-light;
+    border-bottom: 1px solid $colors--theme--border-low-contrast;
     padding-bottom: $spv--large;
 
     > .p-link--soft {

--- a/scss/_settings_placeholders.scss
+++ b/scss/_settings_placeholders.scss
@@ -5,7 +5,7 @@
 $input-border-thickness: 1.5px;
 $bar-thickness: 0.1875rem !default; // 3px at 16px fontsize, expressed in rems so it scales with text if the root font-size changes at a breakpoint
 $border-radius: 0; // deprecated, will be removed in future version of Vanilla
-$border: $input-border-thickness solid $color-mid-light !default;
+$border: $input-border-thickness solid $colors--theme--border-default !default;
 $box-shadow:
   0 1px 1px 0 transparentize($color-x-dark, 0.85),
   0 2px 2px -1px transparentize($color-x-dark, 0.85),

--- a/templates/docs/examples/patterns/card/header.html
+++ b/templates/docs/examples/patterns/card/header.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="p-card">
-  <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/dca2e4c4-raspberry-logo.png" alt="" />
+  <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/31bd2627-logo-raspberry-pi.svg" alt="" />
   <hr class="u-sv1">
   <h3>Raspberry Pi2 and Pi3</h3>
   <p class="p-card__content">For fun, for education and for profit, the RPi makes device development personal and entertaining. With support for both the Pi2 and the new Pi3, Ubuntu Core supports the world’s most beloved board.</p>

--- a/templates/docs/examples/patterns/card/overlay.html
+++ b/templates/docs/examples/patterns/card/overlay.html
@@ -3,9 +3,8 @@
 
 {% block standalone_css %}patterns_card{% endblock %}
 
-{% set is_not_themed = True %}
 {% block content %}
-<section class="p-strip--image is-light" style="background-image:url('https://assets.ubuntu.com/v1/0a98afcd-screenshot_desktop.jpg')">
+<section class="p-strip--image" style="background-image:url('https://assets.ubuntu.com/v1/0a98afcd-screenshot_desktop.jpg')">
   <div class="row">
     <div class="col-6 col-start-large-7">
       <div class="p-card--overlay">


### PR DESCRIPTION
## Done

Updates the card component to use new color theme variables & thus support theming.

Note that the image used in the header example was changed as the [old one](https://vanillaframework.io/docs/examples/patterns/card/header) is not friendly to all themes (dark text becomes impossible to read on dark theme)


Fixes [WD-11865](https://warthogs.atlassian.net/browse/WD-11865)

## QA

- Review [card docs](https://vanilla-framework-5112.demos.haus/docs/patterns/card) & verify cards appear as expected.
- Review all card examples and verify they look as expected in all color themes.
    - [Default](https://vanilla-framework-5112.demos.haus/docs/examples/patterns/card/default?theme=light)
    - [Content bleed](https://vanilla-framework-5112.demos.haus/docs/examples/patterns/card/content-bleed?theme=light)
    - [Header](https://vanilla-framework-5112.demos.haus/docs/examples/patterns/card/header?theme=light)
    - [Highlighted](https://vanilla-framework-5112.demos.haus/docs/examples/patterns/card/highlighted?theme=light)
    - [Image](https://vanilla-framework-5112.demos.haus/docs/examples/patterns/card/image?theme=light)
    - [Overlay](https://vanilla-framework-5112.demos.haus/docs/examples/patterns/card/overlay?theme=light)
- Review [4.13.0 release notes](https://vanilla-framework-5112.demos.haus/docs/whats-new)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

Default light:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/349dd7ac-92b4-499a-af63-6bc90694bba9)
Default dark:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/c3d9e376-2d32-4951-a937-c4a87764df30)
Default paper:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/7bbb7c5d-eaa6-4f5e-b926-531d731acf42)

Content bleed light:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/717c039f-eb1a-4dab-9705-ba4b853fceae)
Content bleed dark:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/89ff4c21-de18-4770-a2f7-d67efc97611b)
Content bleed paper:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/b3d7d70f-5e5b-498d-b02f-044b8f2c6d3c)

Header light:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/a1664447-bae6-4ee9-8d7c-301620ce86b3)
Header dark:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/50281e03-4810-4429-8242-c4537d1b53fb)
Header paper:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/3cb773c8-076e-4e98-bd42-cabd1767872e)

Highlighted light:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/1c1fec92-bd39-45cc-88e2-5636d155dafd)
Highlighted dark:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/c67cd19f-7e7a-48d1-82fa-0f3a9301a95e)
Highlighted paper:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/2624d07a-e68b-46ff-adcc-b908df4dc7ec)

Image light:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/77a28b12-5ffb-4da2-a2ed-4370b7f07bb3)
Image dark:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/2d17a8d8-2d86-4207-aec0-c70b35d142f2)
Image paper:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/88dd80b7-0bcf-4968-8e7e-859557b2e165)

Overlay light:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/f6af9b76-1ca5-4757-bfcb-52cb743ae1a9)
Overlay dark:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/a4e2e1bf-35cc-431a-9f37-60ccf3ed7b92)
Overlay paper:
![image](https://github.com/canonical/vanilla-framework/assets/46915153/2a00108f-ac2a-48d8-ac0a-e3b48aee6196)



[WD-11865]: https://warthogs.atlassian.net/browse/WD-11865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ