### PR TITLE
Add `is-cover` to image container class reference

### DIFF
--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -4,6 +4,8 @@
     Image container:
       .p-image-container:
         Main element of the image component.
+      "&.is-cover":
+        Cover variant, to be used to set the `.p-image-container__image` within to cover the container.
       "&.is-highlighted":
         Highlighted variant, to be used to highlight contents.
       .p-image-container--16-9:


### PR DESCRIPTION
## Done

#5199 added the `is-cover` variant of `p-image-container` but did not add it to the class reference table. This is a small PR to add `is-cover` to the class reference list.

## QA

- Open [image container class reference docs](https://vanilla-framework-5207.demos.haus/docs/patterns/images#class-reference) and verify they are correct (`.is-cover` added correctly)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![image](https://github.com/canonical/vanilla-framework/assets/46915153/25feb91e-e144-4eb3-8820-25baca08500d)
