### PR TITLE
Percy macros artifact fix

### DIFF
--- a/.github/workflows/pr-percy-snapshots.yml
+++ b/.github/workflows/pr-percy-snapshots.yml
@@ -39,6 +39,9 @@ jobs:
 
       - name: Move artifact files into place to replace SCM
         run: |
+          # ensure the examples & macros dirs exist
+          mkdir -p examples
+          mkdir -p macros
           # artifact directory contains `scss/`, `examples/`, `macros/`, `pr_num.txt`, and `pr_head_sha.txt`. 
           # `/examples` and `macros/` must be moved to `templates/`.
           mv examples/ templates/docs/.


### PR DESCRIPTION
## Done

Fixes PRs that don't have `templates/_macros` folders causing [Percy snapshots to fail](https://github.com/canonical/vanilla-framework/actions/runs/10114433037)

## QA

- Verify [test PR](https://github.com/jmuzina/vanilla-framework/pull/30) has no `templates/_macros` folder and runs [Percy snapshots workflow](https://github.com/jmuzina/vanilla-framework/actions/runs/10114547016) successfully

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
