### PR TITLE
Percy examples combination preparation (jinja/python enablement code)

### DIFF
--- a/templates/_layouts/examples.html
+++ b/templates/_layouts/examples.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{% endblock %}{% if self.title() %} | {% endif %}Examples | Vanilla framework documentation</title>
 
+    {% if not is_combined %}
     {% if is_standalone %}
     <link rel="stylesheet" type="text/css" href="{{ versioned_static('build/css/standalone/' + (self.standalone_css() if self.standalone_css is defined else 'base') + '.css') }}" />
     {% else %}
@@ -26,6 +27,7 @@
     {% endif %}
 
     <script defer src="{{ versioned_static('js/example-tools.js') }}"></script>
+    {% endif %}
   
   </head>
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -111,6 +111,10 @@ def _get_examples():
         # Remove "docs/examples/" and extension for the path
         example_path = os.path.splitext(template_path[examples_length:])[0]
 
+        # Ignore "combined" templates
+        if example_path.endswith("/combined"):
+            continue
+
         outermost_parent = example_path.split(os.sep).pop(0)
 
         title = example_path


### PR DESCRIPTION
This is some preparatory code that the example combination PRs that are coming next depend on.

- Adds flag `is_combined` to the examples base template. If the flag is set, the stylesheet/scripts will not be added to the header, as otherwise they would be requested multiple times in the case of a combined example. This lets the examples embedded in combined examples use the scripts/styling loaded in their parent example.
- Hides 'combined' examples from the examples index view, since they are really only intended for usage by testing agents, not users.