### PR TITLE
fix: Search and filter hidden search button alignment and stacking order adjustment

### DIFF
--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -132,6 +132,17 @@
   }
 
   // Utilities
+  %u-off-screen {
+    &:not(:focus):not(:active) {
+      clip-path: inset(50%);
+      height: 1px;
+      overflow: hidden;
+      position: absolute;
+      white-space: nowrap;
+      width: 1px;
+    }
+  }
+
   %vf-hide-text {
     overflow: hidden;
     // vw value necessary because text indent in % does not work with padding;

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -121,10 +121,14 @@
       margin: 0;
       position: relative;
 
-      // Restrict the height of the search box to the height of the search container
-      &,
-      & > * {
-        height: 100%;
+      & > .u-off-screen {
+        // Prevents the bottom margin of the search bottom from growing the height of the search container
+        @extend %u-no-margin--bottom;
+
+        // Make sure the hidden search button appears on top of the input field
+        &:focus {
+          z-index: 1;
+        }
       }
     }
 

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -121,9 +121,13 @@
       margin: 0;
       position: relative;
 
+      // tab-selectable search submit button
       & > .u-off-screen {
         // Prevents the bottom margin of the search bottom from growing the height of the search container
         @extend %u-no-margin--bottom;
+
+        // Make the button dense to ensure it fits vertically in the search box
+        @extend %vf-button-dense-vertical-padding;
 
         // Make sure the hidden search button appears on top of the input field
         &:focus {

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -116,14 +116,16 @@
     }
 
     .p-search-and-filter__box {
+      align-items: center;
       display: inline-flex;
       flex: 1;
+      height: 100%;
       margin: 0;
       position: relative;
 
       // tab-selectable search submit button
       & > .u-off-screen {
-        // Prevents the bottom margin of the search bottom from growing the height of the search container
+        // Prevents the bottom margin of the search button from growing the height of the search container
         @extend %u-no-margin--bottom;
 
         // Make the button dense to ensure it fits vertically in the search box

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -120,6 +120,12 @@
       flex: 1;
       margin: 0;
       position: relative;
+
+      // Restrict the height of the search box to the height of the search container
+      &,
+      & > * {
+        height: 100%;
+      }
     }
 
     .p-search-and-filter__input {

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -122,19 +122,20 @@
       height: 100%;
       margin: 0;
       position: relative;
+    }
 
-      // tab-selectable search submit button
-      & > .u-off-screen {
-        // Prevents the bottom margin of the search button from growing the height of the search container
-        @extend %u-no-margin--bottom;
+    // tab-selectable search button
+    .p-search-and-filter__search-button {
+      // Hide the search button unless it is focused
+      @extend %u-off-screen;
+      // Prevents the bottom margin of the search button from growing the height of the search container
+      @extend %u-no-margin--bottom;
+      // Make the button dense to ensure it fits vertically in the search box
+      @extend %vf-button-dense-vertical-padding;
 
-        // Make the button dense to ensure it fits vertically in the search box
-        @extend %vf-button-dense-vertical-padding;
-
-        // Make sure the hidden search button appears on top of the input field
-        &:focus {
-          z-index: 1;
-        }
+      // Make sure the hidden search button appears on top of the input field
+      &:focus {
+        z-index: 1;
       }
     }
 

--- a/scss/_utilities_off-screen.scss
+++ b/scss/_utilities_off-screen.scss
@@ -2,12 +2,18 @@
 
 // Positions element out of flow & off screen for screen readers
 @mixin vf-u-off-screen {
-  .u-off-screen:not(:focus):not(:active) {
-    clip-path: inset(50%);
-    height: 1px;
-    overflow: hidden;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
+  %u-off-screen {
+    &:not(:focus):not(:active) {
+      clip-path: inset(50%);
+      height: 1px;
+      overflow: hidden;
+      position: absolute;
+      white-space: nowrap;
+      width: 1px;
+    }
+  }
+
+  .u-off-screen {
+    @extend %u-off-screen;
   }
 }

--- a/scss/_utilities_off-screen.scss
+++ b/scss/_utilities_off-screen.scss
@@ -2,17 +2,6 @@
 
 // Positions element out of flow & off screen for screen readers
 @mixin vf-u-off-screen {
-  %u-off-screen {
-    &:not(:focus):not(:active) {
-      clip-path: inset(50%);
-      height: 1px;
-      overflow: hidden;
-      position: absolute;
-      white-space: nowrap;
-      width: 1px;
-    }
-  }
-
   .u-off-screen {
     @extend %u-off-screen;
   }

--- a/templates/docs/examples/patterns/search-and-filter/chip-overflow.html
+++ b/templates/docs/examples/patterns/search-and-filter/chip-overflow.html
@@ -50,7 +50,7 @@
     <form class="p-search-and-filter__box" data-overflowing="false">
       <label class="u-off-screen" for="search">Search and filter</label>
       <input autocomplete="off" class="p-search-and-filter__input" id="search" name="search" placeholder="Search and filter" type="search" value="">
-      <button alt="search" class="u-off-screen" type="submit">Search</button>
+      <button alt="search" class="p-search-and-filter__search-button" type="submit">Search</button>
     </form>
   </div>
   <div class="p-search-and-filter__panel" aria-hidden="true">

--- a/templates/docs/examples/patterns/search-and-filter/default.html
+++ b/templates/docs/examples/patterns/search-and-filter/default.html
@@ -9,7 +9,7 @@
     <form class="p-search-and-filter__box" data-overflowing="false">
       <label class="u-off-screen" for="search">Search and filter</label>
       <input autocomplete="off" class="p-search-and-filter__input" id="search" name="search" placeholder="Search and filter" type="search" value="">
-      <button alt="search" class="u-off-screen" type="submit">Search</button>
+      <button alt="search" class="p-search-and-filter__search-button" type="submit">Search</button>
     </form>
   </div>
   <div class="p-search-and-filter__panel" aria-hidden="true">

--- a/templates/docs/examples/patterns/search-and-filter/expanded.html
+++ b/templates/docs/examples/patterns/search-and-filter/expanded.html
@@ -9,7 +9,7 @@
     <form class="p-search-and-filter__box" data-overflowing="false">
       <label class="u-off-screen" for="search">Search and filter</label>
       <input autocomplete="off" class="p-search-and-filter__input" id="search" name="search" placeholder="Search and filter" type="search" value="">
-      <button alt="search" class="u-off-screen" type="submit">Search</button>
+      <button alt="search" class="p-search-and-filter__search-button" type="submit">Search</button>
     </form>
   </div>
   <div class="p-search-and-filter__panel" aria-hidden="false">

--- a/templates/docs/examples/patterns/search-and-filter/with-chips.html
+++ b/templates/docs/examples/patterns/search-and-filter/with-chips.html
@@ -17,7 +17,7 @@
     <form class="p-search-and-filter__box" data-overflowing="false">
       <label class="u-off-screen" for="search">Search and filter</label>
       <input autocomplete="off" class="p-search-and-filter__input" id="search" name="search" placeholder="Search and filter" type="search" value="">
-      <button alt="search" class="u-off-screen" type="submit">Search</button>
+      <button alt="search" class="p-search-and-filter__search-button" type="submit">Search</button>
     </form>
   </div>
   <div class="p-search-and-filter__panel" aria-hidden="true">

--- a/templates/docs/examples/patterns/search-and-filter/with-search-prompt.html
+++ b/templates/docs/examples/patterns/search-and-filter/with-search-prompt.html
@@ -10,7 +10,7 @@
     <form class="p-search-and-filter__box" data-overflowing="false">
       <label class="u-off-screen" for="search">Search and filter</label>
       <input autocomplete="off" class="p-search-and-filter__input" id="search" name="search" placeholder="Search and filter" type="search" value="vanilla">
-      <button alt="search" class="u-off-screen" type="submit">Search</button>
+      <button alt="search" class="p-search-and-filter__search-button" type="submit">Search</button>
     </form>
   </div>
   <div class="p-search-and-filter__panel" aria-hidden="false">

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -12,7 +12,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Stylesheet size',
       benchmark: 150000,
-      threshold: 440000,
+      threshold: 500000,
       result: results['total-stylesheet-size'],
     },
     {


### PR DESCRIPTION
## Done

- Fixes the search and filter hidden search button throwing off the vertical alignment of the rest of the search and filter container.
- Fixes incorrect stack order of the hidden search button, which was being hidden by the search input text field.

Fixes #5289 , [WD-14048](https://warthogs.atlassian.net/browse/WD-14048)

## QA

- Open [search and filter examples](https://vanilla-framework-5339.demos.haus/docs/examples/patterns/search-and-filter/combined?theme=light)
- Tab through the examples and make sure that the "Search" hidden button does not throw off alignment of its container when it is visible. Also check that it is rendered above its search input element.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
<img width="1063" alt="Screenshot 2024-10-22 at 11 47 14 AM" src="https://github.com/user-attachments/assets/54ab5bab-188d-4609-b161-549c44a4f73b">



[WD-14048]: https://warthogs.atlassian.net/browse/WD-14048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ