### PR TITLE
Fix duplicated suru fan examples

### DIFF
--- a/templates/docs/patterns/suru.md
+++ b/templates/docs/patterns/suru.md
@@ -63,11 +63,11 @@ View example of the bottom fan Suru component
 
 Use `.p-suru--pyramid-left` or `.p-suru--pyramid-right` to create a hero section with the pyramid suru background. Suru component provides the necessary hero padding, background colour and the suru image.
 
-<div class="embedded-example"><a href="/docs/examples/patterns/suru/fan-top" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/suru/fan-pyramid-left" class="js-example">
 View example of the left pyramid Suru component
 </a></div>
 
-<div class="embedded-example"><a href="/docs/examples/patterns/suru/fan-bottom" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/suru/fan-pyramid-right" class="js-example">
 View example of the right pyramid Suru component
 </a></div>
 


### PR DESCRIPTION
## Done

Fixes duplication of suru fan-top and fan-bottom examples in the pyramid suru section

Fixes [WD-12500](https://warthogs.atlassian.net/browse/WD-12500)

## QA

- Open [suru docs](https://vanilla-framework-5232.demos.haus/docs/patterns/suru)
- Verify that the "pyramid suru" section shows Suru pyramid left & right examples, instead of "fan top" & "fan bottom" examples that are shown on [production](https://vanillaframework.io/docs/patterns/suru).

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
![image](https://github.com/user-attachments/assets/3f779a2b-44e7-41de-abf4-1f9e53e311a0)


[WD-12500]: https://warthogs.atlassian.net/browse/WD-12500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ