### PR TITLE
Add button to close example toolbar

### DIFF
--- a/scss/docs/example.scss
+++ b/scss/docs/example.scss
@@ -20,18 +20,22 @@ body {
   box-shadow: $box-shadow--deep;
   display: flex;
   flex-flow: row wrap;
-  gap: $sph--x-large;
+  gap: $sph--small;
   left: 0;
   padding: $spv--x-small $sph--x-small;
   position: fixed;
   right: 0;
 
+  // Above *all* other elements.
+  z-index: 1000000;
+
   .p-example-controls__close-button {
     margin-left: auto;
   }
 
-  // Above *all* other elements.
-  z-index: 1000000;
+  @media (min-width: $breakpoint-small) {
+    gap: $sph--large;
+  }
 
   @media only percy {
     visibility: hidden !important;

--- a/scss/docs/example.scss
+++ b/scss/docs/example.scss
@@ -20,12 +20,15 @@ body {
   box-shadow: $box-shadow--deep;
   display: flex;
   flex-flow: row wrap;
-  gap: $sp-unit;
-  justify-content: space-between;
+  gap: $sph--x-large;
   left: 0;
   padding: $spv--x-small $sph--x-small;
   position: fixed;
   right: 0;
+
+  .p-example-controls__close-button {
+    margin-left: auto;
+  }
 
   // Above *all* other elements.
   z-index: 1000000;

--- a/templates/static/js/example-tools.js
+++ b/templates/static/js/example-tools.js
@@ -154,7 +154,7 @@ var activeTheme = DEFAULT_COLOR_THEME;
       controls.appendChild(baselineGridControl);
 
       const closeButtonFragment = fragmentFromString(`
-        <button class="p-button--negative is-dense p-example-controls__close-button" id="js-example-toolbar-close-button">
+        <button class="p-button is-dense p-example-controls__close-button" id="js-example-toolbar-close-button">
           Close
         </button>
       `);

--- a/templates/static/js/example-tools.js
+++ b/templates/static/js/example-tools.js
@@ -153,7 +153,16 @@ var activeTheme = DEFAULT_COLOR_THEME;
       );
       controls.appendChild(baselineGridControl);
 
+      const closeButtonFragment = fragmentFromString(`
+        <button class="p-button--negative is-dense p-example-controls__close-button" id="js-example-toolbar-close-button">
+          Close
+        </button>,
+      `);
+      controls.appendChild(closeButtonFragment);
       body.appendChild(controls);
+
+      var closeButton = document.getElementById('js-example-toolbar-close-button');
+      closeButton.addEventListener('click', () => controls.remove());
 
       // Below code relies on the controls already existing in the DOM, so must come after `body.appendChild`.
       var themeToggleButtons = document.querySelectorAll('.p-theme-toggle__button');

--- a/templates/static/js/example-tools.js
+++ b/templates/static/js/example-tools.js
@@ -156,7 +156,7 @@ var activeTheme = DEFAULT_COLOR_THEME;
       const closeButtonFragment = fragmentFromString(`
         <button class="p-button--negative is-dense p-example-controls__close-button" id="js-example-toolbar-close-button">
           Close
-        </button>,
+        </button>
       `);
       controls.appendChild(closeButtonFragment);
       body.appendChild(controls);


### PR DESCRIPTION
## Done

Adds a button to the example controls toolbar that closes the controls toolbar. This allows content behind the toolbar to be seen.

Fixes #5283 , [WD-13996](https://warthogs.atlassian.net/browse/WD-13996)

## QA

- Open any example. Try [button](https://vanilla-framework-5309.demos.haus/docs/examples/base/button?theme=light).
- Click the "Close" button in the example toolbar.
- Verify the example controls toolbar is removed from view.
- Refresh the page.
- Verify the toolbar is rendered again.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
<img width="834" alt="Screenshot 2024-08-19 at 1 16 47 PM" src="https://github.com/user-attachments/assets/e9936f4b-96dc-4ed0-b6a4-ae17a450411c">

[WD-13996]: https://warthogs.atlassian.net/browse/WD-13996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ