### PR TITLE
Add cover option to image container component

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -4,6 +4,10 @@
       url: /docs/patterns/links#anchor-link
       status: New
       notes: We've introduced a new class <code>.p-link--anchor-heading</code> to style anchor links in headings.
+    - component: Image container / Cover
+      url: /docs/patterns/images#cover-image
+      status: New
+      notes: We've added a new cover variant to the image container component via <code>is-cover</code> class to support having images cover the container with predefined aspect ratio.
 - version: 4.13.0
   features:
     - component: Image container

--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -42,6 +42,14 @@
       max-height: 100%;
       object-fit: contain;
     }
+
+    &.is-cover {
+      .p-image-container__image {
+        height: 100%;
+        object-fit: cover;
+        width: 100%;
+      }
+    }
   }
 
   .p-image-container--16-9 {

--- a/templates/docs/examples/patterns/image/combined.html
+++ b/templates/docs/examples/patterns/image/combined.html
@@ -10,6 +10,7 @@
 <section>{% include 'docs/examples/patterns/image/shadowed.html' %}</section>
 <section>{% include 'docs/examples/patterns/image/spacing.html' %}</section>
 <section>{% include 'docs/examples/patterns/image/container/highlighted.html' %}</section>
+<section>{% include 'docs/examples/patterns/image/container/cover.html' %}</section>
 <section>{% include 'docs/examples/patterns/image/container/aspect-ratio/all.html' %}</section>
 {% endwith %}
 {% endblock %}

--- a/templates/docs/examples/patterns/image/container/cover.html
+++ b/templates/docs/examples/patterns/image/container/cover.html
@@ -1,0 +1,10 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Image Container / Cover{% endblock %}
+
+{% block standalone_css %}patterns_image{% endblock %}
+
+{% block content %}
+<div class="p-image-container--16-9 is-cover">
+  <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/44095efb-photo-1580536793208-117fdb20ffc1%20(1).jpeg" alt="" width="1000">
+</div>
+{% endblock %}

--- a/templates/docs/patterns/images.md
+++ b/templates/docs/patterns/images.md
@@ -29,6 +29,14 @@ See the [class references section](#class-reference) for more information on the
 View example of image container with 16/9 aspect ratio
 </a></div>
 
+## Cover image
+
+Cover images are used to fill the entire container, cropping the image if necessary. This can be combined with the aspect ratio modifier to crop the image to a specific aspect ratio.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/image/container/cover" class="js-example">
+View example of cover image
+</a></div>
+
 ## Image with border
 
 <div class="p-notification--caution">


### PR DESCRIPTION
## Done

Adds image cover option to image container component, using `is-cover` modifier class.

Fixes [WD-12281](https://warthogs.atlassian.net/browse/WD-12281)

## QA

- Open [demo](https://vanilla-framework-5199.demos.haus/docs/examples/patterns/image/container/cover?theme=light)
- Check if the image covers the container
- Change the container class to some other aspect ratio, such as `p-image-container--3-2` or `p-image-container--square`, verify that image adapts correctly (and still covers the container)
- Review updated documentation:
  - https://vanilla-framework-5199.demos.haus/docs/patterns/images#cover-image

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="902" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/eb0d1d7e-d272-464b-bc31-748e281f5da8">



[WD-12281]: https://warthogs.atlassian.net/browse/WD-12281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ