### PR TITLE
Fix theming of grid examples

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -8,6 +8,10 @@
       url: /docs/patterns/grid
       status: New
       notes: We've added the <code>.row--75-25</code> class to simplify creation of 75/25% grid layouts.
+    - component: Grid
+      url: /docs/patterns/grid
+      status: Deprecated
+      notes: We've deprecated the <code>.row.is-bordered</code> class.
     - component: Navigation / Full-width dropdowns
       url: /docs/patterns/navigation#full-width-dropdowns
       status: New

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -39,7 +39,7 @@
   // (see https://github.com/canonical/vanilla-framework/issues/3199)
   .grid-demo .col,
   .grid-demo [class*='#{$grid-column-prefix}'] {
-    background: transparentize($color-negative, 0.9);
+    background: $colors--theme--background-negative-default;
     margin-bottom: $spv--small;
   }
 
@@ -167,11 +167,12 @@
 
   // variants
 
+  // deprecated, will be removed in v5
   .row.is-bordered {
     position: relative;
 
     &::before {
-      background: $color-mid-light;
+      background: $colors--theme--border-low-contrast;
       content: '';
       height: 1px;
       left: map-get($grid-margin-widths, small);

--- a/templates/docs/examples/layouts/fluid-breakout/visualize-grid.css
+++ b/templates/docs/examples/layouts/fluid-breakout/visualize-grid.css
@@ -1,5 +1,5 @@
 .viz-grid-item,
 .viz-aside {
-  background-color: rgba(199, 22, 43, 0.1);
+  background-color: var(--vf-color-background-negative-default);
   margin-bottom: 1rem;
 }

--- a/templates/docs/examples/patterns/grid/bordered.html
+++ b/templates/docs/examples/patterns/grid/bordered.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Grid / Bordered{% endblock %}
+{% block title %}Grid / Bordered (deprecated){% endblock %}
 
 {% block standalone_css %}patterns_grid{% endblock %}
 


### PR DESCRIPTION
## Done

Removes old color theme variables from `patterns_grid`

- Changes background of the red grid rows in grid examples to a themed value
- Changes border color of `row.is-bordered` to a themed value
- Deprecates `.row.is-bordered`

Fixes [WD-11876](https://warthogs.atlassian.net/browse/WD-11876)

## QA

- Open [combined grid example](https://vanilla-framework-5256.demos.haus/docs/examples/patterns/grid/combined) and verify the red boxes look as expected on all themes
- Open [bordered grid example](https://vanilla-framework-5256.demos.haus/docs/examples/patterns/grid/bordered) and verify the border looks as expected on all themes
- Review [deprecation notice](https://vanilla-framework-5256.demos.haus/docs/whats-new) for `.row.is-bordered`

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
![image](https://github.com/user-attachments/assets/8e46b7de-f872-4513-83ac-2d86a9477229)
![image](https://github.com/user-attachments/assets/f95b0a01-8aa2-4300-ac8d-c0cb4ac0de33)
![image](https://github.com/user-attachments/assets/182665bc-5373-46e7-af95-8a7dfcdfae43)




[WD-11876]: https://warthogs.atlassian.net/browse/WD-11876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ