### PR TITLE
Add new theme variable for Positive Button focus state

### DIFF
--- a/scss/_patterns_buttons.scss
+++ b/scss/_patterns_buttons.scss
@@ -80,7 +80,7 @@
       $button-disabled-border-color: $colors--theme--button-positive-default,
       $button-text-color: $colors--theme--button-positive-text
     );
-    @include vf-focus($color-focus-positive);
+    @include vf-focus($colors--theme--positive-focus);
   }
 }
 

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -39,9 +39,9 @@ $color-link-visited-dark: #a679d2 !default;
 $color-focus-dark: #9cf !default;
 
 // Focus modifications to meet AA 3:1 contrast ratio against
-// button background for positive/negative buttons
+// button background for positive buttons
 $color-focus-positive: #003008 !default;
-$color-focus-negative: #3b0006 !default;
+$color-focus-positive-dark: #9cf !default;
 
 // Button background color changes
 $input-background-opacity-amount: 0.04;
@@ -93,6 +93,7 @@ $states: (
 // --link-default    - default link color
 // --link-visited    - visited link color
 // --focus           - focus highlight/outline color
+// --positive-focus  - focus highlight/outline color for positive buttons
 //
 // Background colors:
 // --background           - default background color
@@ -114,6 +115,7 @@ $colors--light-theme--text-inactive: rgba($color-x-dark, $inactive-text-opacity-
 $colors--light-theme--link-default: $color-link !default;
 $colors--light-theme--link-visited: $color-link-visited !default;
 $colors--light-theme--focus: $color-focus !default;
+$colors--light-theme--positive-focus: $color-focus-positive !default;
 
 $colors--light-theme--background-default: #fff !default;
 $colors--light-theme--background-alt: #f7f7f7 !default;
@@ -174,6 +176,7 @@ $colors--dark-theme--text-inactive: rgba($colors--dark-theme--text-default, $ina
 $colors--dark-theme--link-default: $color-link-dark !default;
 $colors--dark-theme--link-visited: $color-link-visited-dark !default;
 $colors--dark-theme--focus: $color-focus-dark !default;
+$colors--dark-theme--positive-focus: $color-focus-positive-dark !default;
 
 $colors--dark-theme--background-default: #262626 !default;
 $colors--dark-theme--background-alt: #202020 !default;
@@ -241,6 +244,7 @@ $colors--theme--text-inactive: var(--vf-color-text-inactive);
 $colors--theme--link-default: var(--vf-color-link-default);
 $colors--theme--link-visited: var(--vf-color-link-visited);
 $colors--theme--focus: var(--vf-color-focus);
+$colors--theme--positive-focus: var(--vf-color-positive-focus);
 
 $colors--theme--background-default: var(--vf-color-background-default);
 $colors--theme--background-alt: var(--vf-color-background-alt);
@@ -296,6 +300,7 @@ $colors--theme--button-negative-text: var(--vf-color-button-negative-text);
   --vf-color-link-default: #{$colors--light-theme--link-default};
   --vf-color-link-visited: #{$colors--light-theme--link-visited};
   --vf-color-focus: #{$colors--light-theme--focus};
+  --vf-color-positive-focus: #{$colors--light-theme--positive-focus};
 
   --vf-color-background-default: #{$colors--light-theme--background-default};
   --vf-color-background-alt: #{$colors--light-theme--background-alt};
@@ -351,6 +356,7 @@ $colors--theme--button-negative-text: var(--vf-color-button-negative-text);
   --vf-color-link-default: #{$colors--dark-theme--link-default};
   --vf-color-link-visited: #{$colors--dark-theme--link-visited};
   --vf-color-focus: #{$colors--dark-theme--focus};
+  --vf-color-positive-focus: #{$colors--dark-theme--positive-focus};
 
   --vf-color-background-default: #{$colors--dark-theme--background-default};
   --vf-color-background-alt: #{$colors--dark-theme--background-alt};


### PR DESCRIPTION
## Done

- Add new theme color variable for positive button focus state, which combines the existing black color on light mode with the light blue color used for focus on other elements on dark mode

Fixes #5194 

## QA

- Open [Positive Button demo](https://vanilla-framework-5217.demos.haus/docs/examples/patterns/buttons/positive?theme=dark)
- Switch through themes and tab through buttons to witness focus state color
- Verify focus state color appears as expected on all themes

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [X] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [X] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [X] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

![image](https://github.com/user-attachments/assets/b56e18f4-2d85-40f9-b551-28e42516cb87)

![image](https://github.com/user-attachments/assets/6a1f53ae-c015-49a7-bd18-51745adbaf04)
