### PR TITLE
wip: feat: CTA Block

### DIFF
--- a/scss/_patterns_cta.scss
+++ b/scss/_patterns_cta.scss
@@ -1,0 +1,12 @@
+@import 'settings';
+
+@mixin vf-p-cta {
+  .p-cta-block {
+    // same as %section-padding--shallow
+    padding-bottom: $spv--x-large;
+  }
+
+  .p-cta-block > .p-cta-block__content > .p-cta-block__link {
+    display: inline-block;
+  }
+}

--- a/scss/_vanilla.scss
+++ b/scss/_vanilla.scss
@@ -11,6 +11,7 @@
 @import 'patterns_chip';
 @import 'patterns_code-snippet';
 @import 'patterns_contextual-menu';
+@import 'patterns_cta';
 @import 'patterns_divider';
 @import 'patterns_equal-height-row';
 @import 'patterns_form-help-text';
@@ -103,6 +104,7 @@
   @include vf-p-chip;
   @include vf-p-code-snippet;
   @include vf-p-contextual-menu;
+  @include vf-p-cta;
   @include vf-p-divider;
   @include vf-p-equal-height-row;
   @include vf-p-form-help-text;

--- a/scss/standalone/patterns_cta.scss
+++ b/scss/standalone/patterns_cta.scss
@@ -1,0 +1,5 @@
+@import '../vanilla';
+@include vf-base;
+
+@include vf-p-cta;
+@include vf-p-buttons;

--- a/templates/docs/examples/patterns/cta/block/default.html
+++ b/templates/docs/examples/patterns/cta/block/default.html
@@ -1,0 +1,14 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}CTA Block / Default{% endblock %}
+
+{% block standalone_css %}patterns_cta{% endblock %}
+
+{% block content %}
+    <div class="p-cta-block">
+        <hr>
+        <div class="p-cta-block__content">
+            <button class="p-button--positive">Learn more</button>
+            <a class="p-cta-block__link" href="#">Contact us ›</a>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Done

Creates CTA block component. This will be used in many of our future "higher order components".  The need for a separately styled CTA block component arose from [this comment in the Hero PR](https://github.com/canonical/vanilla-framework/pull/5189#issuecomment-2192064590) and [MM message](https://chat.canonical.com/canonical/pl/r751p3rjytftueca4767nk6o6e).

This PR is currently very small (minimal examples, has no release notes, etc.) to create a discussion amongst the team about what is needed here.

See [Figma](https://www.figma.com/design/Hll6ZRvHyTTGBZZSoRd8ei/Higher-order-components-(HOCs)?node-id=987-10988&m=dev)

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![image](https://github.com/canonical/vanilla-framework/assets/46915153/edf4ece1-ac38-401a-bc90-c7f9f38a99a8)
![image](https://github.com/canonical/vanilla-framework/assets/46915153/aa15f294-3691-426d-8463-425951c7ae86)
