### PR TITLE
Fix ascending/descending icons on sortable tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.12.1",
+  "version": "4.12.2",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_table-sortable.scss
+++ b/scss/_patterns_table-sortable.scss
@@ -29,13 +29,13 @@
 
     &[aria-sort='ascending']::after {
       @extend %heading-icon;
+
+      -webkit-transform: rotate(180deg); // stylelint-disable-line property-no-vendor-prefix
+      transform: rotate(180deg);
     }
 
     &[aria-sort='descending']::after {
       @extend %heading-icon;
-
-      -webkit-transform: rotate(180deg); // stylelint-disable-line property-no-vendor-prefix
-      transform: rotate(180deg);
     }
 
     &[aria-sort]:hover {


### PR DESCRIPTION
## Done

- Swap the icons on ascending/descending column headers so they point the correct directions

Fixes [WD-12133](https://warthogs.atlassian.net/browse/WD-12133)

## QA

- Open [sortable table demo](https://vanilla-framework-5135.demos.haus/docs/examples/patterns/tables/table-sortable?theme=light)
- Sort the table by a given column header
- Witness that the ascending/descending icons point the correct directions

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [X] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [X] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [X] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

## Screenshots

![Screenshot from 2024-06-13 11-57-32](https://github.com/canonical/vanilla-framework/assets/168636120/51376047-bf55-4c78-a0c1-6cb4c2578b9c)



[WD-12133]: https://warthogs.atlassian.net/browse/WD-12133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ