### PR TITLE
Set icon alignment in paragraph to text-bottom

### DIFF
--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -89,6 +89,10 @@
       vertical-align: 0;
     }
   }
+
+  p > [class*='p-icon'] {
+    vertical-align: middle;
+  }
   // stylelint-enable selector-max-type
 }
 


### PR DESCRIPTION
## Done

- Set icons in paragraph to have a `vertical-align` set to `middle`

Fixes #5103 
Fixes [WD-13630](https://warthogs.atlassian.net/browse/WD-13630)

## QA

- Open [demo](https://vanilla-framework-5314.demos.haus/docs/patterns/icons#standard)
- Verify icons are aligned to the middle. Increase font-size if necessary to test.
- Review updated documentation:
  - No Changes in documentation

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]


[WD-13630]: https://warthogs.atlassian.net/browse/WD-13630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ