### PR TITLE
Fix Intermittent Percy Snapshot Timeouts

### DIFF
--- a/.github/actions/percy-snapshot/action.yml
+++ b/.github/actions/percy-snapshot/action.yml
@@ -86,6 +86,7 @@ runs:
         PERCY_CLIENT_ERROR_LOGS: false
         # If PR number is set & a Percy-GHA integration is set up, this allows Percy to set status on the PR
         PERCY_PULL_REQUEST: ${{ inputs.pr_number }}
+        PERCY_PAGE_LOAD_TIMEOUT: 120000
       run: |
         # Start a percy build and capture the stdout and stderr
         percy_output=$(

--- a/.github/actions/percy-snapshot/action.yml
+++ b/.github/actions/percy-snapshot/action.yml
@@ -87,6 +87,8 @@ runs:
         # If PR number is set & a Percy-GHA integration is set up, this allows Percy to set status on the PR
         PERCY_PULL_REQUEST: ${{ inputs.pr_number }}
         PERCY_PAGE_LOAD_TIMEOUT: 120000
+        LOG_LEVEL: debug
+        PERCY_DEBUG: "*"
       run: |
         # Start a percy build and capture the stdout and stderr
         percy_output=$(


### PR DESCRIPTION
## Done

Performs the following Percy configuration changes per debugging instructions from Browserstack support (see [Jira ticket](https://warthogs.atlassian.net/browse/WD-13163)):

- Increase page load timeout from 30s to 120s
- Set debug log level to "debug" to show more logging output

Hopefully, this will prevent snapshots from timing out.

Fixes [WD-13163](https://warthogs.atlassian.net/browse/WD-13163)

## QA

- Verify that [test workflow](https://github.com/jmuzina/vanilla-framework/actions/runs/9962635580/job/27526861741) ran successfully and includes verbose logging output.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix relesase (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


[WD-13163]: https://warthogs.atlassian.net/browse/WD-13163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ