### PR TITLE
Update accordion pattern to use new color theme variables

### DIFF
--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -33,7 +33,7 @@
 
     &::before {
       @extend %icon;
-      @include vf-icon-chevron($color-mid-dark);
+      @include vf-icon-chevron-themed;
       @include vf-transition($property: transform, $duration: fast);
 
       content: '';
@@ -46,7 +46,7 @@
       background-color: inherit;
 
       &:hover {
-        background-color: $colors--light-theme--background-hover;
+        background-color: $colors--theme--background-hover;
       }
       @include vf-transition(#{background-color, border-color});
     }


### PR DESCRIPTION
## Done

Updated the accordion pattern to use new color theme variables, making it theme-friendly.

Affects:
- Accordion open/close state chevrons are now themed
- Accordion header hover color is now themed

Fixes [WD-11863](https://warthogs.atlassian.net/browse/WD-11863)

## QA

- Open [demo](https://vanilla-framework-5138.demos.haus/docs/examples/patterns/accordion/tick-elements?theme=light)
- Verify that the color of the expand/collapse chevrons and header section hover colors is correct on all color themes.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
<img width="1449" alt="Screenshot 2024-06-13 at 2 32 07 PM" src="https://github.com/canonical/vanilla-framework/assets/46915153/e7bd2d2c-35bb-41a2-b73b-1aef06c5ae38">



[WD-11863]: https://warthogs.atlassian.net/browse/WD-11863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ