### PR TITLE
Revert "Group Percy snapshots by test case name (#5299)"

### DIFF
--- a/snapshots.js
+++ b/snapshots.js
@@ -130,19 +130,18 @@ async function getPercyConfigURLs() {
   let urls = [];
 
   for (let link of links) {
-    for (const theme of SNAPSHOT_COLOR_THEMES) {
-      const url = new URL(`${link}?${COLOR_THEME_QUERY_PARAM_NAME}=${theme}`);
-      const path = url.pathname.replace(/\/?$/, '/');
+    const path = new URL(link).pathname.replace(/\/?$/, '/');
 
+    for (const theme of SNAPSHOT_COLOR_THEMES) {
+      const url = `${link}?${COLOR_THEME_QUERY_PARAM_NAME}=${theme}`;
       const name = `${path.slice(0, path.length - 1)}?${COLOR_THEME_QUERY_PARAM_NAME}=${theme}`;
       const widths = await getWidthsForExample(path, theme);
 
       // Default theme captured responsively, other themes captured at the largest width
       urls.push({
-        url: url.href,
+        url,
         name,
         widths,
-        testCase: url.pathname.replace(/standalone\//g, ''),
       });
     }
   }

--- a/tests/snapshots.test.js
+++ b/tests/snapshots.test.js
@@ -110,17 +110,3 @@ test('Returns snapshots with only the expected set of color themes', async () =>
   }, new Set());
   expect(JSON.stringify(encounteredThemes)).toBe(JSON.stringify(new Set(SNAPSHOT_COLOR_THEMES)));
 });
-
-test('Returns snapshots with unique combination of test case and name', async () => {
-  const snapshots = await snapshotsTest();
-  const encounteredTestCaseAndName = new Map();
-  const failedSnapshots = [];
-  snapshots.forEach((snapshot) => {
-    const key = `${snapshot.testCase}-${snapshot.name}`;
-    if (encounteredTestCaseAndName.has(key)) {
-      failedSnapshots.push(snapshot);
-    }
-    encounteredTestCaseAndName.set(key, snapshot.url);
-  });
-  expect(failedSnapshots).toHaveLength(0);
-});


### PR DESCRIPTION
This reverts commit 7ff9e824d74db75188468f5b51bb2f37079f79f0 (#5299). 

Upon merging #5299 to main, the resulting [baseline build](https://percy.io/bb49709b/vanilla-framework/builds/36215893/changed/1980308620?browser=chrome&browser_ids=59&category=changed%2Cunchanged&group_snapshots_by=test_case&subcategories=approved&test_case_category=changed&viewLayout=overlay&viewMode=new&width=1280&widths=375%2C800%2C1280) was missing ~30 screenshots, which did not occur in QA. It appears there is still an intermittent issue to be fixed by Browserstack. They have been contacted for a fix, but this PR will revert the change in the meantime.

Until this is merged, Percy tests may have unpredictable screenshots missing.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.