### PR TITLE
Correct theme usage on Side Navigation example

### DIFF
--- a/templates/docs/examples/patterns/side-navigation/_icons.html
+++ b/templates/docs/examples/patterns/side-navigation/_icons.html
@@ -5,11 +5,7 @@
 
   <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer-icons"></div>
 
-  {% if is_dark %}
-  <!-- dark background color should be changed via color theme variables, inline style is used here for example purposes -->
-  {% endif %}
-  <nav class="p-side-navigation__drawer" aria-label="Example side navigation with icons"
-    style="{% if is_dark %}background: #003b4e;{% elif not is_paper %}background: #f7f7f7{% endif %}">
+  <nav class="p-side-navigation__drawer" aria-label="Example side navigation with icons">
     <div class="p-side-navigation__drawer-header">
       <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer-icons">
         Toggle side navigation
@@ -19,16 +15,16 @@
     <h3 class="p-side-navigation__heading">Group heading</h3>
     <ul class="p-side-navigation__list">
       <li class="p-side-navigation__item">
-        <a class="p-side-navigation__link" href="#"><i class="p-icon--information {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level link</a>
+        <a class="p-side-navigation__link" href="#"><i class="p-icon--information p-side-navigation__icon"></i>First level link</a>
       </li>
       <li class="p-side-navigation__item">
-        <a class="p-side-navigation__link" href="#"><i class="p-icon--help {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level link with status<div class="p-side-navigation__status"><i class="p-icon--error {% if is_dark %}is-light{% endif %}"></i></div></a>
+        <a class="p-side-navigation__link" href="#"><i class="p-icon--help p-side-navigation__icon"></i>First level link with status<div class="p-side-navigation__status"><i class="p-icon--error"></i></div></a>
       </li>
       <li class="p-side-navigation__item">
-        <a class="p-side-navigation__link" href="#"><i class="p-icon--user {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>Link with children</a>
+        <a class="p-side-navigation__link" href="#"><i class="p-icon--user p-side-navigation__icon"></i>Link with children</a>
         <ul class="p-side-navigation__list">
           <li class="p-side-navigation__item">
-            <a class="p-side-navigation__link" href="#">Second level link<div class="p-side-navigation__status"><i class="p-icon--warning {% if is_dark %}is-light{% endif %}"></i></div></a>
+            <a class="p-side-navigation__link" href="#">Second level link<div class="p-side-navigation__status"><i class="p-icon--warning"></i></div></a>
           </li>
           <li class="p-side-navigation__item">
             <span class="p-side-navigation__text">Second level text</span>
@@ -48,7 +44,7 @@
                 <a class="p-side-navigation__link" aria-current="page" href="#">Third level active link</a>
               </li>
               <li class="p-side-navigation__item">
-                <a class="p-side-navigation__link" href="#">Third level link with status<div class="p-side-navigation__status"><i class="p-icon--success {% if is_dark %}is-light{% endif %}"></i></div></a>
+                <a class="p-side-navigation__link" href="#">Third level link with status<div class="p-side-navigation__status"><i class="p-icon--success"></i></div></a>
               </li>
             </ul>
           </li>
@@ -66,7 +62,7 @@
         </ul>
       </li>
       <li class="p-side-navigation__item">
-        <span class="p-side-navigation__text"><i class="p-icon--collapse {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level item that is not a link</span>
+        <span class="p-side-navigation__text"><i class="p-icon--collapse p-side-navigation__icon"></i>First level item that is not a link</span>
       </li>
       <li class="p-side-navigation__item">
         <a class="p-side-navigation__link" href="#">First level link with a label<div class="p-side-navigation__status">
@@ -74,7 +70,7 @@
         </div></a>
       </li>
       <li class="p-side-navigation__item">
-        <a class="p-side-navigation__link" href="#"><i class="p-icon--search {% if is_dark %}is-light{% endif %} p-side-navigation__icon"></i>First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status">
+        <a class="p-side-navigation__link" href="#"><i class="p-icon--search p-side-navigation__icon"></i>First level link with a label is long and wraps wraps wraps wraps wraps wraps<div class="p-side-navigation__status">
           <span class="p-status-label--information">Updated</span>
         </div></a>
       </li>


### PR DESCRIPTION
## Done

- Remove hard-coded theme flag variable from Side Navigation example, so that theme colors work properly

Fixes #5209 

## QA

- Open [Side Navigation example](https://vanilla-framework-5216.demos.haus/docs/examples/patterns/side-navigation/default?theme=light)
- Switch to each theme
- Witness correct color usage on backgrounds, text, and icons

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [X] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [X] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [X] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
