### PR TITLE
Update alt background in paper theme

### DIFF
--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -403,7 +403,7 @@ $colors--theme--button-negative-text: var(--vf-color-button-negative-text);
 
   // SCSS variables need to be interpolated to work in CSS custom properties
   --vf-color-background-default: #{$color-paper};
-  --vf-color-background-alt: #{$color-x-light};
+  --vf-color-background-alt: #{#ebebeb};
 
   --vf-color-background-inputs: #{$colors--paper-theme--background-inputs};
   --vf-color-background-active: #{$colors--paper-theme--background-active};


### PR DESCRIPTION
## Done

Update alt background in paper theme from white to `#EBEBEB` (to be darker than default) 

Fixes #5197

## QA

- Open [demo](https://vanilla-framework-5198.demos.haus/docs/examples/patterns/image/container/highlighted?theme=paper)
- Make sure that the highlighted colour on paper theme is correct
- Check other affected components:
  - https://vanilla-framework-5198.demos.haus/docs/examples/patterns/strips/highlighted


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="781" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/87829fa4-3846-49eb-8037-58a7661e488f">

