### PR TITLE
Notify Figma library maintainers on release

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Extract release notes sections
         id: extract_release_notes
         run: |
-          RELEASE_NOTES="${{ github.event.release.body }}"
+          RELEASE_NOTES=$(echo "${{ github.event.release.body }}" | jq -R . | jq -r .)
           FEATURES=$(echo "$RELEASE_NOTES" | sed -n '/## 🚀 Features/,/## /p' | sed '$d')
           BUG_FIXES=$(echo "$RELEASE_NOTES" | sed -n '/## 🐛 Bug Fixes/,/## /p' | sed '$d')
           MAINTENANCE=$(echo "$RELEASE_NOTES" | sed -n '/## 🔨 Maintenance/,/## /p' | sed '$d')

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -67,6 +67,7 @@ jobs:
   
   notify-figma:
     name: Notify Figma library maintainers
+    needs: publish-npm
     runs-on: ubuntu-latest
     steps:
       - name: Extract release notes sections

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -64,3 +64,20 @@ jobs:
         run: upload-assets --url-path vanilla-framework-version-$(cat css/VANILLA_VERSION).min.css css/build.css
         env:
           UPLOAD_ASSETS_API_TOKEN: ${{secrets.UPLOAD_ASSETS_API_TOKEN}}
+  
+  notify-figma:
+    name: Notify Figma library maintainers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract release notes sections
+        id: extract_release_notes
+        run: |
+          RELEASE_NOTES="${{ github.event.release.body }}"
+          FEATURES=$(echo "$RELEASE_NOTES" | sed -n '/## 🚀 Features/,/## /p' | sed '$d')
+          BUG_FIXES=$(echo "$RELEASE_NOTES" | sed -n '/## 🐛 Bug Fixes/,/## /p' | sed '$d')
+          MAINTENANCE=$(echo "$RELEASE_NOTES" | sed -n '/## 🔨 Maintenance/,/## /p' | sed '$d')
+          CHANGE_SUMMARY="\n$FEATURES\n\n$BUG_FIXES\n\n$MAINTENANCE\n"
+          echo "change_summary=$CHANGE_SUMMARY" >> $GITHUB_OUTPUT
+      - name: Notify Figma library maintainers
+        run: |
+          curl -X POST -H "Content-Type: application/json" -d '{"source": "Vanilla CSS", "change-summary": "${{ steps.extract_release_notes.outputs.change_summary }}"}' ${{ secrets.FIGMA_LIBRARY_ALERT_URL }}


### PR DESCRIPTION
As part of my efforts for creating a new Figma library I have added a [script to the webteam bot](https://github.com/canonical/webteam-hubot/blob/main/scripts/figma-library-alerts.js) which can be used to alert Figma library maintainers in the `~Figma library maintainers` chat of changes of sources of truth. Amongst those sources of truth we need to keep track of to keep the Figma libraries up to date is of course Vanilla CSS.
This PR adds a job to the Github action that is triggered on release of a new Vanilla version and sends the sections 🚀 Features, 🐛 Bug Fixes and 🔨 Maintenance of the release notes as an alert to the bot to notify Figma library maintainers of the changes to Vanilla CSS

Additionally to these changes we would need to add the chat bots URL to the action secrets of the repository.

Fixes: [WD-12092](https://warthogs.atlassian.net/browse/WD-12092)

## Done
- Add job to release action to notify Figma library maintainers

## QA
- I am not aware of a good way of QAing Github actions other than in production.

[WD-12092]: https://warthogs.atlassian.net/browse/WD-12092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ