### PR TITLE
fix Percy workflows not running correctly in multi-label case

### DIFF
--- a/.github/workflows/pr-percy-prepare-label.yml
+++ b/.github/workflows/pr-percy-prepare-label.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   copy_artifact:
     name: Copy changed files to GHA artifact
-    if: contains(github.event.pull_request.labels.*.name, vars.PERCY_TEST_REQUESTED_LABEL_NAME)
+    if: "contains(toJson(github.event.pull_request.labels.*.name), 'Review: Percy needed')"
     uses: ./.github/workflows/percy-prepare.yml
     with:
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/pr-percy-prepare-push.yml
+++ b/.github/workflows/pr-percy-prepare-push.yml
@@ -17,7 +17,7 @@ jobs:
     name: Copy changed files to GHA artifact
     # Ignore draft PRS and PRs with the Percy label
     # If we run tests against PRs with the Percy label, we will run tests twice (test is also ran by the labelling workflow)
-    if: ${{ !github.event.pull_request.draft && !contains(github.event.pull_request.labels.*.name, vars.PERCY_TEST_REQUESTED_LABEL_NAME) }}
+    if: "!github.event.pull_request.draft && !contains(toJson(github.event.pull_request.labels.*.name), 'Review: Percy needed')"
     uses: ./.github/workflows/percy-prepare.yml
     with:
       pr_number: ${{ github.event.number }}


### PR DESCRIPTION
## Done

Fixes Percy tests [not being run properly against](https://github.com/canonical/vanilla-framework/actions/runs/9648272740/job/26609053207?pr=5185) PRs with multiple labels.

The array of label names was being converted to "Array" and my if checks were failing. I quoted the conditionals on the jobs, converted them to JSON, and also removed the dependence on a repo variable for the label name.

## QA

- Review comments / action runs on test PR: https://github.com/jmuzina/vanilla-framework/pull/23
- Verify labeled workflow was run against this PR while it had the Percy needed label: https://github.com/canonical/vanilla-framework/actions/runs/9650404273

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).