### PR TITLE
Remove percy_upload status check

### DIFF
--- a/.github/workflows/pr-percy-snapshots.yml
+++ b/.github/workflows/pr-percy-snapshots.yml
@@ -59,31 +59,3 @@ jobs:
           pr_number: ${{ steps.get_pr_data.outputs.pr_number }}
           commitsh: ${{ steps.get_pr_data.outputs.sha }}
           percy_token_write: ${{ secrets.PERCY_TOKEN_WRITE }}
-
-  # Add a check to the PR to show that screenshots were sent to Percy
-  # Manual status check to be removed once IS-GHA integration is complete
-  # https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run
-  apply_pr_check:
-    name: Apply PR check
-    needs: upload
-    if: github.event.workflow_run.event=='pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Apply PR check
-        id: create_check_run
-        uses: octokit/request-action@v2.x
-        with:
-          route: POST /repos/${{ github.repository }}/check-runs
-          owner: octokit
-          repo: request-action
-          name: "percy_upload"
-          head_sha: ${{ needs.upload.outputs.pr_head_sha }}
-          status: completed
-          conclusion: success
-          details_url: ${{ needs.upload.outputs.percy_build_link }}
-          output: |
-            title: "Percy build"
-            summary: "Percy build #${{ needs.upload.outputs.percy_build_id }} created"
-            text: "Percy build was created at ${{ needs.upload.outputs.percy_build_link }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Done

Removes the `percy_upload` status check that is applied to PRs once Percy has been run on them. [WD-11227](https://warthogs.atlassian.net/browse/WD-11227) [integrated Github with Percy ](https://www.browserstack.com/docs/percy/source-code-integrations/github), and the Percy integration now applies its own status check that is more helpful.

![image](https://github.com/user-attachments/assets/19aa235c-53e1-4ef1-8575-ebab81cc715d)

## QA

- Review [testing PR](https://github.com/jmuzina/vanilla-framework/pull/28) and its comments.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

[WD-11227]: https://warthogs.atlassian.net/browse/WD-11227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ