### PR TITLE
Percy Error Logging Improvement

### DIFF
--- a/.github/actions/percy-snapshot/action.yml
+++ b/.github/actions/percy-snapshot/action.yml
@@ -87,13 +87,12 @@ runs:
         # If PR number is set & a Percy-GHA integration is set up, this allows Percy to set status on the PR
         PERCY_PULL_REQUEST: ${{ inputs.pr_number }}
       run: |
-        set -e
-        # Start a percy build and capture the stdout
-
         # Start a percy build and capture the stdout and stderr
-        percy_output=$(yarn percy 2>&1)
-        
-        echo "$percy_output"
+        percy_output=$(
+          {
+            yarn percy 2>&1
+          } | tee /dev/stderr
+        )
         
         # Fail if the Percy stdout contains "Build not created"
         if echo "$percy_output" | grep -q "Build not created"; then
@@ -105,6 +104,8 @@ runs:
         
         # Extract the build link from the stdout of the snapshot command
         build_link=$(echo "$percy_output" | sed -n 's/.*Finalized build #.*: \(https:\/\/percy.io\/[^ ]*\).*/\1/p')
+        # Sanitize the build link to remove any newlines or spaces
+        build_link=$(echo "$build_link" | tr -d '\n' | tr -d ' ')
         
         # Using '/' to split the $build_link, extract the organization and build identifiers
         org_id=$(echo "$build_link" | cut -d '/' -f 4)

--- a/snapshots.js
+++ b/snapshots.js
@@ -32,8 +32,12 @@ async function getExampleFiles(dir = EXAMPLES_RELATIVE_DIR) {
         // Get examples from the subdirectory
         files.push(...(await getExampleFiles(path.join(dir, entry.name))));
       }
+      // Ignore partials, non-HTML files, & the examples index
     } else if (entry.isFile() && entry.name.endsWith('.html') && !entry.name.startsWith('_')) {
-      // Ignore partials & non-HTML files
+      if ((dir === EXAMPLES_RELATIVE_DIR && entry.name === 'index.html') || entry.name === 'standalone.html') {
+        // Ignore the examples index
+        continue;
+      }
       files.push(path.join(dir, entry.name));
     }
   }
@@ -50,9 +54,7 @@ async function getExampleFiles(dir = EXAMPLES_RELATIVE_DIR) {
 function getExampleUrlsFromExamplePaths(urlPaths) {
   // add standalone versions of the examples in base and patterns folders
   const standaloneUrls = urlPaths.filter((file) => file.startsWith('base/') || file.startsWith('patterns/')).map((file) => path.join('standalone', file));
-
   urlPaths = urlPaths.concat(standaloneUrls);
-
   // map the file paths to URLs
   return urlPaths.map((url) => {
     url = url.replace('.html', '');


### PR DESCRIPTION
## Done

Improves error logging of the Percy snapshots action

Fixes [MM thread](https://chat.canonical.com/canonical/pl/5ixu487xjpgduntgmzxyohipaw)

As a drive-by, fixes [snapshots being taken of the examples index page](https://chat.canonical.com/canonical/pl/fjfpwwkph3f6ukme4nytmjym4w). This removes 8 snapshots from the Percy tests:

- `docs/examples/index` (in all themes, in mobile & desktop breakpoints) (4 snapshots)
- `docs/examples/standalone` (in all themes, in mobile & desktop breakpoints) (4 snapshots)

## QA

- Review [failing Percy workflow](https://github.com/jmuzina/vanilla-framework/actions/runs/9746570483/job/26897246078); verify you can see the Percy command output
- Review [passing Percy workflow](https://github.com/jmuzina/vanilla-framework/actions/runs/9746567016); verify you can see the Percy command output, and the link to the created build is correct.
- Checkout this repo and run the following command: 
```
node -p "const fs=require('fs'),snapshots=require('./snapshots');(async()=>{try{const urls=await snapshots(),numSnapshots=urls.reduce((acc,url)=>acc+url.widths.length,0),data=JSON.stringify({numSnapshots,urls},null,4);fs.writeFileSync('percy_urls_report.json',data);console.log(`Exported ${numSnapshots} snapshots to percy_urls_report.json`)}catch(err){console.error('Error exporting snapshots:',err)}})()"
```
- Open `percy_urls_report.json` and verify that no matches are found for any of the following:
  -  `/docs/examples/standalone/"`
  - `/docs/examples/index/`

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
