### PR TITLE
Align logo in reduced nav with the grid

### DIFF
--- a/scss/_patterns_navigation-reduced.scss
+++ b/scss/_patterns_navigation-reduced.scss
@@ -13,6 +13,13 @@
       .p-navigation__logo-tag {
         display: none;
       }
+
+      @media (min-width: $breakpoint-navigation-threshold) {
+        // on large screens align the logo with the grid start
+        .p-navigation__link {
+          padding-left: 0;
+        }
+      }
     }
 
     // reduced nav logo text uses default font size (on small screens)


### PR DESCRIPTION
## Done

Aligns Canonical logo in reduced navigation with the grid.

## QA

- Open [demo](https://vanilla-framework-5215.demos.haus/docs/examples/patterns/navigation/reduced?theme=light)
- Make sure "Canonical" in top reduced navigation is aligned with left side of the page/grid on desktop view
- Make sure "Canonical" is shifted to be aligned with "Ubuntu" logo text and navigation menu items on small screens


## Screenshots

<img width="1277" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/48c3ad18-6853-4e73-a49d-46afe8a5a789">

<img width="440" alt="image" src="https://github.com/canonical/vanilla-framework/assets/83575/273afcf1-738c-41fe-8154-8a2c1dc08808">

