### PR TITLE
Convert Equal Height component's 6-col subgrid to 4-col subgrid on medium screens

### DIFF
--- a/scss/_patterns_equal-height-row.scss
+++ b/scss/_patterns_equal-height-row.scss
@@ -5,6 +5,17 @@
     @extend %vf-row;
     position: relative;
 
+    // Required to override styles in %vf-row
+    @supports (display: grid) {
+      grid-gap: 0 map-get($grid-gutter-widths, small);
+      grid-template-columns: repeat($grid-columns-small, minmax(0, 1fr));
+
+      @media (min-width: $threshold-6-12-col) {
+        grid-gap: 0 map-get($grid-gutter-widths, default);
+        grid-template-columns: repeat($grid-columns, minmax(0, 1fr));
+      }
+    }
+
     .p-equal-height-row__col {
       // smaller screens each column will have border top by default
       border-top-color: $colors--theme--border-low-contrast;
@@ -19,12 +30,11 @@
       position: relative;
 
       @media screen and ($breakpoint-small <= width < $breakpoint-large) {
-        grid-column: span $grid-columns-medium;
         grid-template-columns: subgrid;
 
-        // for medium screen, each column item will take half of the available cols from the parent grid
+        // each column item will take half of the available cols from the parent grid
         .p-equal-height-row__item {
-          grid-column: span calc($grid-columns-medium / 2);
+          grid-column: span calc($grid-columns-small / ($grid-columns-small / 2));
         }
 
         // for medium screen, position the first column item on the left of the grid
@@ -33,6 +43,7 @@
         }
       }
 
+      // each column item will take half of the available cols from the parent grid
       @media screen and (width >= $breakpoint-large) {
         border: none;
         grid-column: span calc($grid-columns / 4);
@@ -94,10 +105,6 @@
   .row > .col-9 {
     & .p-equal-height-row {
       grid-template-columns: repeat($grid-columns-small, minmax(0, 1fr));
-
-      @media screen and ($breakpoint-small <= width < $breakpoint-large) {
-        grid-template-columns: repeat($grid-columns-medium, minmax(0, 1fr));
-      }
 
       @media screen and (width >= $breakpoint-large) {
         grid-template-columns: repeat(9, minmax(0, 1fr));

--- a/scss/_patterns_equal-height-row.scss
+++ b/scss/_patterns_equal-height-row.scss
@@ -34,7 +34,7 @@
 
         // each column item will take half of the available cols from the parent grid
         .p-equal-height-row__item {
-          grid-column: span calc($grid-columns-small / ($grid-columns-small / 2));
+          grid-column: span calc($grid-columns-small / 2);
         }
 
         // for medium screen, position the first column item on the left of the grid


### PR DESCRIPTION
## Done

- Convert Equal Height component's 6-col subgrid to 4-col subgrid on medium screens

Fixes #5190 

## QA

- Open [3-column row](https://vanilla-framework-5218.demos.haus/docs/examples/patterns/equal-height-row/3-column-row?theme=light), [4 items per column](https://vanilla-framework-5218.demos.haus/docs/examples/patterns/equal-height-row/4-items-per-column?theme=light), and [default](https://vanilla-framework-5218.demos.haus/docs/examples/patterns/equal-height-row/default?theme=light) demos
- Resize window and view component at each screen size
- Ensure grid units look as expected
- Use DevTools to confirm subgrids take up 4 columns on small and medium screens

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
