### PR TITLE
Update lists pattern to use new color theme variables

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -87,7 +87,7 @@ $list-step-bullet-margin: $sph--x-large;
     }
 
     &::before {
-      color: $colors--light-theme--text-default;
+      color: $colors--theme--text-default;
       content: counters(list-item, '.') '. ';
       display: inline-block;
       text-align: right;
@@ -96,7 +96,7 @@ $list-step-bullet-margin: $sph--x-large;
 
   %vf-list-item-bullet {
     &::before {
-      color: $colors--light-theme--text-default;
+      color: $colors--theme--text-default;
       content: '•';
       display: inline-block;
       text-align: right;
@@ -175,7 +175,7 @@ $list-step-bullet-margin: $sph--x-large;
     }
 
     &.is-split .p-list__item:last-of-type {
-      border-bottom: 1px solid $color-mid-light;
+      border-bottom: $border;
     }
 
     & & {

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -174,10 +174,6 @@ $list-step-bullet-margin: $sph--x-large;
       }
     }
 
-    &.is-split .p-list__item:last-of-type {
-      border-bottom: $border;
-    }
-
     & & {
       margin-bottom: 0;
       margin-left: $sp-x-large;


### PR DESCRIPTION
## Done
Updates the lists pattern to use newer color theme variables.

Affects the following:

- Color of bullets in unordered lists
- Color of sequence numbers in ordered lists
- Color of the bottom border of the last list element in a split list

Fixes [WD-11866](https://warthogs.atlassian.net/browse/WD-11866)

## QA

- Open Ordered list examples: Verify that sequence numbers color is correct in all thtmes
    - [Stepped/Detailed](https://vanilla-framework-5124.demos.haus/docs/examples/patterns/lists/list-nested-stepped-detailed?theme=light)
    - [With dividers](https://vanilla-framework-5124.demos.haus/docs/examples/patterns/lists/lists-dividers-ordered?theme=light)
- [Split list example](https://vanilla-framework-5124.demos.haus/docs/examples/patterns/lists/lists-split?theme=light): Verify that the color of the bottom border for the last list element is correct in all themes.
- [Unordered list example](https://vanilla-framework-5124.demos.haus/docs/examples/patterns/lists/lists-dividers-bulleted?theme=light): Verify that bullet colors are correct in all themes
- [Ordered/Unordered Variants](https://vanilla-framework-5124.demos.haus/docs/examples/patterns/lists/lists-dividers-all?theme=light): Verify that bullets & sequence numbers are correct colors in all themes.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
Before:
<img width="456" alt="Screenshot 2024-06-11 at 2 52 38 PM" src="https://github.com/canonical/vanilla-framework/assets/46915153/cc303cd4-bfc0-4535-a100-42688f1111b7">
After:
<img width="456" alt="Screenshot 2024-06-11 at 2 51 47 PM" src="https://github.com/canonical/vanilla-framework/assets/46915153/f55d43ae-da7e-4718-a7f2-7ed41b73803d">
Before:
<img width="320" alt="Screenshot 2024-06-11 at 3 10 29 PM" src="https://github.com/canonical/vanilla-framework/assets/46915153/32b1fa9b-4c78-443a-af03-7a7dcf66396e">
After:
<img width="320" alt="Screenshot 2024-06-11 at 3 11 05 PM" src="https://github.com/canonical/vanilla-framework/assets/46915153/9f1bccda-e3b5-4ea7-89d6-c8f1248f7d80">


[WD-11866]: https://warthogs.atlassian.net/browse/WD-11866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ