### PR TITLE
Fix incorrect href value on "Related section" link

### DIFF
--- a/templates/docs/customising-vanilla.md
+++ b/templates/docs/customising-vanilla.md
@@ -8,7 +8,7 @@ Here you will find information on customising Vanilla to suit your project.
 
 ## Overriding default settings
 
-To override the default settings you must do so _before_ you include Vanilla in your main Sass file. It is good practice to include custom styles in a separate settings file. A list of configurable settings can be found in the [Related section](#related).
+To override the default settings you must do so _before_ you include Vanilla in your main Sass file. It is good practice to include custom styles in a separate settings file. A list of configurable settings can be found in the [Related settings section](#related-settings).
 
 ```
 // Override default Vanilla settings in your main Sass file


### PR DESCRIPTION
## Done

- Updated `href` value on link on Customizing Vanilla page so it correctly references heading ID

Fixes #5243 

## QA

- Open [demo](https://vanilla-framework-5244.demos.haus/docs/customising-vanilla)
- Click "Related settings section" link
- Witness page scroll to proper heading

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [X] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [X] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [X] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
