### PR TITLE
Fix Percy tests being queued against PRs with Percy label when the ne…

### DIFF
--- a/.github/workflows/pr-percy-prepare-label.yml
+++ b/.github/workflows/pr-percy-prepare-label.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   copy_artifact:
     name: Copy changed files to GHA artifact
-    if: "contains(toJson(github.event.pull_request.labels.*.name), 'Review: Percy needed')"
+    if: "(github.event.action == 'synchronize' && contains(toJson(github.event.pull_request.labels.*.name), 'Review: Percy needed')) || (github.event.action == 'labeled' && github.event.label.name == 'Review: Percy needed')"
     uses: ./.github/workflows/percy-prepare.yml
     with:
       pr_number: ${{ github.event.number }}


### PR DESCRIPTION
Fixes Percy tests being triggered against PRs that have the Percy label on label events when the label that was just applied is not the Percy needed label.

The logic has been refined as such:

- If the trigger was a PR synchronization (push to a live PR), Percy is run if the PR has the Percy needed label.
- If the trigger was a label being added to the PR, Percy is run if the new label is the Percy needed label.

## QA

- Review [QA PR](https://github.com/jmuzina/vanilla-framework/pull/26); its comments demonstrate all use cases covered by this change
- Verify the actions YAML code for the if conditional in the QA PR is identical to the proposed code for this PR, with the exception of the echo job that is used for QA output.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

