### PR TITLE
Add theme support to tooltip component

### DIFF
--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -33,10 +33,11 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
 
   .p-tooltip__message {
     @extend %small-text;
+    @include vf-theme-dark;
 
-    background-color: $color-dark;
+    background-color: $colors--theme--background-alt;
     border: 0;
-    color: $color-x-light;
+    color: $colors--theme--text-default;
     display: none;
     left: -2 * $triangle-height;
     margin-bottom: 0;
@@ -57,7 +58,7 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
     // tooltip
     &::before {
       border: {
-        bottom: $triangle-height solid $color-dark;
+        bottom: $triangle-height solid $colors--theme--background-alt;
         left: $triangle-height solid transparent;
         right: $triangle-height solid transparent;
       }
@@ -152,7 +153,7 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
           bottom: $triangle-height solid transparent;
           left: $triangle-height solid transparent;
           right: $triangle-height solid transparent;
-          top: $triangle-height solid $color-dark;
+          top: $triangle-height solid $colors--theme--background-alt;
         }
 
         bottom: -2 * $triangle-height;
@@ -186,7 +187,7 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
           bottom: $triangle-height solid transparent;
           left: $triangle-height solid transparent;
           right: $triangle-height solid transparent;
-          top: $triangle-height solid $color-dark;
+          top: $triangle-height solid $colors--theme--background-alt;
         }
 
         bottom: -2 * $triangle-height;
@@ -223,7 +224,7 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
           bottom: $triangle-height solid transparent;
           left: $triangle-height solid transparent;
           right: $triangle-height solid transparent;
-          top: $triangle-height solid $color-dark;
+          top: $triangle-height solid $colors--theme--background-alt;
         }
 
         bottom: -2 * $triangle-height;
@@ -257,7 +258,7 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
         border: {
           bottom: $triangle-height solid transparent;
           left: $triangle-height solid transparent;
-          right: $triangle-height solid $color-dark;
+          right: $triangle-height solid $colors--theme--background-alt;
           top: $triangle-height solid transparent;
         }
 
@@ -296,7 +297,7 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
       &::before {
         border: {
           bottom: $triangle-height solid transparent;
-          left: $triangle-height solid $color-dark;
+          left: $triangle-height solid $colors--theme--background-alt;
           right: $triangle-height solid transparent;
           top: $triangle-height solid transparent;
         }

--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -53,13 +53,16 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
     @include vf-theme-dark; // Default to dark theme
 
     // Apply light theme if an ancestor has the `is-dark` class
-    .is-dark & {
+    body.is-dark &,
+    .p-tooltip.is-dark & {
       @include vf-theme-light;
     }
 
     // Override to dark theme if an ancestor has `is-light` or `is-paper` class
-    .is-light &,
-    .is-paper & {
+    body.is-light &,
+    body.is-paper &,
+    .p-tooltip.is-light &,
+    .p-tooltip.is-paper & {
       @include vf-theme-dark;
     }
 

--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -52,19 +52,21 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
 
     @include vf-theme-dark; // Default to dark theme
 
-    // Apply light theme if an ancestor has the `is-dark` class
+    // stylelint-disable selector-max-type -- Tooltip theming is based on theming of the document body.
+    // Apply light theme if the page or the tooltip component is dark
     body.is-dark &,
     .p-tooltip.is-dark & {
       @include vf-theme-light;
     }
 
-    // Override to dark theme if an ancestor has `is-light` or `is-paper` class
+    // Override to dark theme if the page or the tooltip component is light or paper
     body.is-light &,
     body.is-paper &,
     .p-tooltip.is-light &,
     .p-tooltip.is-paper & {
       @include vf-theme-dark;
     }
+    // stylelint-enable selector-max-type
 
     .is-detached & {
       display: block;

--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -33,7 +33,6 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
 
   .p-tooltip__message {
     @extend %small-text;
-    @include vf-theme-dark;
 
     background-color: $colors--theme--background-alt;
     border: 0;
@@ -50,6 +49,19 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
     transform: translateX(0%) translateY(13px);
     white-space: pre;
     z-index: 11; // one step above p-navigation's z-index
+
+    @include vf-theme-dark; // Default to dark theme
+
+    // Apply light theme if an ancestor has the `is-dark` class
+    .is-dark & {
+      @include vf-theme-light;
+    }
+
+    // Override to dark theme if an ancestor has `is-light` or `is-paper` class
+    .is-light &,
+    .is-paper & {
+      @include vf-theme-dark;
+    }
 
     .is-detached & {
       display: block;

--- a/templates/docs/examples/patterns/tooltips/_nesting-theme-override.jinja
+++ b/templates/docs/examples/patterns/tooltips/_nesting-theme-override.jinja
@@ -1,0 +1,26 @@
+{#-
+  Reusable macro for generating consistent tooltip examples that override the theme of the tooltip based on the theme of the parent element.
+  Params
+    tooltip_background_theme (string) (required): The theme to apply to the tooltip message.
+    is_combined (boolean): Whether the example is being rendered as part of a combined example. Defaults to false.
+-#}
+{%- macro tooltip_nesting_theme_override(tooltip_background_theme, is_combined) -%}
+  {%- if tooltip_background_theme == 'dark' -%}
+    {%- set inverse_theme = 'light' -%}
+  {%- else %}
+    {%- set inverse_theme = 'dark' -%}
+  {%- endif -%}
+
+  <p>{% if not is_combined %}This content is inside a {{ tooltip_background_theme }}-themed page. {% endif %}The strip below uses the {{ inverse_theme }} theme.</p>
+  <div class="p-strip is-{{ inverse_theme }}">
+    <button class="p-tooltip is-{{ inverse_theme }}" aria-describedby="override-tooltip-theme">
+      Correct
+      <span class="p-tooltip__message" role="tooltip" id="override-tooltip-theme">This tooltip is {{ tooltip_background_theme }}-themed to contrast with the {{ inverse_theme }} strip.</span>
+    </button>
+    <hr class="is-muted">
+    <button class="p-tooltip" aria-describedby="default-tooltip-theme">
+      Incorrect
+      <span class="p-tooltip__message" role="tooltip" id="default-tooltip-theme">This tooltip inverts the {{ tooltip_background_theme }} theme of the body, instead of the {{ inverse_theme }} strip.</span>
+    </button>
+  </div>
+{%- endmacro -%}

--- a/templates/docs/examples/patterns/tooltips/combined.html
+++ b/templates/docs/examples/patterns/tooltips/combined.html
@@ -7,5 +7,7 @@
 {% with is_combined = true %}
 <section>{% include 'docs/examples/patterns/tooltips/default.html' %}</section>
 <section>{% include 'docs/examples/patterns/tooltips/detached.html' %}</section>
+<section>{% include 'docs/examples/patterns/tooltips/nesting-theme-override-light.html' %}</section>
+<section>{% include 'docs/examples/patterns/tooltips/nesting-theme-override-dark.html' %}</section>
 {% endwith %}
 {% endblock %}

--- a/templates/docs/examples/patterns/tooltips/nesting-theme-override-dark.html
+++ b/templates/docs/examples/patterns/tooltips/nesting-theme-override-dark.html
@@ -1,0 +1,13 @@
+{% extends "_layouts/examples.html" %}
+{% from "docs/examples/patterns/tooltips/_nesting-theme-override.jinja" import tooltip_nesting_theme_override %}
+
+{% block title %}Tooltips / Overridden theme / Dark{% endblock %}
+
+{% block standalone_css %}patterns_tooltips{% endblock %}
+
+{% set is_dark = True %}
+{% set is_not_themed = true %}
+
+{% block content %}
+{{ tooltip_nesting_theme_override('dark', is_combined) }}
+{% endblock %}

--- a/templates/docs/examples/patterns/tooltips/nesting-theme-override-light.html
+++ b/templates/docs/examples/patterns/tooltips/nesting-theme-override-light.html
@@ -1,0 +1,13 @@
+{% extends "_layouts/examples.html" %}
+{% from "docs/examples/patterns/tooltips/_nesting-theme-override.jinja" import tooltip_nesting_theme_override %}
+
+{% block title %}Tooltips / Overridden theme / Light{% endblock %}
+
+{% block standalone_css %}patterns_tooltips{% endblock %}
+
+{% set is_light = True %}
+{% set is_not_themed = true %}
+
+{% block content %}
+{{ tooltip_nesting_theme_override('light', is_combined) }}
+{% endblock %}

--- a/templates/docs/patterns/tooltips/index.md
+++ b/templates/docs/patterns/tooltips/index.md
@@ -26,6 +26,26 @@ In some cases you may need the tooltip element to exist outside of the element i
 View example of the detached tooltips pattern
 </a></div>
 
+## Theming
+
+Tooltips use the inverse theme of their background to contrast them from surrounding content. By default, this works by inverting the theme applied to the document body.
+For example, tooltips inside a `<body class="is-dark">` will use the light theme.
+
+If a tooltip is inside of an element with a different theme than the document body, you should apply the theme class (`.is-dark`, `.is-light`, or `.is-paper`)
+of the tooltip's background to the tooltip element, so that the tooltip inverts the theme of its background, not the document body.
+
+For example, if you have a tooltip inside a dark-themed element on a light-themed page, add the `.is-dark` class to the `.p-tooltip` to ensure that the tooltip uses the light theme.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tooltips/nesting-theme-override-light" class="js-example">
+View example of the tooltips pattern with a light theme override
+</a></div>
+
+Conversely, if you have a tooltip inside a light-themed element on a dark-themed page, add the `.is-light` class to the `.p-tooltip` to ensure that the tooltip uses the dark theme.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tooltips/nesting-theme-override-dark" class="js-example">
+View example of the tooltips pattern with a dark theme override
+</a></div>
+
 ## Import
 
 To import just this component into your project, copy the snippet below and include it in your main Sass file.


### PR DESCRIPTION
## Done

- Updates tooltips to invert their ancestor's color theme. I.E.: tooltips on dark use light theme, tooltips on light/paper use dark theme.
- Tooltips can be set to use a different theme than the inverse of the body, to handle cases where the tooltip is contained within an element that has a theme different from the body.

Fixes [WD-11871](https://warthogs.atlassian.net/browse/WD-11871)

## QA

- Verify that all tooltip examples look correct on all color themes. They should always use the opposite color theme.
  - [Default](https://vanilla-framework-5326.demos.haus/docs/examples/patterns/tooltips/default?theme=light)
  - [Detached](https://vanilla-framework-5326.demos.haus/docs/examples/patterns/tooltips/detached?theme=light)
  - Theme overrides - ensure that the "correct" tooltip inverts the theme of its surrounding strip, not the page body.
    - [Light](https://vanilla-framework-5326.demos.haus/docs/examples/patterns/tooltips/nesting-theme-override-light)
    - [Dark](https://vanilla-framework-5326.demos.haus/docs/examples/patterns/tooltips/nesting-theme-override-dark)
  - Review [combined tooltips example](https://vanilla-framework-5326.demos.haus/docs/examples/patterns/tooltips/combined) and verify the new examples have been added.
  - Review [theming tooltips docs](https://vanilla-framework-5326.demos.haus/docs/patterns/tooltips#theming)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![image](https://github.com/user-attachments/assets/515aecb5-3dae-41f5-a097-1ecf049284e2)
<img width="682" alt="Screenshot 2024-08-30 at 10 19 36 AM" src="https://github.com/user-attachments/assets/eb0993c7-bddf-43c1-9a8c-5683eba23f3f">



[WD-11871]: https://warthogs.atlassian.net/browse/WD-11871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ