### PR TITLE
Fix standalone logo section scss

### DIFF
--- a/scss/standalone/patterns_logo-section.scss
+++ b/scss/standalone/patterns_logo-section.scss
@@ -2,3 +2,9 @@
 @include vf-base;
 
 @include vf-p-logo-section;
+
+// Used to keep the background dark on the dark logo section
+@include vf-p-strip;
+
+// Needed for .u-fixed-width
+@include vf-u-layout;


### PR DESCRIPTION
## Done

In #5164 , we made the dark logo section example use a `.p-strip .is-dark` to ensure its background is always dark. We did not add the strip to the logo-section's standalone styles, causing this in the standalone view:

![image](https://github.com/canonical/vanilla-framework/assets/46915153/875641e1-0084-4807-a44e-5f9218057cfe)

As a drive-by, I also added `vf-u-layout` to the standalone styles, as the logo section examples use `.u-fixed-width` which is exported there. This causes the logo section to have the wrong width, even on current `main`:

![image](https://github.com/canonical/vanilla-framework/assets/46915153/b25d7ef4-7dd6-4035-bc12-5541292ca651)

## QA

- Verify dark logo section appears the same on [standalone](https://vanilla-framework-5193.demos.haus/docs/examples/standalone/patterns/logo-section/logo-section-dark) and [non-standalone](https://vanilla-framework-5193.demos.haus/docs/examples/patterns/logo-section/logo-section-dark) views


## Screenshots
![image](https://github.com/canonical/vanilla-framework/assets/46915153/662ed079-8170-46fb-a3ff-aae400d9b69c)

