### PR TITLE
Add color theming explanation comment to status label mixin

### DIFF
--- a/scss/_patterns_status-label.scss
+++ b/scss/_patterns_status-label.scss
@@ -1,5 +1,10 @@
 @import 'settings';
 
+/**
+  TODO this component uses hard-coded colors that don't respond to theming, which is not ideal.
+    However, it looks fine on all themes, and re-working it to support theming is a larger undertaking.
+    So, it is being left as-is until it can be revisited as part of the tokens effort in the future.
+ */
 // Default status label styling
 @mixin vf-p-status-label {
   %vf-status-label {

--- a/scss/_patterns_status-label.scss
+++ b/scss/_patterns_status-label.scss
@@ -2,16 +2,7 @@
 
 // Default status label styling
 @mixin vf-p-status-label {
-  .p-status-label,
-  .p-label,
-  .p-status-label--positive,
-  .p-label--positive,
-  .p-status-label--caution,
-  .p-label--caution,
-  .p-status-label--information,
-  .p-label--information,
-  .p-status-label--negative,
-  .p-label--negative {
+  %vf-status-label {
     @extend %x-small-text;
     @extend %u-no-margin--bottom--small;
 
@@ -25,32 +16,42 @@
 
   .p-status-label,
   .p-label {
-    background-color: $colors--theme--button-neutral-default;
-    color: $colors--theme--button-neutral-text;
+    @extend %vf-status-label;
+
+    background-color: $color-mid-dark;
+    color: $color-x-light;
   }
 
   .p-status-label--positive,
   .p-label--positive {
-    background-color: $colors--theme--button-positive-default;
-    color: $colors--theme--button-positive-text;
+    @extend %vf-status-label;
+
+    background-color: $color-positive;
+    color: $color-x-light;
   }
 
   .p-status-label--caution,
   .p-label--caution {
-    background-color: $colors--theme--button-caution-default;
-    color: $colors--theme--button-caution-text;
+    @extend %vf-status-label;
+
+    background-color: $color-caution;
+    color: $colors--light-theme--text-default;
   }
 
   .p-status-label--information,
   .p-label--information {
-    background-color: $colors--theme--button-information-default;
-    color: $colors--theme--button-information-text;
+    @extend %vf-status-label;
+
+    background-color: $color-information;
+    color: $color-x-light;
   }
 
   .p-status-label--negative,
   .p-label--negative {
-    background-color: $colors--theme--button-negative-default;
-    color: $colors--theme--button-negative-text;
+    @extend %vf-status-label;
+
+    background-color: $color-negative;
+    color: $color-x-light;
   }
 }
 

--- a/scss/_patterns_status-label.scss
+++ b/scss/_patterns_status-label.scss
@@ -2,7 +2,16 @@
 
 // Default status label styling
 @mixin vf-p-status-label {
-  %vf-status-label {
+  .p-status-label,
+  .p-label,
+  .p-status-label--positive,
+  .p-label--positive,
+  .p-status-label--caution,
+  .p-label--caution,
+  .p-status-label--information,
+  .p-label--information,
+  .p-status-label--negative,
+  .p-label--negative {
     @extend %x-small-text;
     @extend %u-no-margin--bottom--small;
 
@@ -16,42 +25,32 @@
 
   .p-status-label,
   .p-label {
-    @extend %vf-status-label;
-
-    background-color: $color-mid-dark;
-    color: $color-x-light;
+    background-color: $colors--theme--button-neutral-default;
+    color: $colors--theme--button-neutral-text;
   }
 
   .p-status-label--positive,
   .p-label--positive {
-    @extend %vf-status-label;
-
-    background-color: $color-positive;
-    color: $color-x-light;
+    background-color: $colors--theme--button-positive-default;
+    color: $colors--theme--button-positive-text;
   }
 
   .p-status-label--caution,
   .p-label--caution {
-    @extend %vf-status-label;
-
-    background-color: $color-caution;
-    color: $colors--light-theme--text-default;
+    background-color: $colors--theme--button-caution-default;
+    color: $colors--theme--button-caution-text;
   }
 
   .p-status-label--information,
   .p-label--information {
-    @extend %vf-status-label;
-
-    background-color: $color-information;
-    color: $color-x-light;
+    background-color: $colors--theme--button-information-default;
+    color: $colors--theme--button-information-text;
   }
 
   .p-status-label--negative,
   .p-label--negative {
-    @extend %vf-status-label;
-
-    background-color: $color-negative;
-    color: $color-x-light;
+    background-color: $colors--theme--button-negative-default;
+    color: $colors--theme--button-negative-text;
   }
 }
 

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -13,6 +13,7 @@ $color-x-dark: #000 !default;
 $color-input-shadow: rgba($color-x-dark, 0.12) !default;
 
 // SEMANTIC COLOURS
+$color-neutral: $color-mid-dark;
 $color-negative: #c7162b !default;
 $color-caution: #cc7900 !default;
 $color-positive: #0e8420 !default;
@@ -21,8 +22,11 @@ $color-information: #24598f !default;
 $color-paper: #f3f3f3 !default;
 
 // for dark themes
+$color-neutral-dark: $color-neutral;
 $color-negative-dark: #a11223 !default;
 $color-positive-dark: #008013 !default;
+$color-caution-dark: $color-caution;
+$color-information-dark: $color-information;
 
 // STATE VARIABLES
 $disabled-element-opacity: 0.33;
@@ -278,6 +282,11 @@ $colors--theme--background-information-default: var(--vf-color-background-inform
 $colors--theme--background-information-hover: var(--vf-color-background-information-hover);
 $colors--theme--background-information-active: var(--vf-color-background-information-active);
 
+$colors--theme--button-neutral-default: var(--vf-color-button-neutral-default);
+$colors--theme--button-neutral-hover: var(--vf-color-button-neutral-hover);
+$colors--theme--button-neutral-active: var(--vf-color-button-neutral-active);
+$colors--theme--button-neutral-text: var(--vf-color-button-neutral-text);
+
 $colors--theme--button-positive-default: var(--vf-color-button-positive-default);
 $colors--theme--button-positive-hover: var(--vf-color-button-positive-hover);
 $colors--theme--button-positive-active: var(--vf-color-button-positive-active);
@@ -335,6 +344,11 @@ $colors--theme--accent: var(--vf-color-accent);
   --vf-color-background-information-hover: #{map-get($colors-light-theme--tinted-backgrounds, information, 'hover')};
   --vf-color-background-information-active: #{map-get($colors-light-theme--tinted-backgrounds, information, active)};
 
+  --vf-color-button-neutral-default: #{$color-neutral};
+  --vf-color-button-neutral-hover: #{adjust-color($color-neutral, $lightness: -$hover-background-opacity-percentage)};
+  --vf-color-button-neutral-active: #{adjust-color($color-neutral, $lightness: -$active-background-opacity-percentage)};
+  --vf-color-button-neutral-text: #{vf-contrast-text-color($color-neutral)};
+
   --vf-color-button-positive-default: #{$color-positive};
   --vf-color-button-positive-hover: #{adjust-color($color-positive, $lightness: -$hover-background-opacity-percentage)};
   --vf-color-button-positive-active: #{adjust-color($color-positive, $lightness: -$active-background-opacity-percentage)};
@@ -391,6 +405,11 @@ $colors--theme--accent: var(--vf-color-accent);
   --vf-color-background-information-default: #{map-get($colors-dark-theme--tinted-backgrounds, information, default)};
   --vf-color-background-information-hover: #{map-get($colors-dark-theme--tinted-backgrounds, information, hover)};
   --vf-color-background-information-active: #{map-get($colors-dark-theme--tinted-backgrounds, information, active)};
+
+  --vf-color-button-neutral-default: #{$color-neutral-dark};
+  --vf-color-button-neutral-hover: #{adjust-color($color-neutral-dark, $lightness: -$hover-background-opacity-percentage)};
+  --vf-color-button-neutral-active: #{adjust-color($color-neutral-dark, $lightness: -$active-background-opacity-percentage)};
+  --vf-color-button-neutral-text: #{vf-contrast-text-color($color-neutral-dark)};
 
   --vf-color-button-positive-default: #{$color-positive-dark};
   --vf-color-button-positive-hover: #{adjust-color($color-positive-dark, $lightness: -$hover-background-opacity-percentage)};

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -13,7 +13,6 @@ $color-x-dark: #000 !default;
 $color-input-shadow: rgba($color-x-dark, 0.12) !default;
 
 // SEMANTIC COLOURS
-$color-neutral: $color-mid-dark;
 $color-negative: #c7162b !default;
 $color-caution: #cc7900 !default;
 $color-positive: #0e8420 !default;
@@ -22,11 +21,8 @@ $color-information: #24598f !default;
 $color-paper: #f3f3f3 !default;
 
 // for dark themes
-$color-neutral-dark: $color-neutral;
 $color-negative-dark: #a11223 !default;
 $color-positive-dark: #008013 !default;
-$color-caution-dark: $color-caution;
-$color-information-dark: $color-information;
 
 // STATE VARIABLES
 $disabled-element-opacity: 0.33;
@@ -282,11 +278,6 @@ $colors--theme--background-information-default: var(--vf-color-background-inform
 $colors--theme--background-information-hover: var(--vf-color-background-information-hover);
 $colors--theme--background-information-active: var(--vf-color-background-information-active);
 
-$colors--theme--button-neutral-default: var(--vf-color-button-neutral-default);
-$colors--theme--button-neutral-hover: var(--vf-color-button-neutral-hover);
-$colors--theme--button-neutral-active: var(--vf-color-button-neutral-active);
-$colors--theme--button-neutral-text: var(--vf-color-button-neutral-text);
-
 $colors--theme--button-positive-default: var(--vf-color-button-positive-default);
 $colors--theme--button-positive-hover: var(--vf-color-button-positive-hover);
 $colors--theme--button-positive-active: var(--vf-color-button-positive-active);
@@ -344,11 +335,6 @@ $colors--theme--accent: var(--vf-color-accent);
   --vf-color-background-information-hover: #{map-get($colors-light-theme--tinted-backgrounds, information, 'hover')};
   --vf-color-background-information-active: #{map-get($colors-light-theme--tinted-backgrounds, information, active)};
 
-  --vf-color-button-neutral-default: #{$color-neutral};
-  --vf-color-button-neutral-hover: #{adjust-color($color-neutral, $lightness: -$hover-background-opacity-percentage)};
-  --vf-color-button-neutral-active: #{adjust-color($color-neutral, $lightness: -$active-background-opacity-percentage)};
-  --vf-color-button-neutral-text: #{vf-contrast-text-color($color-neutral)};
-
   --vf-color-button-positive-default: #{$color-positive};
   --vf-color-button-positive-hover: #{adjust-color($color-positive, $lightness: -$hover-background-opacity-percentage)};
   --vf-color-button-positive-active: #{adjust-color($color-positive, $lightness: -$active-background-opacity-percentage)};
@@ -405,11 +391,6 @@ $colors--theme--accent: var(--vf-color-accent);
   --vf-color-background-information-default: #{map-get($colors-dark-theme--tinted-backgrounds, information, default)};
   --vf-color-background-information-hover: #{map-get($colors-dark-theme--tinted-backgrounds, information, hover)};
   --vf-color-background-information-active: #{map-get($colors-dark-theme--tinted-backgrounds, information, active)};
-
-  --vf-color-button-neutral-default: #{$color-neutral-dark};
-  --vf-color-button-neutral-hover: #{adjust-color($color-neutral-dark, $lightness: -$hover-background-opacity-percentage)};
-  --vf-color-button-neutral-active: #{adjust-color($color-neutral-dark, $lightness: -$active-background-opacity-percentage)};
-  --vf-color-button-neutral-text: #{vf-contrast-text-color($color-neutral-dark)};
 
   --vf-color-button-positive-default: #{$color-positive-dark};
   --vf-color-button-positive-hover: #{adjust-color($color-positive-dark, $lightness: -$hover-background-opacity-percentage)};


### PR DESCRIPTION
## Done

This PR adds a comment above the `vf-p-status-label` to explain its use of hard-coded colors. The team has decided not to theme this component yet, but we still want to note it as needing revisiting in the future.

Fixes [WD-11860](https://warthogs.atlassian.net/browse/WD-11860)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
<img width="351" alt="Screenshot 2024-06-13 at 4 08 34 PM" src="https://github.com/canonical/vanilla-framework/assets/46915153/d3afd364-37d3-44ed-a4d8-07677e8a49a0">



[WD-11860]: https://warthogs.atlassian.net/browse/WD-11860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ