### PR TITLE
Percy examples combination - Add combined template name to combined example body / meta head

### DIFF
--- a/templates/_layouts/examples.html
+++ b/templates/_layouts/examples.html
@@ -27,11 +27,16 @@
     {% endif %}
 
     <script defer src="{{ versioned_static('js/example-tools.js') }}"></script>
+    {% else %}
+      <meta name="combined_template_name" content="{{ self._TemplateReference__context.name }}">
     {% endif %}
   
   </head>
 
   <body {% if is_dark %}class="is-dark"{% elif is_paper %}class="is-paper"{% endif %}>
+    {% if is_combined %}
+    <small>{{ self._TemplateReference__context.name }}</small>
+    {% endif %}
     {% block content %}{% endblock %}
   </body>
 </html>


### PR DESCRIPTION
While splitting the combined examples and working on the utilities combination, I noticed that it could become somewhat difficult to keep track of which example you are looking at when looking at bits of a combined example. If there were a problem with a combined example in a Percy snapshot, it would take a bit of work to determine which example the problem came from. 

This PR updates the examples template to do the following for combined examples:

- Embed the name of the current template in the meta head
- Show the name of the current template in the example body 

## Screenshot
Here's an example of how this will look, with the Suru combined example.
![image](https://github.com/canonical/vanilla-framework/assets/46915153/c8d7dcb6-0074-40d3-b9d6-b48145a83852)
