### PR TITLE
Percy examples combination - `patterns/code-snippet`

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -67,3 +67,6 @@
 /docs/examples/base/table: /docs/examples/base/table/default
 /docs/examples/patterns/buttons/dark: /docs/examples/patterns/buttons/default?theme=dark
 /docs/examples/patterns/chip/dark: /docs/examples/patterns/chip/default?theme=dark
+/docs/examples/patterns/code-snippet/default-dark: /docs/examples/patterns/code-snippet/default?theme=dark
+/docs/examples/patterns/code-snippet/dropdown-multiple-dark: /docs/examples/patterns/code-snippet/dropdown-multiple?theme=dark
+/docs/examples/patterns/code-snippet/icon-dark: /docs/examples/patterns/code-snippet/icon?theme=dark

--- a/scss/standalone/combined.scss
+++ b/scss/standalone/combined.scss
@@ -1,3 +1,0 @@
-@import '../settings';
-@import '../utilities_vertical-spacing';
-@include vf-u-vertical-spacing;

--- a/scss/standalone/combined.scss
+++ b/scss/standalone/combined.scss
@@ -1,0 +1,3 @@
+@import '../settings';
+@import '../utilities_vertical-spacing';
+@include vf-u-vertical-spacing;

--- a/templates/docs/examples/patterns/code-snippet/combined.html
+++ b/templates/docs/examples/patterns/code-snippet/combined.html
@@ -1,0 +1,18 @@
+
+{% extends "_layouts/examples.html" %}
+{% block title %}Code snippet / Combined{% endblock %}
+
+{% block standalone_css %}patterns_code-snippet{% endblock %}
+
+{% block content %}
+{% with is_combined = true %}
+<section>{% include 'docs/examples/patterns/code-snippet/default.html' %}</section>
+<section>{% include 'docs/examples/patterns/code-snippet/dropdown.html' %}</section>
+<section>{% include 'docs/examples/patterns/code-snippet/dropdown-multiple.html' %}</section>
+<section>{% include 'docs/examples/patterns/code-snippet/icon.html' %}</section>
+<section>{% include 'docs/examples/patterns/code-snippet/is-bordered.html' %}</section>
+<section>{% include 'docs/examples/patterns/code-snippet/numbered.html' %}</section>
+<section>{% include 'docs/examples/patterns/code-snippet/prism.html' %}</section>
+<section>{% include 'docs/examples/patterns/code-snippet/wrapping.html' %}</section>
+{% endwith %}
+{% endblock %}

--- a/templates/docs/examples/patterns/code-snippet/default-dark.html
+++ b/templates/docs/examples/patterns/code-snippet/default-dark.html
@@ -1,9 +1,0 @@
-{% extends "_layouts/examples.html" %}
-{% block title %}Code snippet / Dark{% endblock %}
-
-{% block standalone_css %}patterns_code-snippet{% endblock %}
-
-{% set is_dark = true %}
-{% block content %}
-{% include "/docs/examples/patterns/code-snippet/_default.html" %}
-{% endblock %}

--- a/templates/docs/examples/patterns/code-snippet/dropdown-multiple-dark.html
+++ b/templates/docs/examples/patterns/code-snippet/dropdown-multiple-dark.html
@@ -1,9 +1,0 @@
-{% extends "_layouts/examples.html" %}
-{% block title %}Code snippet / Multiple dropdowns Dark{% endblock %}
-
-{% block standalone_css %}patterns_code-snippet{% endblock %}
-
-{% set is_dark = true %}
-{% block content %}
-{% include "/docs/examples/patterns/code-snippet/_dropdown-multiple.html" %}
-{% endblock %}

--- a/templates/docs/examples/patterns/code-snippet/icon-dark.html
+++ b/templates/docs/examples/patterns/code-snippet/icon-dark.html
@@ -1,9 +1,0 @@
-{% extends "_layouts/examples.html" %}
-{% block title %}Code Snippet / Icon Dark{% endblock %}
-
-{% block standalone_css %}patterns_code-snippet{% endblock %}
-
-{% set is_dark = true %}
-{% block content %}
-{% include "/docs/examples/patterns/code-snippet/_icon.html" %}
-{% endblock %}


### PR DESCRIPTION
Combines code snippet

Depends on #5142 (includes its code)

Deletes the dark button examples

## QA

- Review [combined code snippet example](https://vanilla-framework-5155.demos.haus/docs/examples/patterns/code-snippet/combined)
- Verify redirects
    - https://vanilla-framework-5155.demos.haus/docs/examples/patterns/code-snippet/default-dark -> https://vanilla-framework-5155.demos.haus/docs/examples/patterns/code-snippet/default?theme=dark
    - https://vanilla-framework-5155.demos.haus/docs/examples/patterns/code-snippet/dropdown-multiple-dark -> https://vanilla-framework-5155.demos.haus/docs/examples/patterns/code-snippet/dropdown-multiple?theme=dark
    - https://vanilla-framework-5155.demos.haus/docs/examples/patterns/code-snippet/icon-dark -> https://vanilla-framework-5155.demos.haus/docs/examples/patterns/code-snippet/icon?theme=dark