### PR TITLE
Update Table of Contents to use new color theme variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_table-of-contents.scss
+++ b/scss/_patterns_table-of-contents.scss
@@ -37,7 +37,7 @@
       }
 
       &:visited {
-        color: $colors--theme--link-visited;
+        color: $colors--theme--link-default;
       }
     }
   }

--- a/scss/_patterns_table-of-contents.scss
+++ b/scss/_patterns_table-of-contents.scss
@@ -13,7 +13,7 @@
     padding-bottom: $spv--large;
 
     &:not(:last-child) {
-      border-bottom: 1px solid $color-mid-light;
+      border-bottom: 1px solid $colors--theme--border-low-contrast;
     }
   }
 
@@ -37,7 +37,7 @@
       }
 
       &:visited {
-        color: $color-link;
+        color: $colors--theme--link-visited;
       }
     }
   }


### PR DESCRIPTION
## Done

- Replaced old color variables with new color theme variables for improved theming support

Fixes [WD-11872](https://warthogs.atlassian.net/browse/WD-11872)

## QA

- Open [Table of Contents demo](https://vanilla-framework-5113.demos.haus/docs/examples/patterns/table-of-contents/sections?theme=light)
- Verify Table of Contents appears as expected (with slight, intentional change to bottom border color)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [X] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [X] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [X] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

## Screenshots

![image](https://github.com/canonical/vanilla-framework/assets/168636120/98b4a8ec-b804-4e2b-847d-6ffb91da5d52)



[WD-11872]: https://warthogs.atlassian.net/browse/WD-11872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ