### PR TITLE
Reduce padding on navigation items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -185,7 +185,7 @@
     -webkit-appearance: none;
     appearance: none;
     // stylelint-enable property-no-vendor-prefix
-    background-position: right calc(map-get($grid-margin-widths, default) / 2) center;
+    background-position: right $sph--small center;
     background-repeat: no-repeat;
     background-size: map-get($icon-sizes, default);
     box-shadow: none;

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -404,6 +404,12 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
       justify-content: space-between;
       margin-right: map-get($grid-margin-widths, default);
       width: 100%;
+
+      // in documentation layout navigation items need to be aligned with the grid of the content
+      // so we substract the navigation item padding from the grid margin
+      .l-docs__main & {
+        margin-left: calc(map-get($grid-margin-widths, default) - $sph--large);
+      }
     }
   }
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -32,7 +32,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     }
 
     @media (min-width: $breakpoint-navigation-threshold) {
-      padding-left: map-get($grid-margin-widths, default);
+      padding-left: $sph--large;
     }
   }
 
@@ -45,7 +45,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     }
 
     @media (min-width: $breakpoint-navigation-threshold) {
-      padding-right: map-get($grid-margin-widths, default);
+      padding-right: $sph--large;
     }
   }
 
@@ -110,7 +110,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     }
 
     @media (min-width: $breakpoint-navigation-threshold) {
-      padding-left: map-get($grid-margin-widths, default);
+      padding-left: $sph--large;
     }
   }
 
@@ -227,7 +227,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
 
       // shift navigation items by the size of grid margin to align with grid
       .p-navigation__items:first-child {
-        margin-left: calc(-1 * map-get($grid-margin-widths, default));
+        margin-left: calc(-1 * $sph--large);
       }
 
       // on medium screen sizes (6 columns) use 2/4 column split
@@ -508,7 +508,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     height: 100%; // keep the height of the navigation when 'Search' label is hidden
 
     padding-left: 0; // on small screens label is hidden, so we remove left padding as well
-    padding-right: calc(map-get($grid-margin-widths, default) + map-get($icon-sizes, default));
+    padding-right: calc(2 * $sph--small + map-get($icon-sizes, default)); // TODO: 2x sp small, or just large?
     position: relative;
 
     // hide "search" label on small screens (only show the icon)
@@ -518,7 +518,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
 
     // show both label and icon on large screens
     @media (min-width: $breakpoint-large) {
-      padding-left: map-get($grid-margin-widths, default);
+      padding-left: $sph--large;
 
       .p-navigation__search-label {
         display: initial;
@@ -536,7 +536,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
       height: $spv--large;
       pointer-events: none;
       position: absolute;
-      right: calc(map-get($grid-margin-widths, default) / 2);
+      right: calc($sph--large / 2);
       text-indent: calc(100% + 10rem);
       top: calc($spv--medium + map-get($nudges, x-small));
       width: map-get($icon-sizes, default);
@@ -679,7 +679,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
       }
 
       @media (min-width: $breakpoint-navigation-threshold) {
-        right: calc(map-get($grid-margin-widths, default) / 2); // position by the center of grid margin
+        right: calc($sph--large / 2); // position by the center of grid margin
         top: calc($spv--large + map-get($nudges, x-small));
         transform: rotate(0deg);
       }
@@ -702,7 +702,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
 
     .p-navigation__link {
       // increase padding to accommodate chevron icon
-      padding-right: map-get($grid-margin-widths, default) + map-get($icon-sizes, default);
+      padding-right: calc(2 * $sph--small + map-get($icon-sizes, default));
     }
 
     &:first-child .p-navigation__link::before {

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -32,10 +32,6 @@
     .p-search-box__reset {
       @extend %search-box-button;
       @extend %transparent-button;
-
-      &:not(:last-of-type):not(:only-of-type) {
-        margin-right: $bar-thickness;
-      }
     }
 
     // Theme set on body element
@@ -80,7 +76,7 @@
 
       border-left-style: solid;
       border-left-width: 1px;
-      margin-right: $bar-thickness;
+      //margin-right: $bar-thickness;
     }
   }
 

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -76,7 +76,6 @@
 
       border-left-style: solid;
       border-left-width: 1px;
-      //margin-right: $bar-thickness;
     }
   }
 


### PR DESCRIPTION
## Done

In #4948 we increased the top navigation padding (to better align with the grid in documentation layout), but this increased padding causes issues in navigations with many elements (most importantly the meganav).

So, to better align with meganav needs we are reverting this change back. Top navigation items no longer use grid margin as their padding value, but are back to using standard large spacing variable.
This change affects navigation paddings, their alignment, and the alignment of navigation search and dropdown icons with form elements.

Fixes https://warthogs.atlassian.net/browse/WD-11984

## QA


- Open [demo](https://vanilla-framework-5116.demos.haus/docs/examples/patterns/navigation/default?theme=light)
- Review updated examples to make sure they look correct (the change should only affect large screen):
  - https://vanilla-framework-5116.demos.haus/docs/examples/patterns/navigation/default?theme=light
    - make sure text of first nav element aligns with text in grid below (on large screen)
  - https://vanilla-framework-5116.demos.haus/docs/examples/patterns/navigation/dropdown-alignment?theme=light
    - make sure the chevrons and search icons on the very right side are all aligned
  - https://vanilla-framework-5116.demos.haus/docs/examples/patterns/navigation/sliding-search?theme=light
    - make sure that search icon doesn't move when you open the search
  - https://vanilla-framework-5116.demos.haus/docs/examples/layouts/docs
    - in documentation layout make sure first nav item is aligned with the content text in the grid below 
  - https://vanilla-framework-5116.demos.haus/docs/examples
    - find some other "Navigation / " examples and make sure they look and work as expected

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1316" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/da18ccf0-691e-4abb-846d-351d791a8fbb">


<img width="1506" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/e6325258-b926-47d2-a4d8-94f8e59ec74b">

