### PR TITLE
Add modal & segmented control to color theme docs page

### DIFF
--- a/templates/docs/settings/color-settings.md
+++ b/templates/docs/settings/color-settings.md
@@ -138,7 +138,9 @@ Starting with the [2.3.0](https://github.com/canonical/vanilla-framework/release
 - [Contextual menu](/docs/patterns/contextual-menu)
 - [Lists / Divider](/docs/patterns/lists#responsive-divider)
 - [Lists / Middot](/docs/patterns/lists#middot)
+- [Modal](/docs/patterns/modal)
 - [Navigation](/docs/patterns/navigation)
+- [Segmented control](/docs/patterns/segmented-control)
 - [Side navigation](/docs/patterns/navigation#side-navigation)
 - [Search box](/docs/patterns/search-box)
 


### PR DESCRIPTION
## Done

In #5106 and #5111 , we added or altered theming support for the modal & segmented control components. However we did not update the [color themes documentation](https://vanillaframework.io/docs/settings/color-settings#color-theming) to include these components in the list of themed components. This PR adds these components to that list.

## QA

- Open [demo](https://vanilla-framework-5118.demos.haus/docs/settings/color-settings#color-theming)
- Verify that the modal & segmented control have been added to the color theme-supported components list.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
<img width="662" alt="Screenshot 2024-06-10 at 11 49 59 AM" src="https://github.com/canonical/vanilla-framework/assets/46915153/a8fc6be3-f03d-4ad2-89dc-7eb6907079ea">
