### PR TITLE
Fixes #5228 duplicate css

### DIFF
--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -43,7 +43,7 @@
   }
 
   %vf-card-padding {
-    overflow: auto;
+    overflow: auto; // prevent overflow of child margins
     padding: $spv--large;
   }
 
@@ -52,8 +52,6 @@
     @extend %vf-card-padding;
 
     margin-bottom: $spv--x-large;
-    overflow: auto; // prevent overflow of child margins
-    padding: $spv--large;
   }
 
   //accordion, table


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

Fixes #5228 Duplicate css of overflow and padding 

## QA - Functionality should remain as it is

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

