### PR TITLE
Update article pagination to use new theme variables

### DIFF
--- a/scss/_patterns_article-pagination.scss
+++ b/scss/_patterns_article-pagination.scss
@@ -3,7 +3,7 @@
 @mixin vf-p-article-pagination {
   %chevron-icon {
     @extend %icon;
-    @include vf-icon-chevron($color-mid-dark);
+    @include vf-icon-chevron-themed;
 
     content: '';
     position: absolute;
@@ -17,7 +17,7 @@
 
   .p-article-pagination__label,
   .p-article-pagination__title {
-    color: $colors--light-theme--text-default;
+    color: $colors--theme--text-default;
     display: block;
     margin-top: 0;
     width: 100%;

--- a/templates/docs/examples/patterns/article-pagination.html
+++ b/templates/docs/examples/patterns/article-pagination.html
@@ -3,7 +3,6 @@
 
 {% block standalone_css %}patterns_article-pagination{% endblock %}
 
-{% set is_not_themed = True %}
 {% block content %}
 <footer class="p-article-pagination">
   <a class="p-article-pagination__link--previous" href="#previous">


### PR DESCRIPTION
## Done

Updates Article Pagination pattern to use new theme variables.

This affects:

- Color of the previous/next button text. It now uses the default text color.
- Color of the previous/next button chevrons. It now uses the default icon color.

Fixes [WD-11864](https://warthogs.atlassian.net/browse/WD-11864)

While working on this, I also noticed that the back/next buttons can be updated to use the new chevron left/right code, and made #5125. 

## QA

- Open [demo](https://vanilla-framework-5126.demos.haus/docs/examples/patterns/article-pagination?theme=light).
- Verify that the color of all text & chevrons is correct in all themes.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
Before:
<img width="869" alt="Screenshot 2024-06-11 at 5 43 37 PM" src="https://github.com/canonical/vanilla-framework/assets/46915153/3853d1ae-894c-470c-bbd7-f7a6edcc63b5">
After:
<img width="869" alt="Screenshot 2024-06-11 at 5 42 47 PM" src="https://github.com/canonical/vanilla-framework/assets/46915153/a423011d-5235-44ca-a2e6-54c082f58308">


[WD-11864]: https://warthogs.atlassian.net/browse/WD-11864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ