### PR TITLE
Remove excess whitespace in class reference table

### DIFF
--- a/templates/_layouts/_class-reference.html
+++ b/templates/_layouts/_class-reference.html
@@ -1,14 +1,26 @@
 {%- for element, items in data.items() -%}
 <hr />
-<div class="row">
-    <div class="col-2 col-medium-1"><h4 class="p-muted-heading">{{ element }}</h4></div>
-    <div class="col-7 col-medium-5">
+<div class="row--25-75-on-large">
+    <div class="col">
+      <h4 class="p-muted-heading">
+        {{ element }}
+      </h4>
+    </div>
+    <div class="col">
         <div class="row">
             {%- for classname, description in items.items() -%}
-            <div class="col-3 col-medium-2"><p><code>{{ classname }}</code></p></div>
-            <div class="col-4 col-medium-3">{{ description | markdown }}</div>
+            <div class="col-3 col-medium-2">
+              <p>
+                <code>{{ classname }}</code>
+              </p>
+            </div>
+            <div class="col-6 col-medium-4">
+              {{ description | markdown }}
+            </div>
             {%- if not loop.last -%}
-            <div class="col-7 col-medium-5"><hr/></div>
+            <div class="col-9 col-medium-6">
+              <hr/>
+            </div>
             {%- endif -%}
             {%- endfor -%}
         </div>


### PR DESCRIPTION
## Done

Reduces extra whitespace used by documentation class reference tables.

Previous implementation was using old nested grid implementation. This updates grid as such:

- Top level grid is now 25/75 split on large instead of 16/58
- Nested grid is now 33/66 on large and medium instead of 43/57 on large and 40/60 on medium

Fixes #5238, [WD-13574](https://warthogs.atlassian.net/browse/WD-13574)

## QA

- Open some class reference tables and verify they look good across all breakpoints. The following components have class reference tables:
  - [Code snippet](https://vanilla-framework-5247.demos.haus/docs/base/code#class-reference)
  - [CTA block](https://vanilla-framework-5247.demos.haus/docs/patterns/cta-block#class-reference)
  - [Image](https://vanilla-framework-5247.demos.haus/docs/patterns/images#class-reference)
  - [Notification](https://vanilla-framework-5247.demos.haus/docs/patterns/notification#class-reference)
  - [Side navigation](https://vanilla-framework-5247.demos.haus/docs/patterns/navigation#side-navigation)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

## Screenshots
### Before
#### Large
![image](https://github.com/user-attachments/assets/1e91ea8c-c5b1-49de-8ce3-5a5e412874a2)
#### Medium
![image](https://github.com/user-attachments/assets/34d53bad-4394-42f1-9804-ed160be16e2a)
#### Small
![image](https://github.com/user-attachments/assets/c8c00d70-ed62-4bd6-a16f-9199e640f76b)
### After
#### Large
![image](https://github.com/user-attachments/assets/1711b8f9-740b-49f5-acc6-709af29cb1d3)
#### Medium
![image](https://github.com/user-attachments/assets/21bb8512-c93c-4d46-af32-b5890f286c86)
#### Small
![image](https://github.com/user-attachments/assets/747af557-ac2d-405f-9f45-6b63ac34516f)


[WD-13574]: https://warthogs.atlassian.net/browse/WD-13574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ