### PR TITLE
Simplify Percy Breakpoint/Theme snapshots

### DIFF
--- a/snapshots.js
+++ b/snapshots.js
@@ -141,7 +141,7 @@ async function getPercyConfigURLs() {
       urls.push({
         url,
         name,
-        widths: theme === DEFAULT_COLOR_THEME ? widths : [widths[widths.length - 1]],
+        widths,
       });
     }
   }

--- a/snapshots.js
+++ b/snapshots.js
@@ -23,6 +23,11 @@ const SNAPSHOT_BREAKPOINTS = {
 /** All supported color themes */
 const SNAPSHOT_COLOR_THEMES = ['light', 'dark', 'paper'];
 
+const DEFAULT_COLOR_THEME = 'light';
+
+/** Name of the query parameter used to request a specific color theme for an example */
+const COLOR_THEME_QUERY_PARAM_NAME = 'theme';
+
 /**
  * Get the example files to snapshot from a directory.
  * @param dir {String} Directory path to get example files from.
@@ -82,12 +87,12 @@ function getExampleUrlsFromExamplePaths(urlPaths) {
 async function getWidthsForExample(urlPath, theme) {
   let widths = new Set([SNAPSHOT_BREAKPOINTS.desktop]);
 
-  if (theme !== 'light') {
-    // Non-light themes are only captured at one width
+  if (theme !== DEFAULT_COLOR_THEME) {
+    // Non-default themes are only captured at one width
     return Array.from(widths);
   }
 
-  // Light theme is also captured at mobile size
+  // Default theme is also captured at mobile size
   widths.add(SNAPSHOT_BREAKPOINTS.mobile);
 
   /**
@@ -107,7 +112,7 @@ async function getWidthsForExample(urlPath, theme) {
   const isResponsive = urlPath.includes('responsive');
 
   if (isResponsive) {
-    // Responsive light theme is also captured at tablet size
+    // Responsive default theme is also captured at tablet size
     widths.add(SNAPSHOT_BREAKPOINTS.tablet);
   }
 
@@ -126,18 +131,17 @@ async function getPercyConfigURLs() {
 
   for (let link of links) {
     const path = new URL(link).pathname.replace(/\/?$/, '/');
-    // TODO this could be functionalized to get the proper themes for a given example.
 
     for (const theme of SNAPSHOT_COLOR_THEMES) {
-      const url = `${link}?theme=${theme}`;
-      const name = `${path.slice(0, path.length - 1)}?theme=${theme}`;
+      const url = `${link}?${COLOR_THEME_QUERY_PARAM_NAME}=${theme}`;
+      const name = `${path.slice(0, path.length - 1)}?${COLOR_THEME_QUERY_PARAM_NAME}=${theme}`;
       const widths = await getWidthsForExample(path, theme);
 
-      // Light theme captured responsively, other themes captured at the largest width
+      // Default theme captured responsively, other themes captured at the largest width
       urls.push({
         url,
         name,
-        widths: theme === 'light' ? widths : [widths[widths.length - 1]],
+        widths: theme === DEFAULT_COLOR_THEME ? widths : [widths[widths.length - 1]],
       });
     }
   }
@@ -149,4 +153,6 @@ module.exports = getPercyConfigURLs;
 module.exports.EXAMPLES_RELATIVE_DIR = EXAMPLES_RELATIVE_DIR;
 module.exports.SNAPSHOT_BREAKPOINTS = SNAPSHOT_BREAKPOINTS;
 module.exports.SNAPSHOT_COLOR_THEMES = SNAPSHOT_COLOR_THEMES;
+module.exports.DEFAULT_COLOR_THEME = DEFAULT_COLOR_THEME;
+module.exports.COLOR_THEME_QUERY_PARAM_NAME = COLOR_THEME_QUERY_PARAM_NAME;
 module.exports.PORT = PORT;

--- a/snapshots.js
+++ b/snapshots.js
@@ -116,19 +116,21 @@ async function getPercyConfigURLs() {
   let urls = [];
 
   for (let link of links) {
-    const path = new URL(link).pathname.replace(/\/?$/, '/');
+    const url = new URL(link);
+    const path = url.pathname.replace(/\/?$/, '/');
     // TODO this could be functionalized to get the proper themes for a given example.
     const themes = ['light', 'dark', 'paper'];
 
     for (const theme of themes) {
-      const url = `${link}?theme=${theme}`;
+      const snapshotUrl = `${link}?theme=${theme}`;
       const name = `${path.slice(0, path.length - 1)}?theme=${theme}`;
       const widths = await getWidthsForExample(path, theme);
 
       // Light theme captured responsively, other themes captured at the largest width
       urls.push({
-        url,
+        url: snapshotUrl,
         name,
+        testCase: url.pathname.replace(/standalone\//g, ''),
         widths: theme === 'light' ? widths : [widths[widths.length - 1]],
       });
     }

--- a/snapshots.js
+++ b/snapshots.js
@@ -116,21 +116,19 @@ async function getPercyConfigURLs() {
   let urls = [];
 
   for (let link of links) {
-    const url = new URL(link);
-    const path = url.pathname.replace(/\/?$/, '/');
+    const path = new URL(link).pathname.replace(/\/?$/, '/');
     // TODO this could be functionalized to get the proper themes for a given example.
     const themes = ['light', 'dark', 'paper'];
 
     for (const theme of themes) {
-      const snapshotUrl = `${link}?theme=${theme}`;
+      const url = `${link}?theme=${theme}`;
       const name = `${path.slice(0, path.length - 1)}?theme=${theme}`;
       const widths = await getWidthsForExample(path, theme);
 
       // Light theme captured responsively, other themes captured at the largest width
       urls.push({
-        url: snapshotUrl,
+        url,
         name,
-        testCase: url.pathname.replace(/standalone\//g, ''),
         widths: theme === 'light' ? widths : [widths[widths.length - 1]],
       });
     }

--- a/tests/snapshots.test.js
+++ b/tests/snapshots.test.js
@@ -1,6 +1,6 @@
 const {URL} = require('url');
 const snapshotsTest = require('../snapshots');
-const {SNAPSHOT_BREAKPOINTS, SNAPSHOT_COLOR_THEMES, PORT} = require('../snapshots');
+const {SNAPSHOT_BREAKPOINTS, SNAPSHOT_COLOR_THEMES, PORT, DEFAULT_COLOR_THEME, COLOR_THEME_QUERY_PARAM_NAME} = require('../snapshots');
 
 /**
  * Combined examples that embed responsive examples.
@@ -14,7 +14,7 @@ test('Returns correct widths for snapshots, including additional breakpoint for 
   const failedUrls = snapshots.filter((snapshot) => {
     const url = new URL(snapshot.url);
     const snapshotPathFromExamplesDir = url.pathname.replace('/docs/examples/', '').replace(/standalone\//g, '');
-    const theme = url.searchParams.get('theme')?.toLowerCase()?.trim();
+    const theme = url.searchParams.get(COLOR_THEME_QUERY_PARAM_NAME)?.toLowerCase()?.trim();
 
     // All urls must have a theme param
     if (!theme) return true;
@@ -22,8 +22,8 @@ test('Returns correct widths for snapshots, including additional breakpoint for 
     // All snapshots are captured at desktop width
     let expectedWidths = new Set([SNAPSHOT_BREAKPOINTS.desktop]);
 
-    if (theme === 'light') {
-      // Light snapshots captured at multiple breakpoints
+    if (theme === DEFAULT_COLOR_THEME) {
+      // Default theme snapshots captured at multiple breakpoints
       expectedWidths.add(SNAPSHOT_BREAKPOINTS.mobile);
 
       const isResponsive =
@@ -49,7 +49,7 @@ test('Returned snapshots have only one url per theme', async () => {
   const encountered = new Map();
   snapshots.forEach((snapshot) => {
     const url = new URL(snapshot.url);
-    const theme = url.searchParams.get('theme');
+    const theme = url.searchParams.get(COLOR_THEME_QUERY_PARAM_NAME);
     if (!encountered.has(url.pathname)) {
       encountered.set(url.pathname, 0);
     }
@@ -103,10 +103,10 @@ test('Returns snapshots with only the expected set of color themes', async () =>
   const snapshots = await snapshotsTest();
   const encounteredThemes = snapshots.reduce((acc, snapshot) => {
     const url = new URL(snapshot.url);
-    if (!url.searchParams.has('theme')) {
+    if (!url.searchParams.has(COLOR_THEME_QUERY_PARAM_NAME)) {
       return acc;
     }
-    return acc.add(url.searchParams.get('theme'));
+    return acc.add(url.searchParams.get(COLOR_THEME_QUERY_PARAM_NAME));
   }, new Set());
   expect(JSON.stringify(encounteredThemes)).toBe(JSON.stringify(new Set(SNAPSHOT_COLOR_THEMES)));
 });

--- a/tests/snapshots.test.js
+++ b/tests/snapshots.test.js
@@ -2,6 +2,7 @@ const {URL} = require('url');
 const snapshotsTest = require('../snapshots');
 
 const PORT = process.env.PORT || 8101;
+const THEMES = ['light', 'dark', 'paper'];
 
 /**
  * Combined examples that embed responsive examples.
@@ -42,6 +43,28 @@ test('Returns correct widths for snapshots, including additional breakpoint for 
 
     return JSON.stringify(snapshot.widths) !== JSON.stringify(expectedWidths);
   });
+  expect(failedUrls).toHaveLength(0);
+});
+
+test('Returned snapshots have only one url per theme', async () => {
+  const snapshots = await snapshotsTest();
+  const encountered = new Map();
+  snapshots.forEach((snapshot) => {
+    const url = new URL(snapshot.url);
+    const theme = url.searchParams.get('theme');
+    if (!encountered.has(url.pathname)) {
+      encountered.set(url.pathname, 0);
+    }
+    encountered.set(url.pathname, encountered.get(url.pathname) + 1);
+  });
+
+  const failedUrls = snapshots
+    .map((snapshot) => snapshot.url)
+    .filter((snapshotAbsoluteUrl) => {
+      const url = new URL(snapshotAbsoluteUrl);
+      return encountered.get(url.pathname) !== THEMES.length;
+    });
+
   expect(failedUrls).toHaveLength(0);
 });
 

--- a/tests/snapshots.test.js
+++ b/tests/snapshots.test.js
@@ -1,8 +1,6 @@
 const {URL} = require('url');
 const snapshotsTest = require('../snapshots');
-
-const PORT = process.env.PORT || 8101;
-const THEMES = ['light', 'dark', 'paper'];
+const {SNAPSHOT_BREAKPOINTS, SNAPSHOT_COLOR_THEMES, PORT} = require('../snapshots');
 
 /**
  * Combined examples that embed responsive examples.
@@ -21,12 +19,12 @@ test('Returns correct widths for snapshots, including additional breakpoint for 
     // All urls must have a theme param
     if (!theme) return true;
 
-    // All snapshots are captured at 1280px width
-    let expectedWidths = new Set([1280]);
+    // All snapshots are captured at desktop width
+    let expectedWidths = new Set([SNAPSHOT_BREAKPOINTS.desktop]);
 
     if (theme === 'light') {
       // Light snapshots captured at multiple breakpoints
-      expectedWidths.add(375);
+      expectedWidths.add(SNAPSHOT_BREAKPOINTS.mobile);
 
       const isResponsive =
         snapshot.url.includes('responsive') ||
@@ -34,8 +32,8 @@ test('Returns correct widths for snapshots, including additional breakpoint for 
         (url.pathname.endsWith('combined') && RESPONSIVE_COMBINED_EXAMPLES.includes(snapshotPathFromExamplesDir));
 
       if (isResponsive) {
-        // Responsive snapshots are also captured at 800px
-        expectedWidths.add(800);
+        // Responsive snapshots are also captured at tablet size
+        expectedWidths.add(SNAPSHOT_BREAKPOINTS.tablet);
       }
     }
 
@@ -62,7 +60,7 @@ test('Returned snapshots have only one url per theme', async () => {
     .map((snapshot) => snapshot.url)
     .filter((snapshotAbsoluteUrl) => {
       const url = new URL(snapshotAbsoluteUrl);
-      return encountered.get(url.pathname) !== THEMES.length;
+      return encountered.get(url.pathname) !== SNAPSHOT_COLOR_THEMES.length;
     });
 
   expect(failedUrls).toHaveLength(0);
@@ -110,5 +108,5 @@ test('Returns snapshots with only the expected set of color themes', async () =>
     }
     return acc.add(url.searchParams.get('theme'));
   }, new Set());
-  expect(JSON.stringify(encounteredThemes)).toBe(JSON.stringify(new Set(['light', 'dark', 'paper'])));
+  expect(JSON.stringify(encounteredThemes)).toBe(JSON.stringify(new Set(SNAPSHOT_COLOR_THEMES)));
 });


### PR DESCRIPTION
## Done

- Light examples are snapshotted responsively
- Dark/paper examples are snapshotted on desktop only
- Slightly simplified / cleaned up snapshots JS code by adding some constants to reduce literal duplication

Fixes [WD-13804](https://warthogs.atlassian.net/browse/WD-13804)

## QA

- View [test build](https://percy.io/bb49709b/test-vanilla-gha-migration/builds/35631002/changed/1946954265?browser=chrome&browser_ids=59&group_snapshots_by=similar_diff&subcategories=approved&viewLayout=overlay&viewMode=new&width=1280&widths=375%2C800%2C1280) and verify snapshots are captured as expected
  - Pay special attention to the relationship between theme and breakpoints
    - All snapshots are captured at 1280px (desktop/large size)
    - Light-theme examples are also captured at 375px (mobile/small size)
    - Examples that include "responsive" in their name or embed such an example are also captured at 800px (tablet/medium size)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
![image](https://github.com/user-attachments/assets/c7116a01-6e03-4c2a-867f-f2c5a6787ff4)

[WD-13804]: https://warthogs.atlassian.net/browse/WD-13804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ