### PR TITLE
Update styling of reduced nav on small screens

### DIFF
--- a/scss/_patterns_navigation-reduced.scss
+++ b/scss/_patterns_navigation-reduced.scss
@@ -3,6 +3,7 @@
     // height of reduced navigation calculated from line height and padding
     $reduced-nav-height: calc(map-get($line-heights, x-small) + 2 * $spv--small);
 
+    background-color: $colors--theme--background-alt;
     position: relative;
     z-index: 99; // display above sticky top navigation, but below modals/overlays
 
@@ -24,13 +25,17 @@
 
     // reduced nav logo text uses default font size (on small screens)
     .p-navigation__logo-title {
+      color: $colors--theme--text-muted;
       font-size: #{map-get($font-sizes, default)}rem;
+    }
+
+    // links in the banner (Menu toggle, search toggle) use muted text colour
+    .p-navigation__banner .p-navigation__link {
+      color: $colors--theme--text-muted;
     }
 
     // REDUCED SIZE OF NAVIGATION ON LARGE SCREENS
     @media (min-width: $breakpoint-navigation-threshold) {
-      background-color: $colors--theme--background-alt;
-
       // adjust font size for reduced nav on large screens
       .p-navigation__link,
       .p-navigation__logo-title {
@@ -73,6 +78,11 @@
     // SEARCH IN REDUCED NAVIGATION
 
     .p-navigation__link--search-toggle {
+      // use muted icon to align with text colour
+      &::after {
+        @include vf-icon-search-muted;
+      }
+
       // search label is always hidden in reduced navigation
       .p-navigation__search-label {
         display: none;

--- a/scss/_patterns_navigation-reduced.scss
+++ b/scss/_patterns_navigation-reduced.scss
@@ -27,6 +27,7 @@
     .p-navigation__logo-title {
       color: $colors--theme--text-muted;
       font-size: #{map-get($font-sizes, default)}rem;
+      font-weight: $font-weight-regular-text;
     }
 
     // links in the banner (Menu toggle, search toggle) use muted text colour


### PR DESCRIPTION
## Done

Updates the styling of top reduced navigation on mobile screens to match desktop:
- changes background to alternative
- changes text colour (and icons) to muted

Fixes https://warthogs.atlassian.net/browse/WD-13652
## QA

- Open [demo](https://vanilla-framework-5246.demos.haus/docs/examples/patterns/navigation/reduced?theme=light)
- Check the very top navigation bar (the one that says Canonical) on mobile screen
- Make sure that the background and text colour is the same as on large screen (not the same as navigation below it)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="729" alt="image" src="https://github.com/user-attachments/assets/2c1300ac-d98f-4e0a-a124-ad3710cb9dc7">

