### PR TITLE
Percy examples combination - `base/paper`

### DIFF
--- a/scss/standalone/combined.scss
+++ b/scss/standalone/combined.scss
@@ -1,3 +1,0 @@
-@import '../settings';
-@import '../utilities_vertical-spacing';
-@include vf-u-vertical-spacing;

--- a/scss/standalone/combined.scss
+++ b/scss/standalone/combined.scss
@@ -1,0 +1,3 @@
+@import '../settings';
+@import '../utilities_vertical-spacing';
+@include vf-u-vertical-spacing;

--- a/templates/docs/examples/base/paper/combined.html
+++ b/templates/docs/examples/base/paper/combined.html
@@ -1,0 +1,14 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Paper / Combined{% endblock %}
+
+{% block standalone_css %}patterns_forms{% endblock %}
+
+{% set is_paper = true %}
+{% set is_not_themed = true %}
+
+{% block content %}
+{% with is_combined = true %}
+<section>{% include 'docs/examples/base/paper/input-on-paper.html' %}</section>
+<section>{% include 'docs/examples/base/paper/search-box-on-paper.html' %}</section>
+{% endwith %}
+{% endblock %}

--- a/templates/docs/examples/base/paper/input-on-paper.html
+++ b/templates/docs/examples/base/paper/input-on-paper.html
@@ -2,7 +2,9 @@
 {% block title %}Paper background / Inputs{% endblock %}
 
 {% block standalone_css %}patterns_forms{% endblock %}
+
 {% set is_paper = True %}
+{% set is_not_themed = true %}
 
 {% block content %}
 <label for="full-name-stacked" class="p-form__label">Full name</label>

--- a/templates/docs/examples/base/paper/search-box-on-paper.html
+++ b/templates/docs/examples/base/paper/search-box-on-paper.html
@@ -7,7 +7,7 @@
 {% set is_not_themed = true %}
 
 {% block content %}
-<form class="p-search-box on-paper">
+<form class="p-search-box">
     <label class="u-off-screen" for="search">Search</label>
     <input type="search" id="search" class="p-search-box__input" name="search" placeholder="Search" required autocomplete="on">
     <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Close</i></button>
@@ -15,7 +15,7 @@
 </form>
 
 <div class="p-card">
-    <form class="p-search-box on-paper">
+    <form class="p-search-box">
         <label class="u-off-screen" for="search">Search</label>
         <input type="search" id="search" class="p-search-box__input" name="search" placeholder="Search" required autocomplete="on">
         <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Close</i></button>

--- a/templates/docs/examples/base/paper/search-box-on-paper.html
+++ b/templates/docs/examples/base/paper/search-box-on-paper.html
@@ -2,7 +2,9 @@
 {% block title %}Paper background / Search box{% endblock %}
 
 {% block standalone_css %}patterns_forms{% endblock %}
+
 {% set is_paper = True %}
+{% set is_not_themed = true %}
 
 {% block content %}
 <form class="p-search-box on-paper">


### PR DESCRIPTION
Combines `base/paper` examples.

Depends on #5142 (includes its code)

## QA

- Review [combined paper example](https://vanilla-framework-5148.demos.haus/docs/examples/base/paper/combined)

This example should be revisited later - it is [very theme-specific](https://vanillaframework.io/docs/base/paper) and I'm not yet sure what `.on-paper` is for (is it to be deprecated once all sites move to paper background?) - in this implementation this combined example will be screenshotted on light & dark for no reason, but I think it's worth it since we are decreasing our usage so much in other areas.