### PR TITLE
Fix tagged navigation icon spacing

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -1,13 +1,13 @@
 @import 'settings';
 
 $lightness-threshold: 70;
-$navigation-logo-tag-width: 22px; // 22px when 1rem is 16px
-$navigation-logo-tag-height: 38px; // 38px when 1rem is 16px
-$navigation-logo-banner-height: 56px; // legacy logo height (on large screens)
+$navigation-logo-tag-width: 1.375rem; // 22px when 1rem is 16px
+$navigation-logo-tag-height: 2.375rem; // 38px when 1rem is 16px
+$navigation-logo-banner-height: 3.5rem; // legacy logo height (on large screens)
 $navigation-logo-size: 1rem;
-$navigation-logo-padding: 25.6px; // ~25.6px to align better with logos as originally designed in SVG
+$navigation-logo-padding: calc(1.5rem + 0.1rem); // ~25.6px to align better with logos as originally designed in SVG
 $sph-navigation-link: 0.3rem;
-$spv-navigation-logo-bottom-position: 4px;
+$spv-navigation-logo-bottom-position: 0.25rem; // 4px when 1rem is 16px
 
 @mixin vf-p-navigation {
   // placeholders

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -1,13 +1,13 @@
 @import 'settings';
 
 $lightness-threshold: 70;
-$navigation-logo-tag-width: 1.375rem; // 22px when 1rem is 16px
-$navigation-logo-tag-height: 2.375rem; // 38px when 1rem is 16px
-$navigation-logo-banner-height: 3.5rem; // legacy logo height (on large screens)
+$navigation-logo-tag-width: 22px; // 22px when 1rem is 16px
+$navigation-logo-tag-height: 38px; // 38px when 1rem is 16px
+$navigation-logo-banner-height: 56px; // legacy logo height (on large screens)
 $navigation-logo-size: 1rem;
-$navigation-logo-padding: calc(1.5rem + 0.1rem); // ~25.6px to align better with logos as originally designed in SVG
+$navigation-logo-padding: 25.6px; // ~25.6px to align better with logos as originally designed in SVG
 $sph-navigation-link: 0.3rem;
-$spv-navigation-logo-bottom-position: 0.25rem; // 4px when 1rem is 16px
+$spv-navigation-logo-bottom-position: 4px;
 
 @mixin vf-p-navigation {
   // placeholders

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -346,9 +346,13 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     }
 
     .p-navigation__logo-tag {
+      align-items: flex-end;
       background-color: $color-ubuntu;
+      display: flex;
       height: $navigation-logo-tag-height;
+      justify-content: center;
       left: 0;
+      padding-bottom: $spv-navigation-logo-bottom-position;
       position: absolute;
       top: 0;
       width: $navigation-logo-tag-width;
@@ -359,11 +363,7 @@ $spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
     }
 
     .p-navigation__logo-icon {
-      bottom: $spv-navigation-logo-bottom-position;
       height: $navigation-logo-size;
-      left: 50%;
-      position: absolute;
-      transform: translate(-50%, 0);
       width: $navigation-logo-size;
     }
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -1,9 +1,9 @@
 @import 'settings';
 
 $lightness-threshold: 70;
-$navigation-logo-tag-width: 1.34rem; // 21.44px when 1rem is 16px
-$navigation-logo-tag-height: 2rem;
-$navigation-logo-tag-height-desktop: 2.3048rem; // 36.877px when 1rem is 16px
+$navigation-logo-tag-width: 1.375rem; // 22px when 1rem is 16px
+$navigation-logo-tag-height: 2rem; // medium & small height of the tag logo
+$navigation-logo-tag-height-desktop: 2.375rem; // 38px when 1rem is 16px
 $navigation-logo-banner-height: 3rem; // legacy logo height (small and medium screens)
 $navigation-logo-banner-height-desktop: 3.5rem; // legacy logo height (on large screens)
 $navigation-logo-size: 1rem;
@@ -18,8 +18,8 @@ $spv-navigation-logo-bottom-position: 0.25rem; // 4px when 1rem is 16px
     padding-top: $spv--medium;
 
     @media (min-width: $breakpoint-navigation-threshold) {
-      padding-bottom: calc($spv--large - 0.125rem);
-      padding-top: calc($spv--large - 0.125rem);
+      padding-bottom: $spv--large;
+      padding-top: $spv--large;
     }
   }
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -7,7 +7,7 @@ $navigation-logo-tag-height-desktop: 2.3048rem; // 36.877px when 1rem is 16px
 $navigation-logo-banner-height: 3rem; // legacy logo height (small and medium screens)
 $navigation-logo-banner-height-desktop: 3.5rem; // legacy logo height (on large screens)
 $navigation-logo-size: 1rem;
-$navigation-logo-padding: calc(1.5rem + 0.19rem); // ~27px to align better with logos as originally designed in SVG
+$navigation-logo-padding: calc(1.5rem + 0.1rem); // ~25.6px to align better with logos as originally designed in SVG
 $sph-navigation-link: 0.3rem;
 $spv-navigation-logo-bottom-position: 0.25rem; // 4px when 1rem is 16px
 
@@ -18,8 +18,8 @@ $spv-navigation-logo-bottom-position: 0.25rem; // 4px when 1rem is 16px
     padding-top: $spv--medium;
 
     @media (min-width: $breakpoint-navigation-threshold) {
-      padding-bottom: $spv--large;
-      padding-top: $spv--large;
+      padding-bottom: calc($spv--large - 0.125rem);
+      padding-top: calc($spv--large - 0.125rem);
     }
   }
 

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -2,10 +2,8 @@
 
 $lightness-threshold: 70;
 $navigation-logo-tag-width: 1.375rem; // 22px when 1rem is 16px
-$navigation-logo-tag-height: 2rem; // medium & small height of the tag logo
-$navigation-logo-tag-height-desktop: 2.375rem; // 38px when 1rem is 16px
-$navigation-logo-banner-height: 3rem; // legacy logo height (small and medium screens)
-$navigation-logo-banner-height-desktop: 3.5rem; // legacy logo height (on large screens)
+$navigation-logo-tag-height: 2.375rem; // 38px when 1rem is 16px
+$navigation-logo-banner-height: 3.5rem; // legacy logo height (on large screens)
 $navigation-logo-size: 1rem;
 $navigation-logo-padding: calc(1.5rem + 0.1rem); // ~25.6px to align better with logos as originally designed in SVG
 $sph-navigation-link: 0.3rem;
@@ -14,13 +12,8 @@ $spv-navigation-logo-bottom-position: 0.25rem; // 4px when 1rem is 16px
 @mixin vf-p-navigation {
   // placeholders
   %navigation-link-responsive-padding-vertical {
-    padding-bottom: $spv--medium;
-    padding-top: $spv--medium;
-
-    @media (min-width: $breakpoint-navigation-threshold) {
-      padding-bottom: $spv--large;
-      padding-top: $spv--large;
-    }
+    padding-bottom: $spv--large;
+    padding-top: $spv--large;
   }
 
   %navigation-link-responsive-padding-left {
@@ -326,10 +319,6 @@ $spv-navigation-logo-bottom-position: 0.25rem; // 4px when 1rem is 16px
     height: $navigation-logo-banner-height;
     margin: 0 $sph--large 0 0;
 
-    @media (min-width: $breakpoint-navigation-threshold) {
-      height: $navigation-logo-banner-height-desktop;
-    }
-
     .p-navigation__item {
       @include vf-focus;
 
@@ -356,10 +345,6 @@ $spv-navigation-logo-bottom-position: 0.25rem; // 4px when 1rem is 16px
       position: absolute;
       top: 0;
       width: $navigation-logo-tag-width;
-
-      @media (min-width: $breakpoint-navigation-threshold) {
-        height: $navigation-logo-tag-height-desktop;
-      }
     }
 
     .p-navigation__logo-icon {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -1,15 +1,15 @@
 @import 'settings';
 
 $lightness-threshold: 70;
-$navigation-logo-tag-width: 1.313rem; // 21px when 1rem is 16px
+$navigation-logo-tag-width: 1.34rem; // 21.44px when 1rem is 16px
 $navigation-logo-tag-height: 2rem;
-$navigation-logo-tag-height-desktop: 2.3rem;
+$navigation-logo-tag-height-desktop: 2.3048rem; // 36.877px when 1rem is 16px
 $navigation-logo-banner-height: 3rem; // legacy logo height (small and medium screens)
 $navigation-logo-banner-height-desktop: 3.5rem; // legacy logo height (on large screens)
 $navigation-logo-size: 1rem;
 $navigation-logo-padding: calc(1.5rem + 0.19rem); // ~27px to align better with logos as originally designed in SVG
 $sph-navigation-link: 0.3rem;
-$spv-navigation-logo-bottom-position: 0.125rem; // 2px when 1rem is 16px
+$spv-navigation-logo-bottom-position: 0.25rem; // 4px when 1rem is 16px
 
 @mixin vf-p-navigation {
   // placeholders


### PR DESCRIPTION
## Done

Moves tagged navigation icon closer to official logo design

Fixes #5186, [WD-12707](https://warthogs.atlassian.net/browse/WD-12707)

## QA

- Verify that navigation logos are properly aligned and the wordmark is properly spaced in relation to the logo
  - Check CoF logo by checking a [navigation example](https://vanilla-framework-5258.demos.haus/docs/examples/patterns/navigation/dropdown?theme=dark)
  - Check Vanilla logo by visiting the [homepage](https://vanilla-framework-5258.demos.haus/)
- Verify that the header's height is a multiple of baseline grid units (8px)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

Before:
![image](https://github.com/user-attachments/assets/d97753b8-6dfd-4729-8582-555fa3a965a1)
After:
![image](https://github.com/user-attachments/assets/ec2fd036-c97b-4b7c-a19b-c3c1bcd5294b)



[WD-12707]: https://warthogs.atlassian.net/browse/WD-12707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ