### PR TITLE
Percy examples combination - Jinja vertical spacing option

### DIFF
--- a/scss/standalone/combined.scss
+++ b/scss/standalone/combined.scss
@@ -1,3 +1,0 @@
-@import '../settings';
-@import '../utilities_vertical-spacing';
-@include vf-u-vertical-spacing;

--- a/scss/standalone/combined.scss
+++ b/scss/standalone/combined.scss
@@ -1,0 +1,3 @@
+@import '../settings';
+@import '../utilities_vertical-spacing';
+@include vf-u-vertical-spacing;

--- a/templates/_layouts/examples.html
+++ b/templates/_layouts/examples.html
@@ -7,31 +7,40 @@
     <title>{% block title %}{% endblock %}{% if self.title() %} | {% endif %}Examples | Vanilla framework documentation</title>
 
     {% if not is_combined %}
-    {% if is_standalone %}
-    <link rel="stylesheet" type="text/css" href="{{ versioned_static('build/css/standalone/' + (self.standalone_css() if self.standalone_css is defined else 'base') + '.css') }}" />
-    {% else %}
-    <link rel="stylesheet" type="text/css" href="{{ versioned_static('build/css/build.css') }}" />
-    {% endif %}
-    <link rel="stylesheet" type="text/css" href="{{ versioned_static('build/css/docs/example.css') }}" />
-    <link rel="icon" href="https://assets.ubuntu.com/v1/ab36e6ed-vanilla_favicon_32px.png" type="image/x-icon" />
-    {% block style %}{% endblock %}
+      {% if is_standalone %}
+        <link rel="stylesheet" type="text/css" href="{{ versioned_static('build/css/standalone/' + (self.standalone_css() if self.standalone_css is defined else 'base') + '.css') }}" />
+      {% else %}
+        <link rel="stylesheet" type="text/css" href="{{ versioned_static('build/css/build.css') }}" />
+      {% endif %}
+      <link rel="stylesheet" type="text/css" href="{{ versioned_static('build/css/docs/example.css') }}" />
+      <link rel="icon" href="https://assets.ubuntu.com/v1/ab36e6ed-vanilla_favicon_32px.png" type="image/x-icon" />
+      {% block style %}{% endblock %}
 
-    {% if is_not_themed %}
-    <script>
-      var SHOW_THEME_SWITCH = false;
-    </script>
-    {% else %}
-    <script>
-      var SHOW_THEME_SWITCH = true;
-    </script>
-    {% endif %}
-
-    <script defer src="{{ versioned_static('js/example-tools.js') }}"></script>
+      {% if is_not_themed %}
+        <script>
+          var SHOW_THEME_SWITCH = false;
+        </script>
+        {% else %}
+        <script>
+          var SHOW_THEME_SWITCH = true;
+        </script>
+      {% endif %}
+      <script defer src="{{ versioned_static('js/example-tools.js') }}"></script>
+    {% elif is_standalone and spacing_below and spacing_below > 0 %}
+      <link rel="stylesheet" type="text/css" href="{{ versioned_static('build/css/standalone/combined.css') }}" />
     {% endif %}
   
   </head>
 
   <body {% if is_dark %}class="is-dark"{% elif is_paper %}class="is-paper"{% endif %}>
     {% block content %}{% endblock %}
+    {% if is_combined and spacing_below and spacing_below > 0 %}
+    <section>
+      {# Add spacing below the combined example if spacing option was passed in #}
+      {% for _ in range(spacing_below) %}
+      <div class="u-sv3"></div>
+      {% endfor %}
+    </section>
+    {% endif %}
   </body>
 </html>

--- a/templates/_layouts/examples.html
+++ b/templates/_layouts/examples.html
@@ -26,8 +26,6 @@
         </script>
       {% endif %}
       <script defer src="{{ versioned_static('js/example-tools.js') }}"></script>
-    {% elif is_standalone and spacing_below and spacing_below > 0 %}
-      <link rel="stylesheet" type="text/css" href="{{ versioned_static('build/css/standalone/combined.css') }}" />
     {% endif %}
   
   </head>

--- a/templates/_layouts/examples.html
+++ b/templates/_layouts/examples.html
@@ -35,12 +35,9 @@
   <body {% if is_dark %}class="is-dark"{% elif is_paper %}class="is-paper"{% endif %}>
     {% block content %}{% endblock %}
     {% if is_combined and spacing_below and spacing_below > 0 %}
-    <section>
-      {# Add spacing below the combined example if spacing option was passed in #}
-      {% for _ in range(spacing_below) %}
-      <div class="u-sv3"></div>
-      {% endfor %}
-    </section>
+    <div style="margin-bottom: {{ spacing_below }}rem">
+      <!-- This is a spacer to ensure the content following this example is not obscured by this example's content. -->
+    </div>
     {% endif %}
   </body>
 </html>


### PR DESCRIPTION
Some combined examples (such as search & filter, context menu, navigation) have overlay/non-contained contents that can overlap other combined examples if we're not careful. 

In my PRs so far I have been handling this case manually by creating multple divs with `u-sv3` after examples that need extra space below them. However, this came to be tedious so I have come up with a (hopefully) more streamlined approach for this.

This does the following:

- Creates a new `combined.scss` that the examples template can import to load vertical spacing utility styling. This prevents having to create separate `-combined.scss` style files for combined examples that need to include the vertical spacing utility.
- Allows passing `spacing_below` into an example template. If `spacing_below` is defined and the example is a combined example, then a div with `margin-bottom: <spacing_below>rem` will be added below the block content to make space for whatever content is needed.

## Example 
Example usage, with [Search & Filter](https://github.com/jmuzina/vanilla-framework/tree/examples-combination-spacing-patterns-search-and-filter)
### Markup
```html
{% extends "_layouts/examples.html" %}
{% block title %}Search and filter / Combined{% endblock %}

{% block standalone_css %}patterns_search-and-filter{% endblock %}

{% block content %}
{% with is_combined = true %}
<section>{% include 'docs/examples/patterns/search-and-filter/chip-overflow.html' %}</section>
<section>{% include 'docs/examples/patterns/search-and-filter/default.html' %}</section>
<section>{% include 'docs/examples/patterns/search-and-filter/expanded.html' %}</section>
<section>
  {% with spacing_below = 17 %}
    {% include 'docs/examples/patterns/search-and-filter/with-chips.html' %}
  {% endwith %}
</section>
<section>{% include 'docs/examples/patterns/search-and-filter/with-search-prompt.html' %}</section>
{% endwith %}
{% endblock %}
```
### Screenshot
![image](https://github.com/canonical/vanilla-framework/assets/46915153/c93e8ede-cb61-414f-b76d-1b612f51fc81)
