### PR TITLE
Fix responsive grid example not rendering correctly in combined view

### DIFF
--- a/scss/docs/example.scss
+++ b/scss/docs/example.scss
@@ -12,6 +12,13 @@ body {
 }
 // stylelint-enable selector-max-type
 
+// Displays the contents of the `class` attribute on all column descendants
+.u-show-col-classes {
+  [class*='col-']::before {
+    content: '.' attr(class);
+  }
+}
+
 .p-example-controls {
   @include vf-transition($property: #{transform, box-shadow, visibility}, $duration: snap);
   align-items: center;

--- a/scss/docs/example.scss
+++ b/scss/docs/example.scss
@@ -12,13 +12,6 @@ body {
 }
 // stylelint-enable selector-max-type
 
-// Displays the contents of the `class` attribute on all column descendants
-.u-show-col-classes {
-  [class*='col-']::before {
-    content: '.' attr(class);
-  }
-}
-
 .p-example-controls {
   @include vf-transition($property: #{transform, box-shadow, visibility}, $duration: snap);
   align-items: center;

--- a/templates/docs/examples/patterns/grid/responsive.html
+++ b/templates/docs/examples/patterns/grid/responsive.html
@@ -3,8 +3,16 @@
 
 {% block standalone_css %}patterns_grid{% endblock %}
 
+{% block style %}
+<style>
+[class*='col-']::before {
+  content: '.' attr(class);
+}
+</style>
+{% endblock %}
+
 {% block content %}
-<div class="grid-demo u-show-col-classes">
+<div class="grid-demo">
   <div class="row">
     <div class="col-2 col-medium-1 col-small-1">
     </div>

--- a/templates/docs/examples/patterns/grid/responsive.html
+++ b/templates/docs/examples/patterns/grid/responsive.html
@@ -3,46 +3,51 @@
 
 {% block standalone_css %}patterns_grid{% endblock %}
 
-{% block style %}
-<style>
-[class*='col-']::before {
-  content: '.' attr(class);
-}
-</style>
-{% endblock %}
-
 {% block content %}
 <div class="grid-demo">
   <div class="row">
     <div class="col-2 col-medium-1 col-small-1">
+      .col-2 col-medium-1 col-small-1
     </div>
     <div class="col-2 col-medium-1 col-small-1">
+      .col-2 col-medium-1 col-small-1
     </div>
     <div class="col-2 col-medium-1 col-small-2">
+      .col-2 col-medium-1 col-small-2
     </div>
     <div class="col-2 col-medium-1 col-small-2">
+      .col-2 col-medium-1 col-small-2
     </div>
     <div class="col-2 col-medium-1 col-small-1">
+      .col-2 col-medium-1 col-small-1
     </div>
     <div class="col-2 col-medium-1 col-small-1">
+      .col-2 col-medium-1 col-small-1
     </div>
   </div>
   <div class="row">
     <div class="col-3 col-medium-1 col-small-1">
+      .col-3 col-medium-1 col-small-1
     </div>
     <div class="col-3 col-medium-2 col-small-1">
+      .col-3 col-medium-2 col-small-1
     </div>
     <div class="col-3 col-medium-2 col-small-1">
+      .col-3 col-medium-2 col-small-1
     </div>
     <div class="col-3 col-medium-1 col-small-1">
+      .col-3 col-medium-1 col-small-1
     </div>
   </div>
   <div class="row">
     <div class="col-4 col-medium-2 col-small-4">
+      .col-4 col-medium-2 col-small-4
     </div>
     <div class="col-4 col-medium-2 col-small-2">
+      .col-4 col-medium-2 col-small-2
     </div>
     <div class="col-4 col-medium-2 col-small-2">
+      .col-4 col-medium-2 col-small-2
     </div>
   </div>
 </div>

--- a/templates/docs/examples/patterns/grid/responsive.html
+++ b/templates/docs/examples/patterns/grid/responsive.html
@@ -7,47 +7,47 @@
 <div class="grid-demo">
   <div class="row">
     <div class="col-2 col-medium-1 col-small-1">
-      .col-2 col-medium-1 col-small-1
+      .col-2.col-medium-1.col-small-1
     </div>
     <div class="col-2 col-medium-1 col-small-1">
-      .col-2 col-medium-1 col-small-1
+      .col-2.col-medium-1.col-small-1
     </div>
     <div class="col-2 col-medium-1 col-small-2">
-      .col-2 col-medium-1 col-small-2
+      .col-2.col-medium-1.col-small-2
     </div>
     <div class="col-2 col-medium-1 col-small-2">
-      .col-2 col-medium-1 col-small-2
+      .col-2.col-medium-1.col-small-2
     </div>
     <div class="col-2 col-medium-1 col-small-1">
-      .col-2 col-medium-1 col-small-1
+      .col-2.col-medium-1.col-small-1
     </div>
     <div class="col-2 col-medium-1 col-small-1">
-      .col-2 col-medium-1 col-small-1
+      .col-2.col-medium-1.col-small-1
     </div>
   </div>
   <div class="row">
     <div class="col-3 col-medium-1 col-small-1">
-      .col-3 col-medium-1 col-small-1
+      .col-3.col-medium-1.col-small-1
     </div>
     <div class="col-3 col-medium-2 col-small-1">
-      .col-3 col-medium-2 col-small-1
+      .col-3.col-medium-2.col-small-1
     </div>
     <div class="col-3 col-medium-2 col-small-1">
-      .col-3 col-medium-2 col-small-1
+      .col-3.col-medium-2.col-small-1
     </div>
     <div class="col-3 col-medium-1 col-small-1">
-      .col-3 col-medium-1 col-small-1
+      .col-3.col-medium-1.col-small-1
     </div>
   </div>
   <div class="row">
     <div class="col-4 col-medium-2 col-small-4">
-      .col-4 col-medium-2 col-small-4
+      .col-4.col-medium-2.col-small-4
     </div>
     <div class="col-4 col-medium-2 col-small-2">
-      .col-4 col-medium-2 col-small-2
+      .col-4.col-medium-2.col-small-2
     </div>
     <div class="col-4 col-medium-2 col-small-2">
-      .col-4 col-medium-2 col-small-2
+      .col-4.col-medium-2.col-small-2
     </div>
   </div>
 </div>

--- a/templates/docs/examples/patterns/grid/responsive.html
+++ b/templates/docs/examples/patterns/grid/responsive.html
@@ -3,16 +3,8 @@
 
 {% block standalone_css %}patterns_grid{% endblock %}
 
-{% block style %}
-<style>
-[class*='col-']::before {
-  content: '.' attr(class);
-}
-</style>
-{% endblock %}
-
 {% block content %}
-<div class="grid-demo">
+<div class="grid-demo u-show-col-classes">
   <div class="row">
     <div class="col-2 col-medium-1 col-small-1">
     </div>


### PR DESCRIPTION
## Done

Fixes the responsive grid example not being rendered correctly in the combined grid example. I moved its style block from the responsive example itself into a example-specific utility class that is applied to the example's main container.

Fixes #5284, [WD-13997](https://warthogs.atlassian.net/browse/WD-13997)

## QA

- Open [combined grid example](https://vanilla-framework-5285.demos.haus/docs/examples/patterns/grid/combined?theme=light) and verify that the responsive example's contents are rendered as expected. It should be at the bottom of the page.
- Very this is still true on [standalone](https://vanilla-framework-5285.demos.haus/docs/examples/standalone/patterns/grid/combined?theme=light) mode.
- Open the [responsive grid example by itself](https://vanilla-framework-5285.demos.haus/docs/examples/patterns/grid/responsive?theme=light). Check that it also renders as expected.
- Verify [responsive grid standalone example](https://vanilla-framework-5285.demos.haus/docs/examples/standalone/patterns/grid/responsive?theme=light) renders as expected.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

Before:
<img width="858" alt="Screenshot 2024-08-07 at 1 29 19 PM" src="https://github.com/user-attachments/assets/2bc7a9be-f849-4910-aadf-29d1bad66836">

After:
<img width="858" alt="Screenshot 2024-08-07 at 1 29 32 PM" src="https://github.com/user-attachments/assets/86262a0b-dce7-4f62-9a46-27f1a01f5853">



[WD-13997]: https://warthogs.atlassian.net/browse/WD-13997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ