### PR TITLE
Add borderless CTA block variant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.16.0
+  features:
+    - component: CTA Block / Borderless
+      url: /docs/patterns/cta-block#borderless
+      status: New
+      notes: We've introduced a new borderless variant of the CTA block component.
 - version: 4.15.0
   features:
     - component: CTA Block

--- a/scss/_patterns_cta.scss
+++ b/scss/_patterns_cta.scss
@@ -5,7 +5,7 @@
       .p-cta-block:
         Main element of the CTA block.
       "&.is-borderless":
-        Borderless variant, to be used to hide top border.
+        Borderless variant, to be used to hide top border and padding.
 */
 
 @import 'settings';
@@ -21,6 +21,7 @@
 
     &.is-borderless {
       border: none;
+      padding-top: 0;
     }
   }
 }

--- a/scss/_patterns_cta.scss
+++ b/scss/_patterns_cta.scss
@@ -4,6 +4,8 @@
     CTA Block:
       .p-cta-block:
         Main element of the CTA block.
+      "&.is-borderless":
+        Borderless variant, to be used to hide top border.
 */
 
 @import 'settings';
@@ -16,5 +18,9 @@
     flex-wrap: wrap;
     padding-bottom: $spv--x-large;
     padding-top: $spv--small;
+
+    &.is-borderless {
+      border: none;
+    }
   }
 }

--- a/templates/docs/examples/patterns/cta-block/borderless.html
+++ b/templates/docs/examples/patterns/cta-block/borderless.html
@@ -1,11 +1,11 @@
 {% extends "_layouts/examples.html" %}
 
-{% block title %}CTA Block / Default{% endblock %}
+{% block title %}CTA Block / Borderless{% endblock %}
 
 {% block standalone_css %}patterns_cta{% endblock %}
 
 {% block content %}
-<div class="p-cta-block">
+<div class="p-cta-block is-borderless">
   <a href="#" class="p-button--positive">Learn more</a>
   <a href="#">Contact us ›</a>
 </div>

--- a/templates/docs/examples/patterns/cta-block/combined.html
+++ b/templates/docs/examples/patterns/cta-block/combined.html
@@ -1,0 +1,11 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}CTA Block / Combined{% endblock %}
+
+{% block standalone_css %}patterns_cta{% endblock %}
+
+{% block content %}
+{% with is_combined = true %}
+<section>{% include 'docs/examples/patterns/cta-block/default.html' %}</section>
+<section>{% include 'docs/examples/patterns/cta-block/borderless.html' %}</section>
+{% endwith %}
+{% endblock %}

--- a/templates/docs/patterns/cta-block/index.md
+++ b/templates/docs/patterns/cta-block/index.md
@@ -11,6 +11,14 @@ A CTA (call to action) block is a pattern that is used to encourage users to tak
 View example of the CTA block pattern
 </a></div>
 
+## Borderless
+
+The CTA block can be used without a border. This is useful when the CTA block is stacked beneath related content.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/cta-block/borderless" class="js-example">
+View example of the CTA block pattern with no border
+</a></div>
+
 ## Class reference
 
 {{ class_reference("cta-block") }}


### PR DESCRIPTION
## Done

- Adds `.p-cta-block.is-borderless`. It was not initially needed in #5196 but it has become necessary for completion of #5275.
- CTA block now has two examples, so I've added a `combined.html` example for them. This means that Percy will be missing the existing CTA block snapshot, and snapshot the new combined example instead.

Fixes #5277, [WD-13924](https://warthogs.atlassian.net/browse/WD-13924)

## QA

- Verify [borderless CTA block example](https://vanilla-framework-5278.demos.haus/docs/examples/patterns/cta-block/borderless?theme=light) has no top border and no top padding
- Verify [default CTA block example](https://vanilla-framework-5278.demos.haus/docs/examples/patterns/cta-block/default?theme=light) has a top border
- Verify all of the above is still true for the [combined example](https://vanilla-framework-5278.demos.haus/docs/examples/patterns/cta-block/combined?theme=light)
- View [borderless CTA docs](https://vanilla-framework-5278.demos.haus/docs/patterns/cta-block#borderless)
- View [borderless CTA class reference](https://vanilla-framework-5278.demos.haus/docs/patterns/cta-block#class-reference)
- Review [4.16.0 release notes](https://vanilla-framework-5278.demos.haus/docs/whats-new)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
<img width="326" alt="Screenshot 2024-08-06 at 4 13 34 PM" src="https://github.com/user-attachments/assets/647dd856-b0ab-4790-8d3a-05e5a3fb68a9">


[WD-13924]: https://warthogs.atlassian.net/browse/WD-13924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ