### PR TITLE
Group Percy snapshots by test case name

### DIFF
--- a/snapshots.js
+++ b/snapshots.js
@@ -131,6 +131,8 @@ async function getPercyConfigURLs() {
 
   for (let link of links) {
     const path = new URL(link).pathname.replace(/\/?$/, '/');
+    const url = new URL(link);
+    const path = url.pathname.replace(/\/?$/, '/');
 
     for (const theme of SNAPSHOT_COLOR_THEMES) {
       const url = `${link}?${COLOR_THEME_QUERY_PARAM_NAME}=${theme}`;
@@ -139,9 +141,10 @@ async function getPercyConfigURLs() {
 
       // Default theme captured responsively, other themes captured at the largest width
       urls.push({
-        url,
+        url: snapshotUrl,
         name,
         widths,
+        testCase: url.pathname.replace(/standalone\//g, ''),
       });
     }
   }

--- a/snapshots.js
+++ b/snapshots.js
@@ -130,18 +130,16 @@ async function getPercyConfigURLs() {
   let urls = [];
 
   for (let link of links) {
-    const path = new URL(link).pathname.replace(/\/?$/, '/');
-    const url = new URL(link);
-    const path = url.pathname.replace(/\/?$/, '/');
-
     for (const theme of SNAPSHOT_COLOR_THEMES) {
-      const url = `${link}?${COLOR_THEME_QUERY_PARAM_NAME}=${theme}`;
+      const url = new URL(`${link}?${COLOR_THEME_QUERY_PARAM_NAME}=${theme}`);
+      const path = url.pathname.replace(/\/?$/, '/');
+
       const name = `${path.slice(0, path.length - 1)}?${COLOR_THEME_QUERY_PARAM_NAME}=${theme}`;
       const widths = await getWidthsForExample(path, theme);
 
       // Default theme captured responsively, other themes captured at the largest width
       urls.push({
-        url: snapshotUrl,
+        url: url.href,
         name,
         widths,
         testCase: url.pathname.replace(/standalone\//g, ''),

--- a/tests/snapshots.test.js
+++ b/tests/snapshots.test.js
@@ -110,3 +110,17 @@ test('Returns snapshots with only the expected set of color themes', async () =>
   }, new Set());
   expect(JSON.stringify(encounteredThemes)).toBe(JSON.stringify(new Set(SNAPSHOT_COLOR_THEMES)));
 });
+
+test('Returns snapshots with unique combination of test case and name', async () => {
+  const snapshots = await snapshotsTest();
+  const encounteredTestCaseAndName = new Map();
+  const failedSnapshots = [];
+  snapshots.forEach((snapshot) => {
+    const key = `${snapshot.testCase}-${snapshot.name}`;
+    if (encounteredTestCaseAndName.has(key)) {
+      failedSnapshots.push(snapshot);
+    }
+    encounteredTestCaseAndName.set(key, snapshot.url);
+  });
+  expect(failedSnapshots).toHaveLength(0);
+});


### PR DESCRIPTION
## Done

Groups Percy snapshots by example test case name. The example's path relative to repo root (ignoring `standalone/` and query parameters) is used as a test case name.

So, for example, given snapshots of `docs/examples/patterns/suru/combined?theme=light` and `docs/examples/standalone/patterns/suru/combined?theme=paper`, both snapshots are grouped under `docs/examples/patterns/suru/combined`

This means we can expect each base & pattern test case to have 6 snapshots (3 per color theme in non-standalone, and another 3 in standalone), and all other test cases will have 3 snapshots.

Read [Percy blog](https://www.browserstack.com/blog/introducing-test-case-base-grouping/) for more information on this feature.

Fixes [WD-13805](https://warthogs.atlassian.net/browse/WD-13805)

## QA

- Review [test build](https://percy.io/bb49709b/test-vanilla-gha-migration/builds/36206268/changed/1979604621?browser=chrome&browser_ids=59&category=changed%2Cunchanged&group_snapshots_by=test_case&subcategories=unreviewed%2Cchanges_requested%2Capproved&test_case_category=changed&viewLayout=overlay&viewMode=new&width=1280&widths=375%2C800%2C1280) with test-case grouping enabled. Ensure that snapshots are grouped as expected. Open the build info and make sure the expected number of screenshots was taken. The only change should be snapshot grouping - there are no changes to breakpoints, snapshot names, themes, etc.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![image](https://github.com/user-attachments/assets/14f0e6b1-58b4-4a29-8a81-90c76e03c168)


[WD-13805]: https://warthogs.atlassian.net/browse/WD-13805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ