### PR TITLE
Responsive image aspect ratio variants 

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -8,6 +8,10 @@
       url: /docs/base/forms#fieldset
       status: New
       notes: We've introduced <code>is-required</code> to legend fieldset elements.
+    - component: Image container
+      url: /docs/patterns/images#image-container-with-aspect-ratio
+      status: New
+      notes: We've added new breakpoint-specific aspect ratio classes to the image container component.
 - version: 4.15.0
   features:
     - component: CTA Block

--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -48,7 +48,7 @@ $breakpoints: (
   ),
 );
 
-@mixin aspect-ratio-classes($aspect-ratios) {
+@mixin aspect-ratio-classes {
   @each $aspect-ratio, $aspect-ratio-value in $aspect-ratios {
     .p-image-container--#{$aspect-ratio} {
       aspect-ratio: $aspect-ratio-value;
@@ -116,7 +116,7 @@ $breakpoints: (
     }
   }
 
-  @include aspect-ratio-classes($aspect-ratios);
+  @include aspect-ratio-classes;
 
   // Deprecated; will be removed in v5
   .p-image--bordered {

--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -27,27 +27,13 @@
 
 @import 'settings';
 
+// Mapping of aspect ratio class names to their `aspect-ratio` values (width / height).
 $aspect-ratios: (
   '16-9': calc(16 / 9),
   '3-2': calc(3 / 2),
   '2-3': calc(2 / 3),
-  'cinematic': calc(2.4 / 1),
+  'cinematic': 2.4,
   'square': 1,
-);
-
-$breakpoints: (
-  small: (
-    min: null,
-    max: $threshold-4-6-col,
-  ),
-  medium: (
-    min: $threshold-4-6-col,
-    max: $threshold-6-12-col,
-  ),
-  large: (
-    min: $threshold-6-12-col,
-    max: null,
-  ),
 );
 
 @mixin aspect-ratio-classes {
@@ -57,14 +43,14 @@ $breakpoints: (
     }
   }
 
-  @each $breakpoint_name, $breakpoint_bounds in $breakpoints {
-    $min-width: map-get($breakpoint_bounds, min);
-    $max-width: map-get($breakpoint_bounds, max);
+  @each $breakpoint-name, $breakpoint-bounds-pair in $breakpoint-bounds {
+    $min-width: map-get($breakpoint-bounds-pair, min);
+    $max-width: map-get($breakpoint-bounds-pair, max);
 
     @if $min-width and $max-width {
       @media ($min-width <= width < $max-width) {
         @each $aspect-ratio, $aspect-ratio-value in $aspect-ratios {
-          .p-image-container--#{$aspect-ratio}-on-#{$breakpoint_name} {
+          .p-image-container--#{$aspect-ratio}-on-#{$breakpoint-name} {
             aspect-ratio: $aspect-ratio-value;
           }
         }
@@ -72,7 +58,7 @@ $breakpoints: (
     } @else if $min-width {
       @media (min-width: $min-width) {
         @each $aspect-ratio, $aspect-ratio-value in $aspect-ratios {
-          .p-image-container--#{$aspect-ratio}-on-#{$breakpoint_name} {
+          .p-image-container--#{$aspect-ratio}-on-#{$breakpoint-name} {
             aspect-ratio: $aspect-ratio-value;
           }
         }
@@ -80,7 +66,7 @@ $breakpoints: (
     } @else if $max-width {
       @media (max-width: $max-width) {
         @each $aspect-ratio, $aspect-ratio-value in $aspect-ratios {
-          .p-image-container--#{$aspect-ratio}-on-#{$breakpoint_name} {
+          .p-image-container--#{$aspect-ratio}-on-#{$breakpoint-name} {
             aspect-ratio: $aspect-ratio-value;
           }
         }

--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -18,6 +18,8 @@
         Wraps contents in a container with an aspect ratio of 2.4:1.
       .p-image-container--square:
         Wraps contents in a container with an aspect ratio of 1:1.
+      .p-image-container--(16-9|3-2|2-3|cinematic|square)-on-(small|medium|large):
+        Wraps contents in a container with the specified aspect ratio on the specified breakpoint.
     Image:
       .p-image-container__image:
         Image element within an image container.

--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -25,6 +25,68 @@
 
 @import 'settings';
 
+$aspect-ratios: (
+  '16-9': calc(16 / 9),
+  '3-2': calc(3 / 2),
+  '2-3': calc(2 / 3),
+  'cinematic': calc(2.4 / 1),
+  'square': 1,
+);
+
+$breakpoints: (
+  small: (
+    min: null,
+    max: $threshold-4-6-col,
+  ),
+  medium: (
+    min: $threshold-4-6-col,
+    max: $threshold-6-12-col,
+  ),
+  large: (
+    min: $threshold-6-12-col,
+    max: null,
+  ),
+);
+
+@mixin aspect-ratio-classes($aspect-ratios) {
+  @each $aspect-ratio, $aspect-ratio-value in $aspect-ratios {
+    .p-image-container--#{$aspect-ratio} {
+      aspect-ratio: $aspect-ratio-value;
+    }
+  }
+
+  @each $breakpoint_name, $breakpoint_bounds in $breakpoints {
+    $min-width: map-get($breakpoint_bounds, min);
+    $max-width: map-get($breakpoint_bounds, max);
+
+    @if $min-width and $max-width {
+      @media ($min-width <= width < $max-width) {
+        @each $aspect-ratio, $aspect-ratio-value in $aspect-ratios {
+          .p-image-container--#{$aspect-ratio}-on-#{$breakpoint_name} {
+            aspect-ratio: $aspect-ratio-value;
+          }
+        }
+      }
+    } @else if $min-width {
+      @media (min-width: $min-width) {
+        @each $aspect-ratio, $aspect-ratio-value in $aspect-ratios {
+          .p-image-container--#{$aspect-ratio}-on-#{$breakpoint_name} {
+            aspect-ratio: $aspect-ratio-value;
+          }
+        }
+      }
+    } @else if $max-width {
+      @media (max-width: $max-width) {
+        @each $aspect-ratio, $aspect-ratio-value in $aspect-ratios {
+          .p-image-container--#{$aspect-ratio}-on-#{$breakpoint_name} {
+            aspect-ratio: $aspect-ratio-value;
+          }
+        }
+      }
+    }
+  }
+}
+
 @mixin vf-p-image {
   .p-image-container,
   [class^='p-image-container--'] {
@@ -54,21 +116,7 @@
     }
   }
 
-  .p-image-container--16-9 {
-    aspect-ratio: 16/9;
-  }
-  .p-image-container--3-2 {
-    aspect-ratio: 3/2;
-  }
-  .p-image-container--2-3 {
-    aspect-ratio: 2/3;
-  }
-  .p-image-container--cinematic {
-    aspect-ratio: 2.4/1;
-  }
-  .p-image-container--square {
-    aspect-ratio: 1/1;
-  }
+  @include aspect-ratio-classes($aspect-ratios);
 
   // Deprecated; will be removed in v5
   .p-image--bordered {

--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -56,7 +56,7 @@ $aspect-ratios: (
         }
       }
     } @else if $min-width {
-      @media (min-width: $min-width) {
+      @media (width >= $min-width) {
         @each $aspect-ratio, $aspect-ratio-value in $aspect-ratios {
           .p-image-container--#{$aspect-ratio}-on-#{$breakpoint-name} {
             aspect-ratio: $aspect-ratio-value;
@@ -64,7 +64,7 @@ $aspect-ratios: (
         }
       }
     } @else if $max-width {
-      @media (max-width: $max-width) {
+      @media (width < $max-width) {
         @each $aspect-ratio, $aspect-ratio-value in $aspect-ratios {
           .p-image-container--#{$aspect-ratio}-on-#{$breakpoint-name} {
             aspect-ratio: $aspect-ratio-value;

--- a/scss/_settings_breakpoints.scss
+++ b/scss/_settings_breakpoints.scss
@@ -5,3 +5,19 @@ $breakpoint-large: 1036px !default;
 $breakpoint-navigation-threshold: $breakpoint-large !default;
 $breakpoint-heading-threshold: $breakpoint-large !default;
 $breakpoint-x-large: 1681px !default; // exclude most laptops
+
+// Mapping of breakpoint names to the min and max widths at which they apply.
+$breakpoint-bounds: (
+  small: (
+    min: null,
+    max: $breakpoint-small,
+  ),
+  medium: (
+    min: $breakpoint-small,
+    max: $breakpoint-large,
+  ),
+  large: (
+    min: $breakpoint-large,
+    max: null,
+  ),
+);

--- a/templates/docs/examples/patterns/image/container/aspect-ratio/all.html
+++ b/templates/docs/examples/patterns/image/container/aspect-ratio/all.html
@@ -4,44 +4,47 @@
 {% block standalone_css %}patterns_image{% endblock %}
 
 {% block content %}
-  <div>
+  <section>
     <span>16:9</span>
     {% include 'docs/examples/patterns/image/container/aspect-ratio/16-9.html' %}
-  </div>
-  <div>
+  </section>
+  <section>
     <span>16:9 (with 16:9 image)</span>
     <div class="p-image-container--16-9 is-highlighted">
       <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/7c9867c1-16x9.png" width="1200" alt="">
     </div>
-  </div>
-  <div>
+  </section>
+  <section>
     <span>3:2</span>
     <div class="p-image-container--3-2 is-highlighted">
       <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
     </div>
-  </div>
-  <div>
+  </section>
+  <section>
     <span>2:3</span>
     <div class="p-image-container--2-3 is-highlighted">
       <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
     </div>
-  </div>
-  <div>
+  </section>
+  <section>
     <span>2:3 (with 2:3 image)</span>
     <div class="p-image-container--2-3 is-highlighted">
       <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/e97cdac9-2x3.png" width="1200" alt="">
     </div>
-  </div>
-  <div>
+  </section>
+  <section>
     <span>2.4:1 (Cinematic)</span>
     <div class="p-image-container--cinematic is-highlighted">
       <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
     </div>
-  </div>
-  <div>
+  </section>
+  <section>
     <span>1:1 (Square)</span>
     <div class="p-image-container--square is-highlighted">
       <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
     </div>
-  </div>
+  </section>
+  <section>
+    {% include 'docs/examples/patterns/image/container/aspect-ratio/responsive-all.html' %}
+  </section>
 {% endblock %}

--- a/templates/docs/examples/patterns/image/container/aspect-ratio/responsive-all.html
+++ b/templates/docs/examples/patterns/image/container/aspect-ratio/responsive-all.html
@@ -1,0 +1,140 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Image Container / Aspect Ratio / Responsive / All{% endblock %}
+
+{% block standalone_css %}patterns_image{% endblock %}
+
+{% block content %}
+  <section>
+    <span>Cinematic on large, 16:9 on medium, 2:3 on small</span>
+    {% include 'docs/examples/patterns/image/container/aspect-ratio/responsive.html' %}
+  </section>
+
+  <section>
+    <span>Cinematic on large, 16:9 on medium</span>
+    <div class="p-image-container--cinematic-on-large p-image-container--16-9-on-medium is-highlighted">
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </section>
+
+  <section>
+    <span>Cinematic on large, 2:3 on small</span>
+    <div class="p-image-container--cinematic-on-large p-image-container--2-3-on-small is-highlighted">
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </section>
+
+  <section>
+    <span>16:9 on medium, 2:3 on small</span>
+    <div class="p-image-container--16-9-on-medium p-image-container--2-3-on-small is-highlighted">
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </section>
+
+  <section>
+    <span>Cinematic on large</span>
+    <div class="p-image-container--cinematic-on-large is-highlighted">
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </section>
+
+  <section>
+    <span>Cinematic on large, 16:9 on medium</span>
+    <div class="p-image-container--cinematic-on-large p-image-container--16-9-on-medium is-highlighted">
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </section>
+
+  <section>
+    <span>Cinematic on large, 2:3 on small</span>
+    <div class="p-image-container--cinematic-on-large p-image-container--2-3-on-small is-highlighted">
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </section>
+
+  <section>
+    <span>16:9 on medium</span>
+    <div class="p-image-container--16-9-on-medium is-highlighted">
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </section>
+
+  <section>
+    <span>16:9 on medium, 2:3 on small</span>
+    <div class="p-image-container--16-9-on-medium p-image-container--2-3-on-small is-highlighted">
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </section>
+
+  <section>
+    <span>2:3 on small</span>
+    <div class="p-image-container--2-3-on-small is-highlighted">
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </section>
+
+  <section>
+    <span>16:9 on medium</span>
+    <div class="p-image-container--16-9-on-medium is-highlighted">
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </section>
+
+  <section>
+    <span>Cinematic on large, 16:9 on medium, 2:3 on small</span>
+    <div class="p-image-container--cinematic-on-large p-image-container--16-9-on-medium p-image-container--2-3-on-small is-highlighted">
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </section>
+
+  <section>
+    <span>Cinematic on large, 16:9 on medium</span>
+    <div class="p-image-container--cinematic-on-large p-image-container--16-9-on-medium is-highlighted">
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </section>
+
+  <section>
+    <span>Cinematic on large, 2:3 on small</span>
+    <div class="p-image-container--cinematic-on-large p-image-container--2-3-on-small is-highlighted">
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </section>
+
+  <section>
+    <span>16:9 on medium, 2:3 on small</span>
+    <div class="p-image-container--16-9-on-medium p-image-container--2-3-on-small is-highlighted">
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </section>
+
+  <section>
+    <span>16:9 on medium</span>
+    <div class="p-image-container--16-9-on-medium is-highlighted">
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </section>
+
+  <section>
+    <span>2:3 on small</span>
+    <div class="p-image-container--2-3-on-small is-highlighted">
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    </div>
+  </section>
+
+{% endblock %}

--- a/templates/docs/examples/patterns/image/container/aspect-ratio/responsive.html
+++ b/templates/docs/examples/patterns/image/container/aspect-ratio/responsive.html
@@ -5,6 +5,7 @@
 
 {% block content %}
   <div class="p-image-container--cinematic-on-large p-image-container--16-9-on-medium p-image-container--2-3-on-small is-highlighted">
-    <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+    <img class="p-image-container__image"
+         src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
   </div>
 {% endblock %}

--- a/templates/docs/examples/patterns/image/container/aspect-ratio/responsive.html
+++ b/templates/docs/examples/patterns/image/container/aspect-ratio/responsive.html
@@ -1,0 +1,10 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Image Container / Aspect Ratio / Responsive{% endblock %}
+
+{% block standalone_css %}patterns_image{% endblock %}
+
+{% block content %}
+  <div class="p-image-container--cinematic-on-large p-image-container--16-9-on-medium p-image-container--2-3-on-small is-highlighted">
+    <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/9b4c074f-Kernelt%20industries-80-short.png" width="300" alt="">
+  </div>
+{% endblock %}

--- a/templates/docs/patterns/images.md
+++ b/templates/docs/patterns/images.md
@@ -29,6 +29,37 @@ See the [class references section](#class-reference) for more information on the
 View example of image container with 16/9 aspect ratio
 </a></div>
 
+### Responsive aspect ratio
+
+You can apply different aspect ratios on different screen sizes by using the responsive aspect ratio classes.
+
+| Class name                                           | Large | Medium | Small |
+| ---------------------------------------------------- | ----- | ------ | ----- |
+| <code>.p-image-container--16-9</code>                | 16:9  | 16:9   | 16:9  |
+| <code>.p-image-container--16-9-on-large</code>       | 16:9  | -      | -     |
+| <code>.p-image-container--16-9-on-medium</code>      | -     | 16:9   | -     |
+| <code>.p-image-container--16-9-on-small</code>       | -     | -      | 16:9  |
+| <code>.p-image-container--3-2</code>                 | 3:2   | 3:2    | 3:2   |
+| <code>.p-image-container--3-2-on-large</code>        | 3:2   | -      | -     |
+| <code>.p-image-container--3-2-on-medium</code>       | -     | 3:2    | -     |
+| <code>.p-image-container--3-2-on-small</code>        | -     | -      | 3:2   |
+| <code>.p-image-container--2-3</code>                 | 2:3   | 2:3    | 2:3   |
+| <code>.p-image-container--2-3-on-large</code>        | 2:3   | -      | -     |
+| <code>.p-image-container--2-3-on-medium</code>       | -     | 2:3    | -     |
+| <code>.p-image-container--2-3-on-small</code>        | -     | -      | 2:3   |
+| <code>.p-image-container--cinematic</code>           | 2.4:1 | 2.4:1  | 2.4:1 |
+| <code>.p-image-container--cinematic-on-large</code>  | 2.4:1 | -      | -     |
+| <code>.p-image-container--cinematic-on-medium</code> | -     | 2.4:1  | -     |
+| <code>.p-image-container--cinematic-on-small</code>  | -     | -      | 2.4:1 |
+| <code>.p-image-container--square</code>              | 1:1   | 1:1    | 1:1   |
+| <code>.p-image-container--square-on-large</code>     | 1:1   | -      | -     |
+| <code>.p-image-container--square-on-medium</code>    | -     | 1:1    | -     |
+| <code>.p-image-container--square-on-small</code>     | -     | -      | 1:1   |
+
+<div class="embedded-example"><a href="/docs/examples/patterns/image/container/aspect-ratio/responsive" class="js-example">
+View example of an image container with aspect ratios that respond to the screen size
+</a></div>
+
 ## Cover image
 
 Cover images are used to fill the entire container, cropping the image if necessary. This can be combined with the aspect ratio modifier to crop the image to a specific aspect ratio.

--- a/templates/docs/patterns/images.md
+++ b/templates/docs/patterns/images.md
@@ -34,28 +34,28 @@ View example of image container with 16/9 aspect ratio
 You can apply different aspect ratios on different screen sizes by using the responsive aspect ratio classes.
 See the table below for a list of all aspect ratio class names and their corresponding aspect ratios on each breakpoint.
 
-| Class name                                           | Large | Medium | Small |
-| ---------------------------------------------------- | ----- | ------ | ----- |
-| <code>.p-image-container--16-9</code>                | 16:9  | 16:9   | 16:9  |
-| <code>.p-image-container--16-9-on-large</code>       | 16:9  | -      | -     |
-| <code>.p-image-container--16-9-on-medium</code>      | -     | 16:9   | -     |
-| <code>.p-image-container--16-9-on-small</code>       | -     | -      | 16:9  |
-| <code>.p-image-container--3-2</code>                 | 3:2   | 3:2    | 3:2   |
-| <code>.p-image-container--3-2-on-large</code>        | 3:2   | -      | -     |
-| <code>.p-image-container--3-2-on-medium</code>       | -     | 3:2    | -     |
-| <code>.p-image-container--3-2-on-small</code>        | -     | -      | 3:2   |
-| <code>.p-image-container--2-3</code>                 | 2:3   | 2:3    | 2:3   |
-| <code>.p-image-container--2-3-on-large</code>        | 2:3   | -      | -     |
-| <code>.p-image-container--2-3-on-medium</code>       | -     | 2:3    | -     |
-| <code>.p-image-container--2-3-on-small</code>        | -     | -      | 2:3   |
-| <code>.p-image-container--cinematic</code>           | 2.4:1 | 2.4:1  | 2.4:1 |
-| <code>.p-image-container--cinematic-on-large</code>  | 2.4:1 | -      | -     |
-| <code>.p-image-container--cinematic-on-medium</code> | -     | 2.4:1  | -     |
-| <code>.p-image-container--cinematic-on-small</code>  | -     | -      | 2.4:1 |
-| <code>.p-image-container--square</code>              | 1:1   | 1:1    | 1:1   |
-| <code>.p-image-container--square-on-large</code>     | 1:1   | -      | -     |
-| <code>.p-image-container--square-on-medium</code>    | -     | 1:1    | -     |
-| <code>.p-image-container--square-on-small</code>     | -     | -      | 1:1   |
+| Class name                                | Large | Medium | Small |
+| ----------------------------------------- | ----- | ------ | ----- |
+| `.p-image-container--16-9`                | 16:9  | 16:9   | 16:9  |
+| `.p-image-container--16-9-on-large`       | 16:9  | -      | -     |
+| `.p-image-container--16-9-on-medium`      | -     | 16:9   | -     |
+| `.p-image-container--16-9-on-small`       | -     | -      | 16:9  |
+| `.p-image-container--3-2`                 | 3:2   | 3:2    | 3:2   |
+| `.p-image-container--3-2-on-large`        | 3:2   | -      | -     |
+| `.p-image-container--3-2-on-medium`       | -     | 3:2    | -     |
+| `.p-image-container--3-2-on-small`        | -     | -      | 3:2   |
+| `.p-image-container--2-3`                 | 2:3   | 2:3    | 2:3   |
+| `.p-image-container--2-3-on-large`        | 2:3   | -      | -     |
+| `.p-image-container--2-3-on-medium`       | -     | 2:3    | -     |
+| `.p-image-container--2-3-on-small`        | -     | -      | 2:3   |
+| `.p-image-container--cinematic`           | 2.4:1 | 2.4:1  | 2.4:1 |
+| `.p-image-container--cinematic-on-large`  | 2.4:1 | -      | -     |
+| `.p-image-container--cinematic-on-medium` | -     | 2.4:1  | -     |
+| `.p-image-container--cinematic-on-small`  | -     | -      | 2.4:1 |
+| `.p-image-container--square`              | 1:1   | 1:1    | 1:1   |
+| `.p-image-container--square-on-large`     | 1:1   | -      | -     |
+| `.p-image-container--square-on-medium`    | -     | 1:1    | -     |
+| `.p-image-container--square-on-small`     | -     | -      | 1:1   |
 
 <div class="embedded-example"><a href="/docs/examples/patterns/image/container/aspect-ratio/responsive" class="js-example">
 View example of an image container with aspect ratios that respond to the screen size

--- a/templates/docs/patterns/images.md
+++ b/templates/docs/patterns/images.md
@@ -31,6 +31,11 @@ View example of image container with 16/9 aspect ratio
 
 ### Responsive aspect ratio
 
+It can be useful to change the aspect ratio of an image container, depending on the screen size.
+Using a tall aspect ratio on a small screen, or a wide aspect ratio on a large screen, may waste page space or make the image's details less visible.
+For example, the cinematic aspect ratio (2.4:1) is great in cases where there are at least 9 columns available.
+However, using this aspect ratio on a small screen may make the image too small to see its details, so aspect ratios like 16:9 or 3:2 may be more appropriate.
+
 You can apply different aspect ratios on different screen sizes by using the responsive aspect ratio classes.
 See the table below for a list of all aspect ratio class names and their corresponding aspect ratios on each breakpoint.
 

--- a/templates/docs/patterns/images.md
+++ b/templates/docs/patterns/images.md
@@ -32,6 +32,7 @@ View example of image container with 16/9 aspect ratio
 ### Responsive aspect ratio
 
 You can apply different aspect ratios on different screen sizes by using the responsive aspect ratio classes.
+See the table below for a list of all aspect ratio class names and their corresponding aspect ratios on each breakpoint.
 
 | Class name                                           | Large | Medium | Small |
 | ---------------------------------------------------- | ----- | ------ | ----- |

--- a/templates/docs/patterns/images.md
+++ b/templates/docs/patterns/images.md
@@ -34,28 +34,138 @@ View example of image container with 16/9 aspect ratio
 You can apply different aspect ratios on different screen sizes by using the responsive aspect ratio classes.
 See the table below for a list of all aspect ratio class names and their corresponding aspect ratios on each breakpoint.
 
-| Class name                                | Large | Medium | Small |
-| ----------------------------------------- | ----- | ------ | ----- |
-| `.p-image-container--16-9`                | 16:9  | 16:9   | 16:9  |
-| `.p-image-container--16-9-on-large`       | 16:9  | -      | -     |
-| `.p-image-container--16-9-on-medium`      | -     | 16:9   | -     |
-| `.p-image-container--16-9-on-small`       | -     | -      | 16:9  |
-| `.p-image-container--3-2`                 | 3:2   | 3:2    | 3:2   |
-| `.p-image-container--3-2-on-large`        | 3:2   | -      | -     |
-| `.p-image-container--3-2-on-medium`       | -     | 3:2    | -     |
-| `.p-image-container--3-2-on-small`        | -     | -      | 3:2   |
-| `.p-image-container--2-3`                 | 2:3   | 2:3    | 2:3   |
-| `.p-image-container--2-3-on-large`        | 2:3   | -      | -     |
-| `.p-image-container--2-3-on-medium`       | -     | 2:3    | -     |
-| `.p-image-container--2-3-on-small`        | -     | -      | 2:3   |
-| `.p-image-container--cinematic`           | 2.4:1 | 2.4:1  | 2.4:1 |
-| `.p-image-container--cinematic-on-large`  | 2.4:1 | -      | -     |
-| `.p-image-container--cinematic-on-medium` | -     | 2.4:1  | -     |
-| `.p-image-container--cinematic-on-small`  | -     | -      | 2.4:1 |
-| `.p-image-container--square`              | 1:1   | 1:1    | 1:1   |
-| `.p-image-container--square-on-large`     | 1:1   | -      | -     |
-| `.p-image-container--square-on-medium`    | -     | 1:1    | -     |
-| `.p-image-container--square-on-small`     | -     | -      | 1:1   |
+<table>
+  <thead>
+    <tr>
+      <th style="width: 400px; max-width: 75svw;">Class name</th>
+      <th>Large</th>
+      <th>Medium</th>
+      <th>Small</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>.p-image-container--16-9</code></td>
+      <td>16:9</td>
+      <td>16:9</td>
+      <td>16:9</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--16-9-on-large</code></td>
+      <td>16:9</td>
+      <td>-</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--16-9-on-medium</code></td>
+      <td>-</td>
+      <td>16:9</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--16-9-on-small</code></td>
+      <td>-</td>
+      <td>-</td>
+      <td>16:9</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--3-2</code></td>
+      <td>3:2</td>
+      <td>3:2</td>
+      <td>3:2</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--3-2-on-large</code></td>
+      <td>3:2</td>
+      <td>-</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--3-2-on-medium</code></td>
+      <td>-</td>
+      <td>3:2</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--3-2-on-small</code></td>
+      <td>-</td>
+      <td>-</td>
+      <td>3:2</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--2-3</code></td>
+      <td>2:3</td>
+      <td>2:3</td>
+      <td>2:3</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--2-3-on-large</code></td>
+      <td>2:3</td>
+      <td>-</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--2-3-on-medium</code></td>
+      <td>-</td>
+      <td>2:3</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--2-3-on-small</code></td>
+      <td>-</td>
+      <td>-</td>
+      <td>2:3</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--cinematic</code></td>
+      <td>2.4:1</td>
+      <td>2.4:1</td>
+      <td>2.4:1</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--cinematic-on-large</code></td>
+      <td>2.4:1</td>
+      <td>-</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--cinematic-on-medium</code></td>
+      <td>-</td>
+      <td>2.4:1</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--cinematic-on-small</code></td>
+      <td>-</td>
+      <td>-</td>
+      <td>2.4:1</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--square</code></td>
+      <td>1:1</td>
+      <td>1:1</td>
+      <td>1:1</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--square-on-large</code></td>
+      <td>1:1</td>
+      <td>-</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--square-on-medium</code></td>
+      <td>-</td>
+      <td>1:1</td>
+      <td>-</td>
+    </tr>
+    <tr>
+      <td><code>.p-image-container--square-on-small</code></td>
+      <td>-</td>
+      <td>-</td>
+      <td>1:1</td>
+    </tr>
+  </tbody>
+</table>
 
 <div class="embedded-example"><a href="/docs/examples/patterns/image/container/aspect-ratio/responsive" class="js-example">
 View example of an image container with aspect ratios that respond to the screen size

--- a/tests/snapshots.test.js
+++ b/tests/snapshots.test.js
@@ -6,7 +6,7 @@ const {SNAPSHOT_BREAKPOINTS, SNAPSHOT_COLOR_THEMES, PORT, DEFAULT_COLOR_THEME, C
  * Combined examples that embed responsive examples.
  * @type {Array<String>} Mapping of example urls to whether they embed responsive examples.
  */
-const RESPONSIVE_COMBINED_EXAMPLES = ['patterns/grid/combined', 'patterns/divider/combined'];
+const RESPONSIVE_COMBINED_EXAMPLES = ['patterns/grid/combined', 'patterns/divider/combined', 'patterns/image/combined'];
 
 test('Returns correct widths for snapshots, including additional breakpoint for responsive examples', async () => {
   const snapshots = await snapshotsTest();


### PR DESCRIPTION
## Done

Adds new `-on-(large|medium|small)` variants of each aspect ratio image container class for more precise control over aspect ratios, depending on the screen size.

Fixes #5274, [WD-13920](https://warthogs.atlassian.net/browse/WD-13920)

## QA

- Open the [responsive-all example](https://vanilla-framework-5308.demos.haus/docs/examples/patterns/image/container/aspect-ratio/responsive-all?theme=light) and verify that the aspect ratio labels above each example there are correct by resizing the window. 
  - Make sure to check at the breakpoints. As long as there are not two classes for the same breakpoint, no two responsive aspect ratio classes should be active.
    - Large: `width >=1036px`
    - Medium: `620px >= width < 1036px`
    - Small: `width < 620px`
- Verify the responsive examples were added to the [combined image example](https://vanilla-framework-5308.demos.haus/docs/examples/patterns/image/combined?theme=light)
- Review [image container with aspect ratio docs](https://vanilla-framework-5308.demos.haus/docs/patterns/images#image-container-with-aspect-ratio)
- Review [4.16.0 release notes](https://vanilla-framework-5308.demos.haus/docs/whats-new)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


[WD-13920]: https://warthogs.atlassian.net/browse/WD-13920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ