### PR TITLE
Add macro install instructions to docs pages

### DIFF
--- a/templates/docs/building-vanilla.md
+++ b/templates/docs/building-vanilla.md
@@ -65,17 +65,17 @@ Now if you open an extra terminal and run `yarn watch-css`, the CSS will be rebu
 ## Jinja Macros
 
 A variety of Vanilla's components and patterns are offered as
-[Jinja Macros](https://jinja.palletsprojects.com/templates/#macros), which may
+[Jinja macros](https://jinja.palletsprojects.com/templates/#macros), which may
 be useful to you if you build sites using the
-[Jinja](https://jinja.palletsprojects.com/) templating engine. These Macros can
+[Jinja](https://jinja.palletsprojects.com/) templating engine. These macros can
 help abstract away some of the complexity of Vanilla's HTML, making producing
 complex page layouts simpler and faster.
 
-In order to pull Vanilla's Macros into your project, you may need to expose them
+In order to pull Vanilla's macros into your project, you may need to expose them
 to your webserver or templating engine. An example of this using Flask and Jinja
 might look like the following:
 
-```
+```python
 from flask import Flask
 from jinja2 import ChoiceLoader, FileSystemLoader
 
@@ -92,7 +92,7 @@ app.jinja_loader = loader
 
 ```
 
-After making the Macros available to your webserver/templating engine, see the
+After making the macros available to your webserver/templating engine, see the
 individual component/pattern docs for import and usage instructions.
 
 ## Webpack


### PR DESCRIPTION
## Done

- Add macro install instructions to Building with Vanilla page
- Add macro import instructions to pattern pages

Fixes [WD-14189](https://warthogs.atlassian.net/browse/WD-14189)

## QA

- Open the following pages:
  - [Building with Vanilla](https://vanilla-framework-5330.demos.haus/docs/building-vanilla#jinja-macros)
  - [Hero](https://vanilla-framework-5330.demos.haus/docs/patterns/hero#import)
  - [Tiered list](https://vanilla-framework-5330.demos.haus/docs/patterns/tiered-list#import)
- Confirm documentation is logical and functions as expected

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [X] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [X] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [X] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


[WD-14189]: https://warthogs.atlassian.net/browse/WD-14189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ