### PR TITLE
Fix aspect ratio in image container component on smaller screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.14.0",
+  "version": "4.14.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.14.1",
+  "version": "4.14.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -30,25 +30,33 @@
     display: grid;
     justify-content: center;
     text-align: center;
-    .p-image-container__image {
-      object-fit: contain;
-    }
     &.is-highlighted {
       background: $colors--theme--background-alt;
     }
   }
 
+  /*
+    To make images in aspect ratio containers responsive, we need to do a padding hack
+    This forces the image to respect aspect ratio on smaller screens
+    The calculation is (1 - (<smaller_dimension_aspect_ratio> / <larger_dimension_aspect_ratio>)) / 2
+    For tall aspect ratios (e.g. 2:3), the padding is applied to the top and bottom
+    For wide aspect ratios (e.g. 16:9), the padding is applied to the left and right
+   */
   .p-image-container--16-9 {
     aspect-ratio: 16/9;
+    padding: 0 21.875%;
   }
   .p-image-container--3-2 {
     aspect-ratio: 3/2;
+    padding: 0 16.667%;
   }
   .p-image-container--2-3 {
     aspect-ratio: 2/3;
+    padding: 16.667% 0;
   }
   .p-image-container--cinematic {
     aspect-ratio: 2.4/1;
+    padding: 0 29.166%;
   }
   .p-image-container--square {
     aspect-ratio: 1/1;

--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -23,6 +23,26 @@
 
 @import 'settings';
 
+/**
+    * Applies padding to maintain aspect ratio
+    * @param {number} $width - The width part of the aspect ratio. I.E., for 16/9, width is 16
+    * @param {number} $height - The height part of the aspect ratio. I.E., for 16/9, width is 9
+    * @see https://nikitahl.com/css-aspect-ratio#padding-hack for reference
+ */
+@mixin image_aspect_ratio_padding($width, $height) {
+  $smaller: min($width, $height);
+  $larger: max($width, $height);
+  $aspect_ratio_offset_padding: calc((1 - ($smaller / $larger)) / 2 * 100%);
+
+  @if $width >= $height {
+    // For wide images, apply padding to the sides
+    padding: 0 $aspect_ratio_offset_padding;
+  } @else {
+    // For tall images, apply padding to the top and bottom
+    padding: $aspect_ratio_offset_padding 0;
+  }
+}
+
 @mixin vf-p-image {
   .p-image-container,
   [class^='p-image-container--'] {
@@ -44,19 +64,19 @@
    */
   .p-image-container--16-9 {
     aspect-ratio: 16/9;
-    padding: 0 21.875%;
+    @include image_aspect_ratio_padding(16, 9);
   }
   .p-image-container--3-2 {
     aspect-ratio: 3/2;
-    padding: 0 16.667%;
+    @include image_aspect_ratio_padding(3, 2);
   }
   .p-image-container--2-3 {
     aspect-ratio: 2/3;
-    padding: 16.667% 0;
+    @include image_aspect_ratio_padding(2, 3);
   }
   .p-image-container--cinematic {
     aspect-ratio: 2.4/1;
-    padding: 0 29.166%;
+    @include image_aspect_ratio_padding(2.4, 1);
   }
   .p-image-container--square {
     aspect-ratio: 1/1;

--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -23,56 +23,38 @@
 
 @import 'settings';
 
-/**
-    * Applies padding to maintain aspect ratio
-    * To make images in aspect ratio containers responsive, we need to do a padding hack
-    * This forces the image to respect aspect ratio on smaller screens.
-    * However, this may force the image to reduce its size in cases where its size is close to an exact fit of its container.
-    * @param {number} $width - The width part of the aspect ratio. I.E., for 16/9, width is 16
-    * @param {number} $height - The height part of the aspect ratio. I.E., for 16/9, width is 9
-    * @see https://nikitahl.com/css-aspect-ratio#padding-hack for reference
- */
-@mixin image_aspect_ratio_padding($width, $height) {
-  $smaller: min($width, $height);
-  $larger: max($width, $height);
-  $aspect_ratio_offset_padding: calc((1 - ($smaller / $larger)) / 2 * 100%);
-
-  @if $width >= $height {
-    // For wide images, apply padding to the sides
-    padding: 0 $aspect_ratio_offset_padding;
-  } @else {
-    // For tall images, apply padding to the top and bottom
-    padding: $aspect_ratio_offset_padding 0;
-  }
-}
-
 @mixin vf-p-image {
   .p-image-container,
   [class^='p-image-container--'] {
     align-items: center;
-    display: grid;
+    display: flex;
     justify-content: center;
     text-align: center;
+
     &.is-highlighted {
       background: $colors--theme--background-alt;
+    }
+
+    .p-image-container__image {
+      // max height prevents the image from stretching the container
+      // when the aspect ratio is set, and object-fit ensures the aspect ratio
+      // of the image content is maintained
+      max-height: 100%;
+      object-fit: contain;
     }
   }
 
   .p-image-container--16-9 {
     aspect-ratio: 16/9;
-    @include image_aspect_ratio_padding(16, 9);
   }
   .p-image-container--3-2 {
     aspect-ratio: 3/2;
-    @include image_aspect_ratio_padding(3, 2);
   }
   .p-image-container--2-3 {
     aspect-ratio: 2/3;
-    @include image_aspect_ratio_padding(2, 3);
   }
   .p-image-container--cinematic {
     aspect-ratio: 2.4/1;
-    @include image_aspect_ratio_padding(2.4, 1);
   }
   .p-image-container--square {
     aspect-ratio: 1/1;

--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -25,6 +25,9 @@
 
 /**
     * Applies padding to maintain aspect ratio
+    * To make images in aspect ratio containers responsive, we need to do a padding hack
+    * This forces the image to respect aspect ratio on smaller screens.
+    * However, this may force the image to reduce its size in cases where its size is close to an exact fit of its container.
     * @param {number} $width - The width part of the aspect ratio. I.E., for 16/9, width is 16
     * @param {number} $height - The height part of the aspect ratio. I.E., for 16/9, width is 9
     * @see https://nikitahl.com/css-aspect-ratio#padding-hack for reference
@@ -55,13 +58,6 @@
     }
   }
 
-  /*
-    To make images in aspect ratio containers responsive, we need to do a padding hack
-    This forces the image to respect aspect ratio on smaller screens
-    The calculation is (1 - (<smaller_dimension_aspect_ratio> / <larger_dimension_aspect_ratio>)) / 2
-    For tall aspect ratios (e.g. 2:3), the padding is applied to the top and bottom
-    For wide aspect ratios (e.g. 16:9), the padding is applied to the left and right
-   */
   .p-image-container--16-9 {
     aspect-ratio: 16/9;
     @include image_aspect_ratio_padding(16, 9);

--- a/templates/docs/examples/patterns/image/container/aspect-ratio/all.html
+++ b/templates/docs/examples/patterns/image/container/aspect-ratio/all.html
@@ -11,6 +11,12 @@
     </div>
   </div>
   <div>
+    <span>16:9 (with 16:9 image)</span>
+    <div class="p-image-container--16-9 is-highlighted">
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/7c9867c1-16x9.png" width="1200" alt="">
+    </div>
+  </div>
+  <div>
     <span>3:2</span>
     <div class="p-image-container--3-2 is-highlighted">
       <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
@@ -20,6 +26,12 @@
     <span>2:3</span>
     <div class="p-image-container--2-3 is-highlighted">
       <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </div>
+  <div>
+    <span>2:3 (with 2:3 image)</span>
+    <div class="p-image-container--2-3 is-highlighted">
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/e97cdac9-2x3.png" width="1200" alt="">
     </div>
   </div>
   <div>


### PR DESCRIPTION
## Done

Fixes image container aspect ratio not being respected on smaller displays.

Fixes #5159 

## QA

- Open [demo](https://vanilla-framework-5179.demos.haus/docs/examples/patterns/image/container/aspect-ratio/all)
- Verify that all images are the correct aspect ratio in all breakpoints.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
![image](https://github.com/canonical/vanilla-framework/assets/46915153/e0298641-2d65-450b-850a-3d41d86ba283)

