### PR TITLE
Theme accent color

### DIFF
--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -39,7 +39,7 @@
       @include vf-highlight-bar($colors--theme--text-default);
 
       &.is-accent {
-        @include vf-highlight-bar($colors--theme--accent-default);
+        @include vf-highlight-bar($colors--theme--accent);
       }
     }
 

--- a/scss/_base_hr.scss
+++ b/scss/_base_hr.scss
@@ -39,7 +39,7 @@
       @include vf-highlight-bar($colors--theme--text-default);
 
       &.is-accent {
-        @include vf-highlight-bar($color-accent);
+        @include vf-highlight-bar($colors--theme--accent-default);
       }
     }
 

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -1,7 +1,7 @@
 @mixin vf-b-typography-definitions {
   %vf-is-accent {
     &.is-accent {
-      color: $color-accent;
+      color: $colors--theme--accent-default;
     }
   }
 

--- a/scss/_base_typography-definitions.scss
+++ b/scss/_base_typography-definitions.scss
@@ -1,7 +1,7 @@
 @mixin vf-b-typography-definitions {
   %vf-is-accent {
     &.is-accent {
-      color: $colors--theme--accent-default;
+      color: $colors--theme--accent;
     }
   }
 

--- a/scss/_patterns_rule.scss
+++ b/scss/_patterns_rule.scss
@@ -16,7 +16,7 @@
     @include vf-highlight-bar($colors--theme--text-default);
 
     &.is-accent {
-      @include vf-highlight-bar($color-accent);
+      @include vf-highlight-bar($colors--theme--accent-default);
     }
   }
 }

--- a/scss/_patterns_rule.scss
+++ b/scss/_patterns_rule.scss
@@ -16,7 +16,7 @@
     @include vf-highlight-bar($colors--theme--text-default);
 
     &.is-accent {
-      @include vf-highlight-bar($colors--theme--accent-default);
+      @include vf-highlight-bar($colors--theme--accent);
     }
   }
 }

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -430,5 +430,5 @@ $color-ubuntu: #e95420; // Ubuntu orange, should not be overridden
 $color-brand: $color-ubuntu !default;
 $color-brand-dark: $color-brand !default;
 $color-accent: #0f95a1 !default;
-$color-accent-dark: adjust-color(desaturate($color-accent, 10%), $lightness: 35%) !default;
+$color-accent-dark: #70bbc2 !default;
 $color-accent-background: $colors--dark-theme--background-default !default; // changed from "brand" colour to dark theme background

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -430,5 +430,5 @@ $color-ubuntu: #e95420; // Ubuntu orange, should not be overridden
 $color-brand: $color-ubuntu !default;
 $color-brand-dark: $color-brand !default;
 $color-accent: #0f95a1 !default;
-$color-accent-dark: desaturate($color-accent, 20%) !default;
+$color-accent-dark: adjust-color(desaturate($color-accent, 10%), $lightness: 35%) !default;
 $color-accent-background: $colors--dark-theme--background-default !default; // changed from "brand" colour to dark theme background

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -106,6 +106,9 @@ $states: (
 // --border-default       - default border color
 // --border-high-contrast - high contrast version of border color, to be used when border needs more visibility (form inputs, etc)
 // --border-low-contrast  - low contrast version of border color, to be used when border needs more visibility (separators)
+//
+// Highlight colors:
+// --accent-default      - default accent color
 
 // Light theme
 $colors--light-theme--text-default: #000 !default;
@@ -290,6 +293,8 @@ $colors--theme--button-negative-hover: var(--vf-color-button-negative-hover);
 $colors--theme--button-negative-active: var(--vf-color-button-negative-active);
 $colors--theme--button-negative-text: var(--vf-color-button-negative-text);
 
+$colors--theme--accent-default: var(--vf-color-accent);
+
 // Theme colors exposed as CSS custom properties
 @mixin vf-theme-light--colors {
   // SCSS variables need to be interpolated to work in CSS custom properties
@@ -345,6 +350,8 @@ $colors--theme--button-negative-text: var(--vf-color-button-negative-text);
   --vf-color-button-negative-hover: #{adjust-color($color-negative, $lightness: -$hover-background-opacity-percentage)};
   --vf-color-button-negative-active: #{adjust-color($color-negative, $lightness: -$active-background-opacity-percentage)};
   --vf-color-button-negative-text: #{vf-contrast-text-color($color-negative)};
+
+  --vf-color-accent: #{$color-accent};
 }
 
 @mixin vf-theme-dark--colors {
@@ -401,6 +408,8 @@ $colors--theme--button-negative-text: var(--vf-color-button-negative-text);
   --vf-color-button-negative-hover: #{adjust-color($color-negative-dark, $lightness: -$hover-background-opacity-percentage)};
   --vf-color-button-negative-active: #{adjust-color($color-negative-dark, $lightness: -$active-background-opacity-percentage)};
   --vf-color-button-negative-text: #{vf-contrast-text-color($color-negative-dark)};
+
+  --vf-color-accent: #{$color-accent-dark};
 }
 
 @mixin vf-theme-paper--colors {
@@ -421,4 +430,5 @@ $color-ubuntu: #e95420; // Ubuntu orange, should not be overridden
 $color-brand: $color-ubuntu !default;
 $color-brand-dark: $color-brand !default;
 $color-accent: #0f95a1 !default;
+$color-accent-dark: desaturate($color-accent, 20%) !default;
 $color-accent-background: $colors--dark-theme--background-default !default; // changed from "brand" colour to dark theme background

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -108,7 +108,7 @@ $states: (
 // --border-low-contrast  - low contrast version of border color, to be used when border needs more visibility (separators)
 //
 // Highlight colors:
-// --accent-default      - default accent color
+// --accent         - default accent color
 
 // Light theme
 $colors--light-theme--text-default: #000 !default;
@@ -293,7 +293,7 @@ $colors--theme--button-negative-hover: var(--vf-color-button-negative-hover);
 $colors--theme--button-negative-active: var(--vf-color-button-negative-active);
 $colors--theme--button-negative-text: var(--vf-color-button-negative-text);
 
-$colors--theme--accent-default: var(--vf-color-accent);
+$colors--theme--accent: var(--vf-color-accent);
 
 // Theme colors exposed as CSS custom properties
 @mixin vf-theme-light--colors {


### PR DESCRIPTION
## Done

Themes the accent color. Dark theme uses a 20% desaturated and 35% lightened version of the light theme accent color.

Fixes [WD-11879](https://warthogs.atlassian.net/browse/WD-11879)

## QA

- Open [demo](https://vanilla-framework-5328.demos.haus/docs/examples/base/headings/accented?theme=dark)
- Verify accented color is correct and easy to read on all themes.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
![image](https://github.com/user-attachments/assets/471178e3-06fb-4e28-8e64-1d368dfba2a7)



[WD-11879]: https://warthogs.atlassian.net/browse/WD-11879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ