### PR TITLE
Update layout files to use CSS range syntax

### DIFF
--- a/scss/_layouts_fluid-breakout.scss
+++ b/scss/_layouts_fluid-breakout.scss
@@ -149,7 +149,7 @@
       grid-column: 2 / -1;
       grid-template-columns: repeat(2, minmax(0, 1fr));
 
-      @media (max-width: $threshold-4-6-col - 1) {
+      @media (width < $threshold-4-6-col) {
         grid-template-columns: repeat(1, minmax(0, 1fr));
         width: $l-fluid-breakout-main-child-width;
       }
@@ -163,7 +163,7 @@
       &:nth-child(2) {
         justify-content: flex-end;
 
-        @media (max-width: $threshold-4-6-col - 1) {
+        @media (width < $threshold-4-6-col) {
           justify-content: flex-start;
         }
       }


### PR DESCRIPTION
## Done

- Updated layout files to use new CSS range syntax, based on conversation in #5287 - this resolves an existing issue where gaps would exist between breakpoints for these utilities

Fixes #5312 
Fixes [WD-14298](https://warthogs.atlassian.net/browse/WD-14298)

## QA

- Open [fluid breakout layout demo](https://vanilla-framework-5315.demos.haus/docs/examples/layouts/fluid-breakout/fluid-breakout-cards-with-aside-and-toolbar?theme=light)
- Ensure correct styles are applied to toolbar/toolbar items between each breakpoint - the best way to test this is to reduce the browser window to ~619.5px and ensure styles are applied

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [X] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [X] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [X] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


[WD-14298]: https://warthogs.atlassian.net/browse/WD-14298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ