### PR TITLE
Improve combined example baseline alignment

### DIFF
--- a/templates/_layouts/examples.html
+++ b/templates/_layouts/examples.html
@@ -40,9 +40,9 @@
   </html>
 {% else %}
   {# Include a link to the embedded template #}
-  <div>
+  <p>
     <small><a href="/{{ self._TemplateReference__context.name }}">{{ self._TemplateReference__context.name }}</a></small>
-  </div>
+  </p>
   {# In the combined case, render just the body, as the HTML & head is handled by the combined example #}
   {{ body_content() }}
   {% if is_combined and spacing_below and spacing_below > 0 %}


### PR DESCRIPTION
## Done

Wraps the links/names for examples embedded in combined examples in a `p` rather than a `div`. This improves the baseline alignment of combined examples, as the links themselves should not throw the combined example off of the baseline.

Note that individual examples may still throw the combined example off of the baseline, if the component itself has margin/padding issues.

Fixes #5324, [WD-14463](https://warthogs.atlassian.net/browse/WD-14463)

## QA

- Open any combined example. For example, [typography combined](https://vanilla-framework-5327.demos.haus/docs/examples/base/typography/combined?theme=light).
- Verify that the embedded example links are wrapped in a `<p>` and have correct paragraph padding & margin.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![image](https://github.com/user-attachments/assets/cce8ba0f-7197-41dd-9b5b-98e64f65dbb4)

[WD-14463]: https://warthogs.atlassian.net/browse/WD-14463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ