### PR TITLE
WIP: feat: Combine examples for Percy

### DIFF
--- a/templates/_layouts/examples.html
+++ b/templates/_layouts/examples.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{% endblock %}{% if self.title() %} | {% endif %}Examples | Vanilla framework documentation</title>
 
+    {% if not is_combined %}
     {% if is_standalone %}
     <link rel="stylesheet" type="text/css" href="{{ versioned_static('build/css/standalone/' + (self.standalone_css() if self.standalone_css is defined else 'base') + '.css') }}" />
     {% else %}
@@ -26,6 +27,7 @@
     {% endif %}
 
     <script defer src="{{ versioned_static('js/example-tools.js') }}"></script>
+    {% endif %}
   
   </head>
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -111,6 +111,10 @@ def _get_examples():
         # Remove "docs/examples/" and extension for the path
         example_path = os.path.splitext(template_path[examples_length:])[0]
 
+        # Ignore "combined" templates
+        if example_path.endswith("/combined"):
+            continue
+
         outermost_parent = example_path.split(os.sep).pop(0)
 
         title = example_path


### PR DESCRIPTION
This PR is based on the feature branch [percy-examples-combination](https://github.com/canonical/vanilla-framework/tree/percy-examples-combination)  which is composed of multiple smaller PRs. This can merge after all of the split PRs have been merged.

List of PRs & completion state: (WIP)

## Done

Combines many of our examples into single views so many examples can be screenshotted at once. Removed theme-specific examples where possible and started using query parameters to snapshot examples in each theme, increasing test coverage and decreasing snapshots usage from ~1.4k to ~650 per build.

Changed the Percy script so that it uses combined example scripts (following naming convention of `combined.html`. If a directory contains a `combined.html`, it is assumed that that `combined.html` includes the HTML of all other non-partial HTML files in the directory. These "combined" templates are not rendered in the [examples index](https://vanilla-framework-5117.demos.haus/docs/examples). Note that several templates were moved into directories so that this naming convention can work (i.e., `base/headings` directory contains `heading-` templates that were previously loosely contained in `base/`). 

Combined screenshots inherit the breakpoints of the examples they embed. I.E., if a combined example by itself would be snapshotted at [375, 1200] widths, but it embeds an example that is "responsive" (thus needing an additional snapshot at 800px), the combined example will be snapshotted at [375, 800, 1200] widths.

This also removes theme-specific example embeds from the documentation where possible. If we want the embedded examples to be themed, we can implement theme switching for the example embeds at a later date.

`redirects.yaml` was updated to redirect requests for old theme-specific examples to the non-theme specific example with the proper color theme query parameter populated, and to redirect requests for examples into the proper subdirectory where necessary.

Closes [WD-11673](https://warthogs.atlassian.net/browse/WD-11673)

### PR Snapshots count disclaimer
**This PR will cause a Percy build with MORE Percy snapshots, not less** - this is because `snapshots.js` has to be on the default branch to be used in the workflow action. This PR modifies `snapshots.js` to used combined HTML where possible, but this PR is still using the old version of `snapshots.js`. This means there is a snapshot for each example, including combined examples and each example within them.

[Here is an example](https://percy.io/bb49709b/test-vanilla-gha-migration/builds/34688902/changed/1896806411?browser=chrome&browser_ids=56&group_snapshots_by=similar_diff&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=1280&widths=375%2C800%2C1280) of the new Percy baseline after merging this PR (will be the first Percy build to use combined examples)

## QA

- Open [demo](https://vanilla-framework-5117.demos.haus/)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


[WD-11673]: https://warthogs.atlassian.net/browse/WD-11673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ