### PR TITLE
Change strips image example background to decrease load time

### DIFF
--- a/templates/docs/examples/patterns/strips/image.html
+++ b/templates/docs/examples/patterns/strips/image.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_strip{% endblock %}
 
 {% block content %}
-<section class="p-strip--image is-light" style="background-image:url('https://assets.ubuntu.com/sites/ubuntu/latest/u/img/backgrounds/image-background-paper.png')">
+<section class="p-strip--image is-light" style="background-image:url('https://assets.ubuntu.com/v1/1d2ab6ba-suru-background.png')">
   <div class="row u-vertically-center">
     <div class="col-8">
       <h1>Get started with big software, fast</h1>


### PR DESCRIPTION
## Done

Changes background image used in deprecated strip with image example to hopefully reduce load time on Percy and reduce instances of the strips example being dropped from Percy tests.

Fixes [WD-13163](https://warthogs.atlassian.net/browse/WD-13163)

## QA

- Verify [strip image example](https://vanilla-framework-5237.demos.haus/docs/examples/patterns/strips/image?theme=light) background is loaded 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
![image](https://github.com/user-attachments/assets/1c053da0-99bb-4232-99f5-26308690fecf)



[WD-13163]: https://warthogs.atlassian.net/browse/WD-13163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ