### PR TITLE
Correct labels on grid examples

### DIFF
--- a/templates/docs/examples/patterns/grid/empty-columns.html
+++ b/templates/docs/examples/patterns/grid/empty-columns.html
@@ -19,7 +19,7 @@
       </div>
       <div class="col-4">
         <div class="row">
-          <div class="col-3 col-start-large-2">col-3 col-start-large-2 inside col-4</div>
+          <div class="col-3 col-start-large-2">.col-3 .col-start-large-2 inside .col-4</div>
         </div>
       </div>
   </div>
@@ -29,7 +29,7 @@
       </div>
       <div class="col-4">
         <div class="row">
-          <div class="col-3">col-3 inside col-4</div>
+          <div class="col-3">.col-3 inside .col-4</div>
         </div>
       </div>
   </div>

--- a/templates/docs/examples/patterns/grid/incorrect-empty-columns.html
+++ b/templates/docs/examples/patterns/grid/incorrect-empty-columns.html
@@ -49,7 +49,7 @@
       </div>
       <div class="col-4">
         <div class="row">
-          <div class="col-3 col-start-large-7">col-3 col-start-large-7</div>
+          <div class="col-3 col-start-large-7">.col-3 .col-start-large-7</div>
         </div>
       </div>
   </div>

--- a/templates/docs/examples/patterns/grid/nested-medium.html
+++ b/templates/docs/examples/patterns/grid/nested-medium.html
@@ -6,48 +6,48 @@
 {% block content %}
 <div class="row grid-demo">
   <div class="col-medium-6">
-    col-medium-6
+    .col-medium-6
     <div class="row">
       <div class="col-medium-3">
-        col-medium-3
+        .col-medium-3
         <div class="col-medium-1">
-          col-medium-1
+          .col-medium-1
         </div>
         <div class="col-medium-1">
-          col-medium-1
+          .col-medium-1
         </div>
         <div class="col-medium-1">
-          col-medium-1
+          .col-medium-1
         </div>
         <div class="col-medium-1">
-          col-medium-1
+          .col-medium-1
         </div>
         <div class="col-medium-1">
-          col-medium-1
+          .col-medium-1
         </div>
         <div class="col-medium-1">
-          col-medium-1
+          .col-medium-1
         </div>
       </div>
       <div class="col-medium-3">
-        col-medium-3
+        .col-medium-3
         <div class="col-medium-1">
-          col-medium-1
+          .col-medium-1
         </div>
         <div class="col-medium-1">
-          col-medium-1
+          .col-medium-1
         </div>
         <div class="col-medium-1">
-          col-medium-1
+          .col-medium-1
         </div>
         <div class="col-medium-1">
-          col-medium-1
+          .col-medium-1
         </div>
         <div class="col-medium-1">
-          col-medium-1
+          .col-medium-1
         </div>
         <div class="col-medium-1">
-          col-medium-1
+          .col-medium-1
         </div>
       </div>
     </div>

--- a/templates/docs/examples/patterns/grid/nested-small.html
+++ b/templates/docs/examples/patterns/grid/nested-small.html
@@ -6,59 +6,59 @@
 {% block content %}
 <div class="row grid-demo">
   <div class="col-small-4">
-    col-small-4
+    .col-small-4
     <div class="row">
       <div class="col-small-2">
-        col-small-2
+        .col-small-2
         <div class="row">
           <div class="col-small-1">
-            col-small-1
+            .col-small-1
           </div>
           <div class="col-small-1">
-            col-small-1
+            .col-small-1
           </div>
         </div>
       </div>
       <div class="col-small-2">
-        col-small-2
+        .col-small-2
       </div>
     </div>
   </div>
   <div class="col-small-3">
-    col-small-3
+    .col-small-3
     <div class="row">
       <div class="col-small-1">
-        col-small-1
+        .col-small-1
       </div>
       <div class="col-small-1">
-        col-small-1
+        .col-small-1
       </div>
       <div class="col-small-1">
-        col-small-1
+        .col-small-1
       </div>
     </div>
   </div>
   <div class="col-small-1">
-    col-small-1
+    .col-small-1
   </div>
   <div class="col-small-4">
     <div class="row">
       <div class="col-small-1">
-        col-small-1
+        .col-small-1
       </div>
       <div class="col-small-2">
-        col-small-2
+        .col-small-2
         <div class="row">
           <div class="col-small-1">
-            col-small-1
+            .col-small-1
           </div>
           <div class="col-small-1">
-            col-small-1
+            .col-small-1
           </div>
         </div>
       </div>
       <div class="col-small-1">
-        col-small-1
+        .col-small-1
       </div>
     </div>
   </div>

--- a/templates/docs/examples/patterns/grid/nested.html
+++ b/templates/docs/examples/patterns/grid/nested.html
@@ -6,24 +6,24 @@
 {% block content %}
 <div class="row grid-demo">
   <div class="col-small-4 col-medium-6 col-12">
-    col-small-4 .col-medium-6 .col-12
+    .col-small-4 .col-medium-6 .col-12
     <div class="row">
       <div class="col-small-3 col-medium-3 col-9">
-        col-small-3 .col-medium-3 .col-9
+        .col-small-3 .col-medium-3 .col-9
         <div class="row">
           <div class="col-small-1 col-medium-1 col-2">
-            col-small-1 col-medium-1 col-2
+            .col-small-1 .col-medium-1 .col-2
           </div>
           <div class="col-small-1 col-medium-1 col-3">
-            col-small-1 col-medium-1 col-2
+            .col-small-1 .col-medium-1 .col-3
           </div>
           <div class="col-small-1 col-medium-1 col-3">
-            col-small-1 col-medium-1 col-2
+            .col-small-1 .col-medium-1 .col-3
           </div>
         </div>
       </div>
       <div class="col-small-1 col-medium-3 col-3">
-        col-small-2 col-medium-3 col-3
+        .col-small-1 .col-medium-3 .col-3
       </div>
     </div>
   </div>

--- a/templates/docs/examples/patterns/grid/offsets.html
+++ b/templates/docs/examples/patterns/grid/offsets.html
@@ -9,13 +9,23 @@
     col-start-small-2 col-order-small-2
     col-start-medium-3 col-order-medium-2
     col-start-large-4 col-order-large-2">
-    <p>col-start-large-2 col-order-large-2</p>
+    <p>
+      .col-small-3 .col-medium-4 .col-9<br>
+      .col-start-small-2 .col-order-small-2<br>
+      .col-start-medium-3 .col-order-medium-2<br>
+      .col-start-large-4 .col-order-large-2
+    </p>
   </div>
   <div class="col-small-1 col-medium-2 col-3
     col-start-small-1 col-order-small-1
     col-start-medium-1 col-order-medium-1
     col-start-large-1 col-order-large-1">
-    <p>col-start-large-1 col-order-large-1</p>
+    <p>
+      .col-small-1 .col-medium-2 .col-3<br>
+      .col-start-small-1 .col-order-small-1<br>
+      .col-start-medium-1 .col-order-medium-1<br>
+      .col-start-large-1 .col-order-large-1
+    </p>
   </div>
 </div>
 {% endblock %}

--- a/templates/docs/examples/patterns/grid/responsive.html
+++ b/templates/docs/examples/patterns/grid/responsive.html
@@ -6,7 +6,7 @@
 {% block style %}
 <style>
 [class*='col-']::before {
-  content: attr(class);
+  content: '.' attr(class);
 }
 </style>
 {% endblock %}


### PR DESCRIPTION
## Done

- Fixed incorrect labels on Nested and Offset grid examples
- Added missing periods on other grid examples

Fixes #5221 

## QA

- Open the following grid examples:
  - [empty columns](https://vanilla-framework-5222.demos.haus/docs/examples/patterns/grid/empty-columns?theme=light)
  - [incorrect empty columns](https://vanilla-framework-5222.demos.haus/docs/examples/patterns/grid/incorrect-empty-columns?theme=light)
  - [nested medium](https://vanilla-framework-5222.demos.haus/docs/examples/patterns/grid/nested-medium?theme=light)
  - [nested small](https://vanilla-framework-5222.demos.haus/docs/examples/patterns/grid/nested-small?theme=light)
  - [nested all](https://vanilla-framework-5222.demos.haus/docs/examples/patterns/grid/nested?theme=light)
  - [offsets](https://vanilla-framework-5222.demos.haus/docs/examples/patterns/grid/offsets?theme=light)
  - [responsive](https://vanilla-framework-5222.demos.haus/docs/examples/patterns/grid/responsive?theme=light)
- Confirm labels on example pages match the actual grid classes being used

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [X] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [X] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [X] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
