### PR TITLE
Remove deprecated -webkit-search-cancel-button pseudo-element styles

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -163,11 +163,6 @@
     &::-webkit-search-results-decoration {
       display: none;
     }
-
-    &::-webkit-search-cancel-button {
-      -webkit-appearance: searchfield-cancel-button; // stylelint-disable-line property-no-vendor-prefix
-      cursor: pointer;
-    }
   }
 
   input[list] {


### PR DESCRIPTION
## Done

- Remove deprecated -webkit-search-cancel-button pseudo-element styles

This pseudo-element appears to have been deprecated and removed from Webkit, displaying the following console alert on pages it's used on:

```
The keyword 'searchfield-cancel-button' used on the 'appearance' property was deprecated and has now been removed. It will no longer have any effect.
```

I believe this means it can be safely removed with no ill effects. See linked Issue for more context.

Fixes #5088 

## QA

- Open [search box demo](https://vanilla-framework-5265.demos.haus/docs/examples/patterns/search-box/default?theme=light)
- Input some text into the search input
- Witness no browser-styled reset button; only 2 buttons should be Vanilla-provided

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [X] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [X] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [X] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
