### PR TITLE
bug: Don't close navigation on vertical resize

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.16.1",
+  "version": "4.16.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.16.0",
+  "version": "4.16.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/templates/docs/examples/patterns/navigation/_script-sliding.js
+++ b/templates/docs/examples/patterns/navigation/_script-sliding.js
@@ -255,8 +255,18 @@ const initNavigationSliding = () => {
     };
   };
 
-  // hide side navigation drawer when screen is resized
-  window.addEventListener('resize', throttle(closeAllDropdowns, 10));
+  // hide side navigation drawer when screen is resized horizontally
+  let previousWidth = window.innerWidth;
+  window.addEventListener(
+    'resize',
+    throttle(function () {
+      const currentWidth = window.innerWidth;
+      if (currentWidth !== previousWidth) {
+        closeAllDropdowns();
+        previousWidth = currentWidth;
+      }
+    }, 10),
+  );
 };
 
 initNavigationSliding();


### PR DESCRIPTION
## Done

- Stop closing navigation on vertical resize, as this was causing the navigation to close unexpectedly when the top bar would automatically hide

Fixes [list issues/bugs if needed]

## QA

- Open [demo](https://vanilla-framework-5302.demos.haus/)
- Check that the navigation closes on horizontal resize on desktop and mobile

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
