### PR TITLE
Merge before running Percy

### DIFF
--- a/.github/workflows/percy-prepare.yml
+++ b/.github/workflows/percy-prepare.yml
@@ -29,8 +29,6 @@ jobs:
             scss/
             tokens/
             sd.config.json
-          ref: ${{ github.event.inputs.commitsh }}
-          repository: ${{ github.event.inputs.repository }}
 
       - name: Populate artifact directory
         run: |

--- a/.github/workflows/percy-prepare.yml
+++ b/.github/workflows/percy-prepare.yml
@@ -8,12 +8,11 @@ on:
       pr_number:
         required: true
         type: number
-      repository: 
-        required: true
-        type: string
+        description: "The PR number associated with the workflow call"
       commitsh:
         required: true
         type: string
+        description: "The SHA signature of the HEAD commit associated with the workflow call"
 
 jobs:
   copy_artifact:

--- a/.github/workflows/pr-percy-prepare-label.yml
+++ b/.github/workflows/pr-percy-prepare-label.yml
@@ -17,7 +17,6 @@ jobs:
     uses: ./.github/workflows/percy-prepare.yml
     with:
       pr_number: ${{ github.event.number }}
-      repository: ${{ github.repository }}
       commitsh: ${{ github.event.pull_request.head.sha }}
 
 # Completion should trigger `pr-percy-snapshots` workflow.

--- a/.github/workflows/pr-percy-prepare-push.yml
+++ b/.github/workflows/pr-percy-prepare-push.yml
@@ -24,7 +24,6 @@ jobs:
     uses: ./.github/workflows/percy-prepare.yml
     with:
       pr_number: ${{ github.event.number }}
-      repository: ${{ github.repository }}
       commitsh: ${{ github.event.pull_request.head.sha }}
 
 # Completion should trigger `pr-percy-snapshots` workflow.


### PR DESCRIPTION
## Done

Modifies the Percy "prepare" workflow to check out a merge commit of `main` and a PR, rather than the PR head commit. This reduces the need for us to rebase/merge `main` into each PR before running Percy.

Fixes #5282, [WD-13965](https://warthogs.atlassian.net/browse/WD-13965)

## QA

- Review [test PR](https://github.com/jmuzina/vanilla-framework/pull/33)
  - Download the percy artifact uploaded by the [prepare job](https://github.com/jmuzina/vanilla-framework/actions/runs/10377147930)
  - Open `scss/_vanilla.scss` and verify line 4 reads `// This was added by the PR Test`.
  - Verify that this modification to `_vanilla.scss` is not in the main branch of my fork, and was added by the test PR.
  - Open `scss/_base.scss` and verify line 2 reads `// This was added by the main branch`.
  - Verify that this modification to `_base.scss` is only in the main branch of my work, and is not present in my PR's source.
- Verify this PR's Percy workflow ran successfully. 
  - This PR has been intentionally based off of an old version of Vanilla (specifically, the version from after merging #5268 ). So, running the prepare workflow for this PR should cause a merge of this PR vs the current `main` to be checked out.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
