### PR TITLE
Bugfix: Allows for long strings to be wrapped within the notification container.

### DIFF
--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -142,6 +142,7 @@ $notification-text-margin-bottom: $spv--large - $spv-nudge;
       margin: 0;
       max-width: unset;
       padding: 0;
+      word-wrap: break-word;
     }
 
     .p-notification__close {


### PR DESCRIPTION
## Done

- Added ```word-wrap: break-word``` to p-notification__message classes.

Fixes [list issues/bugs if needed]

## QA

- Open [demo](https://vanilla-framework-5240.demos.haus/docs/examples/patterns/notifications/notifications?theme=light)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]
/docs/patterns/notification

## Screenshots

Default implementation wraps strings with spaces.
![image](https://github.com/user-attachments/assets/2637ebb3-6aaf-4e66-a720-ffa0baef8aea)

Default implementation does not wrap long strings with no spaces.
![image](https://github.com/user-attachments/assets/a0c631ee-4c5e-4fd1-aaed-1e699fd95aad)

Additional scss attribute wraps long strings with no spaces:
![image](https://github.com/user-attachments/assets/4c52d6e4-3ab4-4cdc-9ddc-ed1d9f0176b2)
