### PR TITLE
Update alternative background colour in dark theme

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -67,7 +67,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     }
 
     &:hover {
-      background-color: $colors--theme--background-alt;
+      background-color: $colors--theme--background-hover;
     }
 
     &[aria-pressed='true'],
@@ -430,7 +430,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
   }
 
   [class*='p-navigation__item'].is-selected > .p-navigation__link {
-    background-color: $colors--theme--background-alt;
+    background-color: $colors--theme--background-hover;
 
     @include vf-highlight-bar($colors--theme--text-default, left, true);
 

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -172,7 +172,7 @@ $colors--dark-theme--link-default: $color-link-dark !default;
 $colors--dark-theme--link-visited: $color-link-visited-dark !default;
 
 $colors--dark-theme--background-default: #262626 !default;
-$colors--dark-theme--background-alt: #2d2d2d !default;
+$colors--dark-theme--background-alt: #202020 !default;
 $colors--dark-theme--background-code: $color-code-background-dark !default;
 $colors--dark-theme--background-inputs: rgba($colors--dark-theme--text-default, $input-background-opacity-amount) !default;
 $colors--dark-theme--background-active: rgba($colors--dark-theme--text-default, $active-background-opacity-amount) !default;


### PR DESCRIPTION
## Done

Updates dark theme alt background colour to `#202020` to make it darker than default `#262626`.

Drive-by: top navigation items were updated to use hover theme colours instead of alt background.

## QA

- Review affected examples, make sure they are using correct value.
- https://vanilla-framework-5128.demos.haus/docs/examples/patterns/strips/highlighted?theme=dark
  - highlighted strip in dark mode should be #202020 (background alt variable)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1466" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/3c60a59f-e6fd-48ca-b486-cb3a40f61642">

