### PR TITLE
Manually set baseline build commit signature

### DIFF
--- a/.github/actions/percy-snapshot/action.yml
+++ b/.github/actions/percy-snapshot/action.yml
@@ -82,8 +82,12 @@ runs:
         PERCY_TOKEN: ${{ inputs.percy_token_write }}
         # This is used to name the build on the Percy dashboard. For PRs, it is `pull/{pr_number}`, and for baseline, it is `main`.
         PERCY_BRANCH: ${{ inputs.branch_name }}
+        # The branch that the snapshots are being taken against
+        PERCY_TARGET_BRANCH: main
         # HEAD commit SHA signature that triggered this test
         PERCY_COMMIT: ${{ inputs.commitsh }}
+        # The commit SHA signature that the snapshots are being taken against. Since this is always run on `main`, this will be the commit signature of the last commit to main.
+        PERCY_TARGET_COMMIT: ${{ github.sha }}
         # If PR number is set & a Percy-GHA integration is set up, this allows Percy to set status on the PR
         PERCY_PULL_REQUEST: ${{ inputs.pr_number }}
         # GH runner sometimes runs into issues loading assets (large images especially) in the default 30s timeout.


### PR DESCRIPTION
## Done

#5300 updated the Percy workflow to merge `main` into a PR before it is tested, but our dual-workflow approach seems to throw a wrench in Percy's [baseline build detection](https://www.browserstack.com/docs/percy/baseline-management/git#how-are-the-base-builds-selected-with-git): even though the files being tested are a merge of `main` with a PR, Percy may select a baseline build that is older than the current baseline build, causing false positive test results.

This occurred in #5338 (PR branch was cut from main before merge of #5270). However the [Percy build](https://percy.io/bb49709b/vanilla-framework/builds/36326870) used a baseline build from before the merge of #5270), causing the tree list snapshots to incorrectly appear as new.  It appears Percy needs to be manually instructed to use the latest `main` commit for this two-workflow approach to not have hiccups with merge conflicts. This can be done with [environment variables](https://www.browserstack.com/docs/percy/get-started/set-env-var#Percy_SDK).

This should mean that you only need to merge/rebase branches for Percy tests where source merge conflicts exist.

## QA

- Verify my [fork's main branch](https://github.com/jmuzina/vanilla-framework/commits/main/) is the same as [Vanilla's main branch](https://github.com/canonical/vanilla-framework/commits/main/), but with this PR's commit added.
- Verify my [test PR](https://github.com/jmuzina/vanilla-framework/pull/34) is identical in contents to #5338 
- Verify that the [Percy build for my test PR](https://percy.io/bb49709b/test-vanilla-gha-migration/builds/36332575/changed/1986222370?browser=chrome&browser_ids=59&group_snapshots_by=similar_diff&subcategories=unreviewed%2Cchanges_requested&viewLayout=overlay&viewMode=new&width=1280&widths=375%2C800%2C1280) has only the expected changes from #5338 , and has no unexpected "New snapshot" results for the tree list snapshots.
- Verify that [baseline builds](https://percy.io/bb49709b/test-vanilla-gha-migration/builds/36333239/changed/1986267149?browser=chrome&browser_ids=59&group_snapshots_by=similar_diff&subcategories=approved&viewLayout=overlay&viewMode=new&width=1280&widths=375%2C800%2C1280) still show the visual changes between the previous and new baseline build, and the head commit and base commit on the baseline build details are not the same. 

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
