### PR TITLE
Styling updates for reduced navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.14.0",
+  "version": "4.14.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -21,6 +21,10 @@
   @include vf-themed-icon($light-value: vf-icon-chevron-url($colors--light-theme--icon), $dark-value: vf-icon-chevron-url($colors--dark-theme--icon));
 }
 
+@mixin vf-icon-chevron-muted {
+  @include vf-themed-icon($light-value: vf-icon-chevron-url($colors--light-theme--text-muted), $dark-value: vf-icon-chevron-url($colors--dark-theme--text-muted));
+}
+
 // anchor
 @function vf-icon-anchor-url($color) {
   @return url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8 1a2.5 2.5 0 01.75 4.885v1.068h2.27v1.5H8.75v5.022c2.438-.161 4.172-1.077 4.172-1.669h1.5C14.422 13.57 11.547 15 8 15c-3.547 0-6.422-1.43-6.422-3.194h1.5c0 .592 1.734 1.508 4.172 1.67V8.452H4.904v-1.5H7.25V5.886A2.501 2.501 0 018 1zm0 1.5a1 1 0 100 2 1 1 0 000-2z' fill='#{vf-url-friendly-color($color)}' fill-rule='nonzero'/%3E%3C/svg%3E");
@@ -267,6 +271,10 @@
 
 @mixin vf-icon-search-themed {
   @include vf-themed-icon($light-value: vf-icon-search-url($colors--light-theme--icon), $dark-value: vf-icon-search-url($colors--dark-theme--icon));
+}
+
+@mixin vf-icon-search-muted {
+  @include vf-themed-icon($light-value: vf-icon-search-url($colors--light-theme--text-muted), $dark-value: vf-icon-search-url($colors--dark-theme--text-muted));
 }
 
 // success

--- a/scss/_patterns_navigation-reduced.scss
+++ b/scss/_patterns_navigation-reduced.scss
@@ -7,10 +7,6 @@
 
     // orange logo tag is hidden in reduced navigation
     .p-navigation__tagged-logo {
-      .p-navigation__link {
-        padding-left: 0;
-      }
-
       .p-navigation__logo-tag {
         display: none;
       }

--- a/scss/_patterns_navigation-reduced.scss
+++ b/scss/_patterns_navigation-reduced.scss
@@ -36,12 +36,27 @@
 
       .p-navigation__item--dropdown-toggle .p-navigation__link {
         &::after {
+          @include vf-icon-chevron-muted;
           top: $spv--small;
         }
       }
 
       .p-navigation__item--dropdown-toggle.is-active {
         background-color: $colors--theme--background-default;
+
+        .p-navigation__link {
+          color: $colors--theme--text-default;
+        }
+
+        .p-navigation__link::after {
+          @include vf-icon-chevron-themed;
+        }
+      }
+
+      .p-navigation__link--search-toggle {
+        &::after {
+          @include vf-icon-search-muted;
+        }
       }
     }
 


### PR DESCRIPTION
## Done

Visual adjustments for reduced navigation:
- shifting Canonical logo to make it aligned with logo text below it and with nav items on mobile
- updateing icon colours to use muted colour in reduced nav on desktop

Fixes https://warthogs.atlassian.net/browse/WD-12921
Fixes https://warthogs.atlassian.net/browse/WD-12922

## QA

- Open [demo](https://vanilla-framework-5206.demos.haus/docs/examples/patterns/navigation/reduced?theme=light)
- Make sure that chevron and search icons are the same colour as text it top reduced navigation bar
- Make sure "Canonical Ubuntu" logo text is aligned with Ubuntu text below
- On small screen open the top "Menu", make sure "Canonical Ubuntu" is aligned with menu items

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)


## Screenshots

<img width="1314" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/4f743361-d4a8-4407-a016-e33048f30185">

<img width="447" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/fcae36a6-2757-449c-990c-ca6d2164dda5">


