### PR TITLE
Feat: Implement grid with 4 columns on medium

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.16.0",
+  "version": "4.17.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.17.0
+  features:
+    - component: Grid
+      url: /docs/patterns/grid#4-column-grid
+      status: Updated
+      notes: We've added the <code>.row--4-cols-medium</code> class, which creates a grid with a multiple of 4 columns on all screen sizes.
 - version: 4.16.0
   features:
     - component: CTA Block / Borderless

--- a/releases.yml
+++ b/releases.yml
@@ -3,7 +3,7 @@
     - component: Grid
       url: /docs/patterns/grid#4-column-grid
       status: Updated
-      notes: We've added the <code>.row--4-cols-medium</code> class, which creates a grid with a multiple of 4 columns on all screen sizes.
+      notes: We've added the <code>.p-row</code> class, which creates a grid with a multiple of 4 columns on all screen sizes.
 - version: 4.16.0
   features:
     - component: CTA Block / Borderless

--- a/scss/_base_grid-definitions.scss
+++ b/scss/_base_grid-definitions.scss
@@ -5,6 +5,31 @@
   padding-right: 0;
 }
 
+// Apply grid properties for a given breakpoint
+@mixin vf-b-grid-template-impl($breakpoint, $columns) {
+  grid-gap: 0 map-get($grid-gutter-widths, $breakpoint);
+  grid-template-columns: repeat($columns, minmax(0, 1fr));
+  // Expose the number of columns available for child elements as a CSS var, so that columns can span full grid width without increasing selector specificity\
+  --vf-grid-columns: #{$columns};
+
+  & > * {
+    grid-column-end: span $columns;
+  }
+}
+
+// Apply grid properties for a given breakpoint. If a min_width is provided, wrap the properties in a media query
+@mixin vf-b-grid-template($breakpoint, $columns, $min_width: None) {
+  @supports (display: grid) {
+    @if $min-width == None {
+      @include vf-b-grid-template-impl($breakpoint, $columns);
+    } @else {
+      @media (min-width: $min_width) {
+        @include vf-b-grid-template-impl($breakpoint, $columns);
+      }
+    }
+  }
+}
+
 @mixin vf-b-grid-definitions {
   %display-block {
     // make columns explicitly display:block; the use of a placeholder is to ensure the rule appears only once in the compiled css
@@ -29,45 +54,50 @@
     }
   }
 
-  %vf-row {
+  %vf-row-small {
+    @include vf-b-grid-template(small, $grid-columns-small);
+  }
+
+  %vf-row-medium-4 {
+    @include vf-b-grid-template(default, $grid-columns-medium-4, $threshold-4-small-4-med-col);
+  }
+
+  %vf-row-medium-6 {
+    @include vf-b-grid-template(default, $grid-columns-medium, $threshold-4-6-col);
+  }
+
+  %vf-row-large {
+    @include vf-b-grid-template(default, $grid-columns, $threshold-6-12-col);
+  }
+
+  %vf-row-base {
     @extend %fixed-width-container;
 
     @supports (display: grid) {
       display: grid;
-      grid-gap: 0 map-get($grid-gutter-widths, small);
-      grid-template-columns: repeat($grid-columns-small, minmax(0, 1fr));
       grid-template-rows: auto;
       margin-left: auto;
       margin-right: auto;
       max-width: $grid-max-width;
 
-      & > * {
-        grid-column-end: span $grid-columns-small;
-      }
-
       [class*='#{$grid-column-prefix}'] {
         grid-column-start: auto;
       }
-
-      // set static gutter width per breakpoint
-      @media (min-width: $threshold-4-6-col) {
-        grid-gap: 0 map-get($grid-gutter-widths, default);
-        grid-template-columns: repeat($grid-columns-medium, minmax(0, 1fr));
-
-        & > * {
-          grid-column-end: span $grid-columns-medium;
-        }
-      }
-
-      @media (min-width: $threshold-6-12-col) {
-        grid-gap: 0 map-get($grid-gutter-widths, default);
-        grid-template-columns: repeat($grid-columns, minmax(0, 1fr));
-
-        & > * {
-          grid-column-end: span $grid-columns;
-        }
-      }
     }
+  }
+
+  %vf-row {
+    @extend %vf-row-base;
+    @extend %vf-row-small;
+    @extend %vf-row-medium-6;
+    @extend %vf-row-large;
+  }
+
+  %vf-row-medium-4 {
+    @extend %vf-row-base;
+    @extend %vf-row-small;
+    @extend %vf-row-medium-4;
+    @extend %vf-row-large;
   }
 
   %vf-grid-container-padding {

--- a/scss/_patterns_grid.scss
+++ b/scss/_patterns_grid.scss
@@ -3,20 +3,25 @@
 // CSS grid implementation of columns for all screens sizes
 @mixin vf-grid-column($col) {
   @supports (display: grid) {
-    grid-column-end: span #{$col};
+    // Get the smaller of the parent column span count or the grid row's maximum column count
+    // This prevents columns from using more columns than their grid row allows
+    --vf-grid-colspan: min(#{$col}, var(--vf-grid-columns));
+
+    grid-column-end: span var(--vf-grid-colspan);
 
     //nesting
     @if $col > 1 {
-      & .row {
-        grid-template-columns: repeat($col, minmax(0, 1fr));
+      & .#{$grid-row-class},
+      & .#{$grid-row-4-cols-class} {
+        grid-template-columns: repeat(var(--vf-grid-colspan), minmax(0, 1fr));
       }
     }
   }
 }
 
-@mixin vf-grid-column-reordering($label, $col-count, $reset: false) {
+@mixin vf-grid-column-reordering($label, $col-count, $reset: false, $row-class: $grid-row-class) {
   @for $i from 1 through $col-count {
-    .row [class*='#{$grid-column-prefix}'].#{$grid-column-prefix}start-#{$label}-#{$i} {
+    .#{$row-class} [class*='#{$grid-column-prefix}'].#{$grid-column-prefix}start-#{$label}-#{$i} {
       @if $reset {
         grid-column-start: initial;
       } @else {
@@ -34,6 +39,17 @@
   }
 }
 
+// span full width on some breakpoint (to match block level element behaviour)
+@mixin vf-grid-span-full-grid($min-width: None) {
+  @if $min-width == None {
+    grid-column: auto / span var(--vf-grid-columns);
+  } @else {
+    @media (min-width: $min-width) {
+      grid-column: auto / span var(--vf-grid-columns);
+    }
+  }
+}
+
 @mixin vf-p-grid {
   // FIXME: this should be removed from framework SCSS
   // (see https://github.com/canonical/vanilla-framework/issues/3199)
@@ -43,18 +59,29 @@
     margin-bottom: $spv--small;
   }
 
-  .row {
+  .#{$grid-row-class} {
     @extend %vf-row;
+  }
+
+  .#{$grid-row-4-cols-class} {
+    @extend %vf-row-medium-4;
   }
 
   // mobile grid
 
   // by default medium and large screen col classes should span full width on mobile (to match block level element behaviour)
   %span-full-grid-on-mobile {
-    grid-column: auto / span $grid-columns-small;
+    @include vf-grid-span-full-grid;
   }
 
   @for $i from 1 through $grid-columns-medium {
+    .#{$grid-medium-col-prefix}#{$i} {
+      @extend %span-full-grid-on-mobile;
+      @extend %display-block;
+    }
+  }
+
+  @for $i from 1 through $grid-columns-medium-4 {
     .#{$grid-medium-col-prefix}#{$i} {
       @extend %span-full-grid-on-mobile;
       @extend %display-block;
@@ -79,12 +106,9 @@
   }
 
   // tablet grid
-
   // on medium/tablet screens, small and large grid class names span full width (to match block level element behaviour)
   %span-full-grid-on-tablet {
-    @media (min-width: $threshold-4-6-col) {
-      grid-column: auto / span $grid-columns-medium;
-    }
+    @include vf-grid-span-full-grid($threshold-4-small-4-med-col);
   }
 
   @for $i from 1 through $grid-columns-small {
@@ -100,8 +124,20 @@
   }
 
   // col-medium-X classes define grid for medium screens
+  // col-medium-X classes for grids with 6 columns on medium
   @media (min-width: $threshold-4-6-col) {
     @for $i from $grid-columns-medium through 1 {
+      .#{$grid-medium-col-prefix}#{$i} {
+        @include vf-grid-column($i);
+
+        width: 100%;
+      }
+    }
+  }
+
+  // col-medium-X classes for grids with 4 columns on medium
+  @media (min-width: $threshold-4-small-4-med-col) {
+    @for $i from $grid-columns-medium-4 through 1 {
       .#{$grid-medium-col-prefix}#{$i} {
         @include vf-grid-column($i);
 
@@ -114,9 +150,7 @@
 
   // on desktop screens small and medium grid class names span full width (to match block level element behaviour)
   %span-full-grid-on-desktop {
-    @media (min-width: $threshold-6-12-col) {
-      grid-column: auto / span $grid-columns;
-    }
+    @include vf-grid-span-full-grid($threshold-4-med-12-col);
   }
 
   @for $i from 1 through $grid-columns-small {
@@ -131,8 +165,14 @@
     }
   }
 
+  @for $i from 1 through $grid-columns-medium-4 {
+    .#{$grid-medium-col-prefix}#{$i} {
+      @extend %span-full-grid-on-desktop;
+    }
+  }
+
   // col-X class names define grid on large/desktop screens
-  @media (min-width: $threshold-6-12-col) {
+  @media (min-width: $threshold-4-med-12-col) {
     @for $i from $grid-columns through 1 {
       // set col-* to span respective number of columns on desktop
       .#{$grid-large-col-prefix}#{$i} {
@@ -146,21 +186,25 @@
   $offsets: (
     (small, 0, $threshold-4-6-col, $grid-columns-small),
     (medium, $threshold-4-6-col, $threshold-6-12-col, $grid-columns-medium),
+    (medium-new, $threshold-4-small-4-med-col, $threshold-4-med-12-col, $grid-columns-medium-4),
     (large, $threshold-6-12-col, false, $grid-columns)
   );
 
   @each $label, $breakpoint-min, $breakpoint-reset, $col-count in $offsets {
     @if $breakpoint-min == 0 {
       @include vf-grid-column-reordering($label, $col-count);
+      @include vf-grid-column-reordering($label, $col-count, $row-class: $grid-row-4-cols-class);
     } @else {
       @media (min-width: #{$breakpoint-min}) {
         @include vf-grid-column-reordering($label, $col-count);
+        @include vf-grid-column-reordering($label, $col-count, $row-class: $grid-row-4-cols-class);
       }
     }
 
     @if $breakpoint-reset {
       @media (min-width: #{$breakpoint-reset}) {
         @include vf-grid-column-reordering($label, $col-count, $reset: true);
+        @include vf-grid-column-reordering($label, $col-count, $reset: true, $row-class: $grid-row-4-cols-class);
       }
     }
   }
@@ -168,7 +212,7 @@
   // variants
 
   // deprecated, will be removed in v5
-  .row.is-bordered {
+  .#{$grid-row-class}.is-bordered {
     position: relative;
 
     &::before {
@@ -199,7 +243,7 @@
   $col-75: calc(($grid-columns / 4) * 3);
 
   // 50/50 split on medium and large screens
-  .row--50-50 {
+  .#{$grid-row-class}--50-50 {
     @extend %vf-row;
 
     > .col {
@@ -216,7 +260,7 @@
   }
 
   // 25/75 split on medium and large screens
-  .row--25-75 {
+  .#{$grid-row-class}--25-75 {
     @extend %vf-row;
 
     > .col {
@@ -256,7 +300,7 @@
   }
 
   // 50/50 split just on medium screens
-  .row--50-50-on-medium {
+  .#{$grid-row-class}--50-50-on-medium {
     @extend %vf-row;
 
     > .col {
@@ -266,7 +310,7 @@
     }
   }
 
-  .row--25-75-on-medium {
+  .#{$grid-row-class}--25-75-on-medium {
     @extend %vf-row;
 
     > .col {
@@ -288,7 +332,7 @@
   }
 
   // 50/50 split just on large screens
-  .row--50-50-on-large {
+  .#{$grid-row-class}--50-50-on-large {
     @extend %vf-row;
 
     > .col {
@@ -298,7 +342,7 @@
     }
   }
 
-  .row--25-75-on-large {
+  .#{$grid-row-class}--25-75-on-large {
     @extend %vf-row;
 
     > .col {
@@ -321,7 +365,7 @@
   }
 
   // 75/25 split on medium and large screens
-  .row--75-25 {
+  .#{$grid-row-class}--75-25 {
     @extend %vf-row;
 
     > .col {
@@ -354,7 +398,7 @@
     }
   }
 
-  .row--75-25-on-medium {
+  .#{$grid-row-class}--75-25-on-medium {
     @extend %vf-row;
 
     > .col {
@@ -375,7 +419,7 @@
     }
   }
 
-  .row--75-25-on-large {
+  .#{$grid-row-class}--75-25-on-large {
     @extend %vf-row;
 
     > .col {
@@ -391,7 +435,7 @@
     }
   }
 
-  .row--25-25-50 {
+  .#{$grid-row-class}--25-25-50 {
     @extend %vf-row;
 
     > .col {
@@ -420,7 +464,7 @@
     }
   }
 
-  .row--25-25-25-25 {
+  .#{$grid-row-class}--25-25-25-25 {
     @extend %vf-row;
 
     > .col {

--- a/scss/_settings_grid.scss
+++ b/scss/_settings_grid.scss
@@ -15,7 +15,7 @@ $threshold-4-med-12-col: $breakpoint-large !default;
 
 $grid-column-prefix: 'col-' !default;
 $grid-row-class: 'row' !default;
-$grid-row-4-cols-class: '#{$grid-row-class}--4-cols-medium' !default;
+$grid-row-4-cols-class: 'p-#{$grid-row-class}' !default;
 $grid-small-col-prefix: '#{$grid-column-prefix}small-' !default;
 $grid-medium-col-prefix: '#{$grid-column-prefix}medium-' !default;
 $grid-large-col-prefix: #{$grid-column-prefix} !default;

--- a/scss/_settings_grid.scss
+++ b/scss/_settings_grid.scss
@@ -5,11 +5,17 @@
 $grid-max-width: 80rem !default;
 $grid-columns-small: 4 !default;
 $grid-columns-medium: 6 !default;
+$grid-columns-medium-4: 4 !default;
 $grid-columns: 12 !default;
+
 $threshold-4-6-col: $breakpoint-small !default;
+$threshold-4-small-4-med-col: $breakpoint-small !default;
 $threshold-6-12-col: $breakpoint-large !default;
+$threshold-4-med-12-col: $breakpoint-large !default;
 
 $grid-column-prefix: 'col-' !default;
+$grid-row-class: 'row' !default;
+$grid-row-4-cols-class: '#{$grid-row-class}--4-cols-medium' !default;
 $grid-small-col-prefix: '#{$grid-column-prefix}small-' !default;
 $grid-medium-col-prefix: '#{$grid-column-prefix}medium-' !default;
 $grid-large-col-prefix: #{$grid-column-prefix} !default;

--- a/templates/404.html
+++ b/templates/404.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div id="main-content" class="p-strip">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-12">
       <h1 class="u-no-margin--bottom">404 - Page not found</h1>
     </div>
@@ -10,7 +10,7 @@
 </div>
 
 <div class="p-strip is-shallow">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-12">
       <p>Sorry, we can't find the page you're looking for. If you think this is an error on our site, please <a href="https://github.com/canonical/vanilla-framework/issues/new">file a bug on GitHub.</a></p>
     </div>

--- a/templates/404.html
+++ b/templates/404.html
@@ -2,16 +2,16 @@
 
 {% block content %}
 <div id="main-content" class="p-strip">
-  <div class="row">
-    <div class="col 12">
+  <div class="row--4-cols-medium">
+    <div class="col-12">
       <h1 class="u-no-margin--bottom">404 - Page not found</h1>
     </div>
   </div>
 </div>
 
 <div class="p-strip is-shallow">
-  <div class="row">
-    <div class="col 12">
+  <div class="row--4-cols-medium">
+    <div class="col-12">
       <p>Sorry, we can't find the page you're looking for. If you think this is an error on our site, please <a href="https://github.com/canonical/vanilla-framework/issues/new">file a bug on GitHub.</a></p>
     </div>
   </div>

--- a/templates/410.html
+++ b/templates/410.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div id="main-content" class="p-strip">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-12">
       <h1 class="u-no-margin--bottom">410 - Page deleted</h1>
     </div>
@@ -10,7 +10,7 @@
 </div>
 
 <div class="p-strip is-shallow">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-12">
       <p>{{ message or "This page has been removed" }}</p>
     </div>

--- a/templates/410.html
+++ b/templates/410.html
@@ -2,16 +2,16 @@
 
 {% block content %}
 <div id="main-content" class="p-strip">
-  <div class="row">
-    <div class="col 12">
+  <div class="row--4-cols-medium">
+    <div class="col-12">
       <h1 class="u-no-margin--bottom">410 - Page deleted</h1>
     </div>
   </div>
 </div>
 
 <div class="p-strip is-shallow">
-  <div class="row">
-    <div class="col 12">
+  <div class="row--4-cols-medium">
+    <div class="col-12">
       <p>{{ message or "This page has been removed" }}</p>
     </div>
   </div>

--- a/templates/500.html
+++ b/templates/500.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div id="main-content" class="p-strip">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-12">
       <h1 class="u-no-margin--bottom">500 - Internal server error</h1>
     </div>
@@ -10,7 +10,7 @@
 </div>
 
 <div class="p-strip is-shallow">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-12">
       <p>Something went wrong on our end. If you have the time, please help us out by <a href="https://github.com/canonical-websites/vanillaframework.io/issues/new">filing a bug.</a></p>
     </div>

--- a/templates/500.html
+++ b/templates/500.html
@@ -2,16 +2,16 @@
 
 {% block content %}
 <div id="main-content" class="p-strip">
-  <div class="row">
-    <div class="col 12">
+  <div class="row--4-cols-medium">
+    <div class="col-12">
       <h1 class="u-no-margin--bottom">500 - Internal server error</h1>
     </div>
   </div>
 </div>
 
 <div class="p-strip is-shallow">
-  <div class="row">
-    <div class="col 12">
+  <div class="row--4-cols-medium">
+    <div class="col-12">
       <p>Something went wrong on our end. If you have the time, please help us out by <a href="https://github.com/canonical-websites/vanillaframework.io/issues/new">filing a bug.</a></p>
     </div>
   </div>

--- a/templates/_layouts/_footer.html
+++ b/templates/_layouts/_footer.html
@@ -5,7 +5,7 @@
       <p class="u-no-margin--bottom">&copy; {{ now("%Y") }} Canonical Ltd.</p>
     </div>
     <div class="l-docs__main">
-      <div class="row--4-cols-medium">
+      <div class="p-row">
         <nav class="col-3" aria-label="Footer">
           <ul class="p-list u-no-margin--bottom">
             <li class="p-list__item">
@@ -34,7 +34,7 @@
 </footer>
 {% else %}
 <footer class="p-strip is-dark">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-3">
       <p class="u-no-margin--bottom">&copy; {{ now("%Y") }} Canonical Ltd.</p>
     </div>

--- a/templates/_layouts/_footer.html
+++ b/templates/_layouts/_footer.html
@@ -5,7 +5,7 @@
       <p class="u-no-margin--bottom">&copy; {{ now("%Y") }} Canonical Ltd.</p>
     </div>
     <div class="l-docs__main">
-      <div class="row">
+      <div class="row--4-cols-medium">
         <nav class="col-3" aria-label="Footer">
           <ul class="p-list u-no-margin--bottom">
             <li class="p-list__item">
@@ -34,7 +34,7 @@
 </footer>
 {% else %}
 <footer class="p-strip is-dark">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-3">
       <p class="u-no-margin--bottom">&copy; {{ now("%Y") }} Canonical Ltd.</p>
     </div>

--- a/templates/accessibility.html
+++ b/templates/accessibility.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div id="main-content" class="p-strip">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-12">
         <h1>Accessibility guidelines</h1>
         <p>Vanilla Framework aims for Level AA conformance with the <br><a href="https://www.w3.org/TR/WCAG22/">Web Content Accessibility Guidelines (WCAG) 2.2</a></p>
@@ -85,7 +85,7 @@
 </div>
 
 <div class="p-strip">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-6">
         <h2>Key WCAG documents</h2>
         <p>The volume of information on the WCAG 2.0 website can be disorienting. <br>We keep the following links handy for quick reference:</p>
@@ -94,7 +94,7 @@
 </div>
 
 <div class="p-strip u-no-padding--top">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <ul class="p-list is-split">
         <li class="p-list__item"><a href="https://www.w3.org/TR/WCAG20/">WCAG 2.0</a>: the W3C standard, includes principles, guidelines and success criteria</li>
         <li class="p-list__item"><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/">Understanding WCAG 2.0</a>: detailed reference, includes intent, benefits to people with disabilities, examples, resources and techniques</li>

--- a/templates/accessibility.html
+++ b/templates/accessibility.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div id="main-content" class="p-strip">
-    <div class="row">
+    <div class="row--4-cols-medium">
       <div class="col-12">
         <h1>Accessibility guidelines</h1>
         <p>Vanilla Framework aims for Level AA conformance with the <br><a href="https://www.w3.org/TR/WCAG22/">Web Content Accessibility Guidelines (WCAG) 2.2</a></p>
@@ -19,12 +19,12 @@
 </div>
 
 <div class="p-strip">
-    <div class="row">
-      <div class="col-6">
+    <div class="row--50-50-on-large">
+      <div class="col">
         <h2>Ensuring conformance</h2>
         <p>We use the following tools to continually audit the framework:</p>
       </div>
-      <div class="col-6">
+      <div class="col">
         <p class="p-heading--5 u-no-margin--bottom"><a href="https://www.w3.org/WAI/eval/report-tool/#!/evaluation/audit">Accessibility report tool</a></p>
         <p>A checklist that can be filtered by A / AA / AAA level, with a short description and links to the related "Understanding" and "How to Meet" articles that accompany each criterion.</p>
         <p class="p-heading--5 u-no-margin--bottom"><a href="https://www.w3.org/WAI/ARIA/apg/">WAI-ARIA Authoring Practices Guide</a></p>
@@ -40,12 +40,12 @@
 </div>
 
 <div class="p-strip">
-    <div class="row">
-      <div class="col-6">
+    <div class="row--50-50-on-large">
+      <div class="col">
         <h2>Curated criteria checklist</h2>
         <p class="u-no-padding--bottom">The scope of the WCAG spec can be overwhelming. We find the following checklist a good starting point if you're new to accessibility:</p>
       </div>
-      <div class="col-6">
+      <div class="col">
       </div>
     </div>
 </div>
@@ -85,7 +85,7 @@
 </div>
 
 <div class="p-strip">
-    <div class="row">
+    <div class="row--4-cols-medium">
       <div class="col-6">
         <h2>Key WCAG documents</h2>
         <p>The volume of information on the WCAG 2.0 website can be disorienting. <br>We keep the following links handy for quick reference:</p>
@@ -94,7 +94,7 @@
 </div>
 
 <div class="p-strip u-no-padding--top">
-    <div class="row">
+    <div class="row--4-cols-medium">
       <ul class="p-list is-split">
         <li class="p-list__item"><a href="https://www.w3.org/TR/WCAG20/">WCAG 2.0</a>: the W3C standard, includes principles, guidelines and success criteria</li>
         <li class="p-list__item"><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/">Understanding WCAG 2.0</a>: detailed reference, includes intent, benefits to people with disabilities, examples, resources and techniques</li>
@@ -109,12 +109,12 @@
 </div>
 
 <div class="p-strip">
-    <div class="row">
-      <div class="col-6">
+    <div class="row--50-50-on-large">
+      <div class="col">
         <h2>Useful tools</h2>
         <p>The web is abundant in tools that help to create and test for accessible sites. We find the following particularly useful:</p>
       </div>
-      <div class="col-6">
+      <div class="col">
         <ul class="p-list--divided">
           <li class="p-list__item"><a href="https://developer.chrome.com/docs/devtools/accessibility/reference/">Chrome Accessibility Developer Tools</a></li>
           <li class="p-list__item"><a href="https://webaim.org/resources/contrastchecker/">Contrast checker tool</a></li>

--- a/templates/browser-support.html
+++ b/templates/browser-support.html
@@ -7,11 +7,11 @@
 
 {% block content %}
 <div id="main-content" class="p-strip">
-    <div class="row">
-      <div class="col-6">
+    <div class="row--50-50-on-large">
+      <div class="col">
         <h1 class="u-no-margin--bottom">Browser support</h1>
       </div>
-      <div class="col-6">
+      <div class="col">
         <p>Vanilla framework follows the principles of progressive enhancement and web standards. Users should be able to access core content and functionality from any browser or operating system, with varying degrees of access to visual and other enhancements — design components do not have to look exactly the same on every browser.</p>
       </div>
     </div>
@@ -22,11 +22,11 @@
 </div>
 
 <div class="p-strip">
-    <div class="row">
-      <div class="col-6">
+    <div class="row--50-50-on-large">
+      <div class="col">
         <h2>Bugs and prioritisation</h2>
       </div>
-      <div class="col-6">
+      <div class="col">
         <ul class="p-list">
           <li class="p-list__item is-ticked">If the bug prevents access to core content (for example, by hiding it or covering it), it should be prioritised</li>
           <li class="p-list__item is-ticked">If the bug relates to visual differences that do not affect access to content on modern browsers, it should be queued up</li>
@@ -42,12 +42,12 @@
 </div>
 
 <div class="p-strip">
-    <div class="row">
-      <div class="col-6">
+    <div class="row--50-50-on-large">
+      <div class="col">
         <h2>Supported browsers</h2>
         <p>The following are the browsers that we actively test all components on. That does not mean other browsers are not supported or that bugs reported are not acted on.</p>
       </div>
-      <div class="col-6">
+      <div class="col">
         <ul class="p-list is-split">
           <li class="p-list__item">
             <div class="p-heading-icon--small">

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div id="main-content" class="p-strip">
-    <div class="row">
+    <div class="row--4-cols-medium">
       <div class="col-12">
         <h1 class="u-no-margin--bottom">Contribute</h1>
       </div>
@@ -18,7 +18,7 @@
 </div>
 
 <div class="p-strip">
-    <div class="row">
+    <div class="row--4-cols-medium">
       <div class="p-strip u-no-padding--top"><h2>Meet the team</h2></div>
       {% for team_member in team_members %}
         <div class="col-3 p-media-object">
@@ -46,10 +46,10 @@
   </div>
 
   <div class="p-strip">
-      <div class="row">
+      <div class="row--4-cols-medium">
         <div class="p-strip u-no-padding--top"><h2>Contributors</h2></div>
       </div>
-      <div class="row">
+      <div class="row--4-cols-medium">
         {% for contributor in contributors%}
           <div class="col-3 p-media-object">
             <img src="{{ contributor.avatar_url }}" class="p-media-object__image is-round" alt="">
@@ -74,10 +74,10 @@
 </div>
 
 <div class="p-strip">
-    <div class="row">
+    <div class="row--4-cols-medium">
       <div class="p-strip u-no-padding--top"><h2>Contribute</h2></div>
     </div>
-    <div class="row">
+    <div class="row--4-cols-medium">
       <div class="col-6">
         <p>When <a href="https://github.com/canonical/vanilla-framework/issues/new/choose">submitting a new issue</a>, please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.</p>
         <p>Please provide as much information possible detailing what you're currently experiencing and what you'd expect to experience.</p>
@@ -85,7 +85,7 @@
         <p>When committing changes, make sure to group related changes so that the project is always in a working state. Use succinct yet descriptive commit messages to allow for easy reading of the commit log.</p>
       </div>
       <div class="col-6">
-        <div class="row">
+        <div class="row--4-cols-medium">
           <div class="col-6 p-card">
             <h3>Guidelines</h3>
             <p>We follow two guideline documents that align with the practices that the Canonical Web Team follows across all projects.
@@ -95,7 +95,7 @@
               </ul>
           </div>
         </div>
-        <div class="row">
+        <div class="row--4-cols-medium">
           <div class="col-3 p-card">
             <h3>File a bug</h3>
             <p>We use <a href="https://github.com/canonical/vanilla-framework/issues">GitHub issues</a> to track all our bugs and feature requests.</p>
@@ -114,8 +114,8 @@
 </div>
 
 <div class="p-strip">
-    <div class="row">
-      <div class="col-6">
+    <div class="row--50-50-on-large">
+      <div class="col">
         <div class="p-heading-icon">
           <div class="p-heading-icon__header is-stacked">
             <svg width="60" height="60" class="p-heading-icon__img" viewBox="0 0 12 16" version="1.1" aria-hidden="true">
@@ -130,7 +130,7 @@
         <p>The simplest way to run Vanilla framework is to first <a href="https://docs.docker.com/install/">install Docker</a> and <a href="https://github.com/canonical/dotrun#installation">dotrun</a>, and then use the <code>dotrun</code> script to <a
             href="https://github.com/canonical/vanilla-framework#vanilla-local-development">build the site</a>. Before proposing a pull request, ensure that the tests pass on your local fork. To kick off the tests for your project, in the terminal <code>dotrun test</code>.</p>
       </div>
-      <div class="col-6">
+      <div class="col">
         <div class="p-heading-icon">
           <div class="p-heading-icon__header is-stacked">
             <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/ce518a18-CoF-2022_solid+O.svg" alt=""/>

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div id="main-content" class="p-strip">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-12">
         <h1 class="u-no-margin--bottom">Contribute</h1>
       </div>
@@ -18,7 +18,7 @@
 </div>
 
 <div class="p-strip">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="p-strip u-no-padding--top"><h2>Meet the team</h2></div>
       {% for team_member in team_members %}
         <div class="col-3 p-media-object">
@@ -46,10 +46,10 @@
   </div>
 
   <div class="p-strip">
-      <div class="row--4-cols-medium">
+      <div class="p-row">
         <div class="p-strip u-no-padding--top"><h2>Contributors</h2></div>
       </div>
-      <div class="row--4-cols-medium">
+      <div class="p-row">
         {% for contributor in contributors%}
           <div class="col-3 p-media-object">
             <img src="{{ contributor.avatar_url }}" class="p-media-object__image is-round" alt="">
@@ -74,10 +74,10 @@
 </div>
 
 <div class="p-strip">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="p-strip u-no-padding--top"><h2>Contribute</h2></div>
     </div>
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-6">
         <p>When <a href="https://github.com/canonical/vanilla-framework/issues/new/choose">submitting a new issue</a>, please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.</p>
         <p>Please provide as much information possible detailing what you're currently experiencing and what you'd expect to experience.</p>
@@ -85,7 +85,7 @@
         <p>When committing changes, make sure to group related changes so that the project is always in a working state. Use succinct yet descriptive commit messages to allow for easy reading of the commit log.</p>
       </div>
       <div class="col-6">
-        <div class="row--4-cols-medium">
+        <div class="p-row">
           <div class="col-6 p-card">
             <h3>Guidelines</h3>
             <p>We follow two guideline documents that align with the practices that the Canonical Web Team follows across all projects.
@@ -95,7 +95,7 @@
               </ul>
           </div>
         </div>
-        <div class="row--4-cols-medium">
+        <div class="p-row">
           <div class="col-3 p-card">
             <h3>File a bug</h3>
             <p>We use <a href="https://github.com/canonical/vanilla-framework/issues">GitHub issues</a> to track all our bugs and feature requests.</p>

--- a/templates/docs/examples/brochure/_25-25-50.html
+++ b/templates/docs/examples/brochure/_25-25-50.html
@@ -1,5 +1,5 @@
 <section class="p-section">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <hr class="p-rule">
   </div>
   <div class="row--25-25-50">
@@ -25,7 +25,7 @@
       </i>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
    <hr class="p-rule">
   </div>
   <div class="row--25-25-50">

--- a/templates/docs/examples/brochure/_25-25-50.html
+++ b/templates/docs/examples/brochure/_25-25-50.html
@@ -1,5 +1,5 @@
 <section class="p-section">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <hr class="p-rule">
   </div>
   <div class="row--25-25-50">
@@ -25,7 +25,7 @@
       </i>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
    <hr class="p-rule">
   </div>
   <div class="row--25-25-50">

--- a/templates/docs/examples/brochure/_25-75-nested.html
+++ b/templates/docs/examples/brochure/_25-75-nested.html
@@ -1,5 +1,5 @@
 <section class="p-section">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <!-- we remove the bottom margin, as this separator is followed by highlighted separators in the grid below -->
     <hr class="p-rule u-no-margin--bottom">
   </div>

--- a/templates/docs/examples/brochure/_25-75-nested.html
+++ b/templates/docs/examples/brochure/_25-75-nested.html
@@ -1,5 +1,5 @@
 <section class="p-section">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <!-- we remove the bottom margin, as this separator is followed by highlighted separators in the grid below -->
     <hr class="p-rule u-no-margin--bottom">
   </div>

--- a/templates/docs/examples/brochure/_50-50.html
+++ b/templates/docs/examples/brochure/_50-50.html
@@ -1,6 +1,6 @@
 <section class="p-section">
   <div class="p-section--shallow">
-    <div class="row">
+    <div class="row--4-cols-medium">
       <hr class="p-rule">
     </div>
     <div class="row--50-50">
@@ -16,7 +16,7 @@
     </div>
   </div>
   <div class="p-section--shallow">
-    <div class="row">
+    <div class="row--4-cols-medium">
       <hr class="p-rule">
     </div>
     <div class="row--50-50">
@@ -31,7 +31,7 @@
     </div>
   </div>
   <div class="p-section--shallow">
-    <div class="row">
+    <div class="row--4-cols-medium">
       <hr class="p-rule">
     </div>
     <div class="row--50-50">

--- a/templates/docs/examples/brochure/_50-50.html
+++ b/templates/docs/examples/brochure/_50-50.html
@@ -1,6 +1,6 @@
 <section class="p-section">
   <div class="p-section--shallow">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <hr class="p-rule">
     </div>
     <div class="row--50-50">
@@ -16,7 +16,7 @@
     </div>
   </div>
   <div class="p-section--shallow">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <hr class="p-rule">
     </div>
     <div class="row--50-50">
@@ -31,7 +31,7 @@
     </div>
   </div>
   <div class="p-section--shallow">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <hr class="p-rule">
     </div>
     <div class="row--50-50">

--- a/templates/docs/examples/brochure/index.html
+++ b/templates/docs/examples/brochure/index.html
@@ -57,7 +57,7 @@
 </section>
 
 <section class="p-section">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <hr class="p-rule">
   </div>
 
@@ -98,7 +98,7 @@
 <div class="u-fixed-width">
   <h5 class="p-muted-heading">Example</h5>
 </div>
-<div class="row">
+<div class="row--4-cols-medium">
   <hr class="p-rule">
 </div>
 
@@ -116,7 +116,7 @@
 
 <div class="u-fixed-width">
   <h5 class="p-muted-heading">Example</h5>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <hr class="p-rule">
   </div>
 </div>

--- a/templates/docs/examples/brochure/index.html
+++ b/templates/docs/examples/brochure/index.html
@@ -57,7 +57,7 @@
 </section>
 
 <section class="p-section">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <hr class="p-rule">
   </div>
 
@@ -98,7 +98,7 @@
 <div class="u-fixed-width">
   <h5 class="p-muted-heading">Example</h5>
 </div>
-<div class="row--4-cols-medium">
+<div class="p-row">
   <hr class="p-rule">
 </div>
 
@@ -116,7 +116,7 @@
 
 <div class="u-fixed-width">
   <h5 class="p-muted-heading">Example</h5>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <hr class="p-rule">
   </div>
 </div>

--- a/templates/docs/examples/index.html
+++ b/templates/docs/examples/index.html
@@ -13,7 +13,7 @@
       <hr />
     </div>
 
-    <div class="row">
+    <div class="row--4-cols-medium">
       <div class="col-3">
         <h2>Base elements</h2>
         <nav aria-label="Documentation: base elements">

--- a/templates/docs/examples/index.html
+++ b/templates/docs/examples/index.html
@@ -13,7 +13,7 @@
       <hr />
     </div>
 
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-3">
         <h2>Base elements</h2>
         <nav aria-label="Documentation: base elements">

--- a/templates/docs/examples/layouts/docs.html
+++ b/templates/docs/examples/layouts/docs.html
@@ -58,7 +58,7 @@
         </div>
       </div>
       <div class="l-docs__main">
-        <div class="row--4-cols-medium">
+        <div class="p-row">
           <form class="p-search-box u-no-margin--bottom">
             <input type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="" autocomplete="on"/>
             <button type="reset" class="p-search-box__reset" name="close"><i class="p-icon--close">Close</i></button>
@@ -137,7 +137,7 @@
 
   <div class="l-docs__title" id="main-content">
     <div class="p-section--shallow">
-      <div class="row--4-cols-medium">
+      <div class="p-row">
         <div class="col-12">
           <h1>Main documentation content</h1>
         </div>
@@ -164,7 +164,7 @@
   </div>
 
   <main class="l-docs__main">
-      <div class="row--4-cols-medium">
+      <div class="p-row">
         <div class="col-12">
           <p>Main documentation content block is contained in grid <code>col-9</code>. Any standard base elements or Vanilla components can be used in the documentation pages.</p>
 
@@ -260,7 +260,7 @@
           <p>Main documentation content block is contained in grid <code>col-9</code>.</p>
 
           <p>For two columns split use two <code>col-4</code> columns.</p>
-          <div class="row--4-cols-medium">
+          <div class="p-row">
             <div class="col-4">
               <ul class="p-list">
                 <li class="p-list__item"><a href="#docs/whats-new-2-6">New features in 2.6&nbsp;›</a></li>
@@ -283,7 +283,7 @@
 
           <p>For three columns split use three <code>col-3</code> columns.</p>
 
-          <div class="row--4-cols-medium">
+          <div class="p-row">
             <div class="col-3">
               <ul class="p-list--divided">
                 <li class="p-list__item"><a href="#docs/settings/animation-settings">Animation</a></li>
@@ -317,7 +317,7 @@
         <p style="padding-left: 1.5rem">© 2020 Canonical Ltd.</p>
       </div>
       <div class="l-docs__main">
-        <nav class="row--4-cols-medium" aria-label="Footer">
+        <nav class="p-row" aria-label="Footer">
           <div class="has-cookie">
             <p><a class="is-dark" href="#">Ubuntu</a> and <a class="is-dark" href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>
             <ul class="p-inline-list--middot">

--- a/templates/docs/examples/layouts/docs.html
+++ b/templates/docs/examples/layouts/docs.html
@@ -58,7 +58,7 @@
         </div>
       </div>
       <div class="l-docs__main">
-        <div class="row">
+        <div class="row--4-cols-medium">
           <form class="p-search-box u-no-margin--bottom">
             <input type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="" autocomplete="on"/>
             <button type="reset" class="p-search-box__reset" name="close"><i class="p-icon--close">Close</i></button>
@@ -137,7 +137,7 @@
 
   <div class="l-docs__title" id="main-content">
     <div class="p-section--shallow">
-      <div class="row">
+      <div class="row--4-cols-medium">
         <div class="col-12">
           <h1>Main documentation content</h1>
         </div>
@@ -164,7 +164,7 @@
   </div>
 
   <main class="l-docs__main">
-      <div class="row">
+      <div class="row--4-cols-medium">
         <div class="col-12">
           <p>Main documentation content block is contained in grid <code>col-9</code>. Any standard base elements or Vanilla components can be used in the documentation pages.</p>
 
@@ -260,7 +260,7 @@
           <p>Main documentation content block is contained in grid <code>col-9</code>.</p>
 
           <p>For two columns split use two <code>col-4</code> columns.</p>
-          <div class="row">
+          <div class="row--4-cols-medium">
             <div class="col-4">
               <ul class="p-list">
                 <li class="p-list__item"><a href="#docs/whats-new-2-6">New features in 2.6&nbsp;›</a></li>
@@ -283,7 +283,7 @@
 
           <p>For three columns split use three <code>col-3</code> columns.</p>
 
-          <div class="row">
+          <div class="row--4-cols-medium">
             <div class="col-3">
               <ul class="p-list--divided">
                 <li class="p-list__item"><a href="#docs/settings/animation-settings">Animation</a></li>
@@ -317,7 +317,7 @@
         <p style="padding-left: 1.5rem">© 2020 Canonical Ltd.</p>
       </div>
       <div class="l-docs__main">
-        <nav class="row" aria-label="Footer">
+        <nav class="row--4-cols-medium" aria-label="Footer">
           <div class="has-cookie">
             <p><a class="is-dark" href="#">Ubuntu</a> and <a class="is-dark" href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>
             <ul class="p-inline-list--middot">

--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -41,7 +41,7 @@
 </header>
 
 <section id="search-docs" class="p-strip--highlighted is-shallow">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <form class="p-search-box u-no-margin--bottom">
       <input type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="" autocomplete="on"/>
       <button type="reset" class="p-search-box__reset" name="close"><i class="p-icon--close">Close</i></button>
@@ -51,7 +51,7 @@
 </section>
 
 <div class="p-strip is-shallow">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <aside class="col-3">
       <nav class="p-side-navigation--raw-html is-sticky" id="drawer" aria-label="Table of contents">
         <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
@@ -210,7 +210,7 @@
       <p>Main documentation content block is contained in grid <code>col-9</code>.</p>
 
       <p>For two columns split use two <code>col-4</code> columns.</p>
-      <div class="row--4-cols-medium">
+      <div class="p-row">
         <div class="col-4">
           <ul class="p-list">
             <li class="p-list__item"><a href="#docs/whats-new-2-6">New features in 2.6&nbsp;›</a></li>
@@ -233,7 +233,7 @@
 
       <p>For three columns split use three <code>col-3</code> columns.</p>
 
-      <div class="row--4-cols-medium">
+      <div class="p-row">
         <div class="col-3">
           <ul class="p-list--divided">
             <li class="p-list__item"><a href="#docs/settings/animation-settings">Animation</a></li>
@@ -260,7 +260,7 @@
 </div>
 
 <footer class="p-strip--highlighted">
-  <nav class="row--4-cols-medium" aria-label="Footer">
+  <nav class="p-row" aria-label="Footer">
     <div class="has-cookie">
       <p>© 2020 Canonical Ltd. <a href="#">Ubuntu</a> and <a href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>
       <ul class="p-inline-list--middot">

--- a/templates/docs/examples/layouts/documentation.html
+++ b/templates/docs/examples/layouts/documentation.html
@@ -41,7 +41,7 @@
 </header>
 
 <section id="search-docs" class="p-strip--highlighted is-shallow">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <form class="p-search-box u-no-margin--bottom">
       <input type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="" autocomplete="on"/>
       <button type="reset" class="p-search-box__reset" name="close"><i class="p-icon--close">Close</i></button>
@@ -51,7 +51,7 @@
 </section>
 
 <div class="p-strip is-shallow">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <aside class="col-3">
       <nav class="p-side-navigation--raw-html is-sticky" id="drawer" aria-label="Table of contents">
         <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
@@ -210,7 +210,7 @@
       <p>Main documentation content block is contained in grid <code>col-9</code>.</p>
 
       <p>For two columns split use two <code>col-4</code> columns.</p>
-      <div class="row">
+      <div class="row--4-cols-medium">
         <div class="col-4">
           <ul class="p-list">
             <li class="p-list__item"><a href="#docs/whats-new-2-6">New features in 2.6&nbsp;›</a></li>
@@ -233,7 +233,7 @@
 
       <p>For three columns split use three <code>col-3</code> columns.</p>
 
-      <div class="row">
+      <div class="row--4-cols-medium">
         <div class="col-3">
           <ul class="p-list--divided">
             <li class="p-list__item"><a href="#docs/settings/animation-settings">Animation</a></li>
@@ -260,7 +260,7 @@
 </div>
 
 <footer class="p-strip--highlighted">
-  <nav class="row" aria-label="Footer">
+  <nav class="row--4-cols-medium" aria-label="Footer">
     <div class="has-cookie">
       <p>© 2020 Canonical Ltd. <a href="#">Ubuntu</a> and <a href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>
       <ul class="p-inline-list--middot">

--- a/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-cards-with-aside-and-toolbar.html
+++ b/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-cards-with-aside-and-toolbar.html
@@ -11,7 +11,7 @@
 
 {% block content %}
 <div class="p-strip is-shallow">
-  <div class="row grid-demo">
+  <div class="row--4-cols-medium grid-demo">
     {% for i in range(12) %}
     {% with index = i + 1 %}
     <div class="col-small-1 col-medium-1 col-1">

--- a/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-cards-with-aside-and-toolbar.html
+++ b/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-cards-with-aside-and-toolbar.html
@@ -11,7 +11,7 @@
 
 {% block content %}
 <div class="p-strip is-shallow">
-  <div class="row--4-cols-medium grid-demo">
+  <div class="p-row grid-demo">
     {% for i in range(12) %}
     {% with index = i + 1 %}
     <div class="col-small-1 col-medium-1 col-1">

--- a/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-full--cve-table.html
+++ b/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-full--cve-table.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 <div class="p-strip is-shallow">
-  <div class="row--4-cols-medium grid-demo">
+  <div class="p-row grid-demo">
     {% for i in range(12) %}
     {% with index = i + 1 %}
     <div class="col-small-1 col-medium-1 col-1">

--- a/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-full--cve-table.html
+++ b/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-full--cve-table.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 <div class="p-strip is-shallow">
-  <div class="row grid-demo">
+  <div class="row--4-cols-medium grid-demo">
     {% for i in range(12) %}
     {% with index = i + 1 %}
     <div class="col-small-1 col-medium-1 col-1">

--- a/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-left-aside-and-toolbar.html
+++ b/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-left-aside-and-toolbar.html
@@ -11,7 +11,7 @@
 
 {% block content %}
 <div class="p-strip is-shallow grid-demo u-no-padding-top">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-1">
       <span>.col-1</span>
     </div>

--- a/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-left-aside-and-toolbar.html
+++ b/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-left-aside-and-toolbar.html
@@ -11,7 +11,7 @@
 
 {% block content %}
 <div class="p-strip is-shallow grid-demo u-no-padding-top">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-1">
       <span>.col-1</span>
     </div>

--- a/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-left-aside.html
+++ b/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-left-aside.html
@@ -11,7 +11,7 @@
 
 {% block content %}
 <div class="p-strip is-shallow grid-demo u-no-padding-top">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-1">
       <span>.col-1</span>
     </div>

--- a/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-left-aside.html
+++ b/templates/docs/examples/layouts/fluid-breakout/fluid-breakout-left-aside.html
@@ -11,7 +11,7 @@
 
 {% block content %}
 <div class="p-strip is-shallow grid-demo u-no-padding-top">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-1">
       <span>.col-1</span>
     </div>

--- a/templates/docs/examples/layouts/full-width/default.html
+++ b/templates/docs/examples/layouts/full-width/default.html
@@ -134,9 +134,9 @@
 
 <div class="p-strip--highlighted is-shallow l-full-width">
   <div class="l-main">
-    <div class="row">
-      <div class="col-6 col-medium-3"><h1 class="p-heading--2">Get started</h1></div>
-      <div class="col-6 col-medium-3"><p>You can use Vanilla in your projects in a few different ways. See <a href="/docs/building-vanilla">Building with Vanilla</a> and <a href="/docs/customising-vanilla">Customising Vanilla</a> for more in-depth setup instructions.</p></div>
+    <div class="row--4-cols-medium">
+      <div class="col-6 col-medium-2"><h1 class="p-heading--2">Get started</h1></div>
+      <div class="col-6 col-medium-2"><p>You can use Vanilla in your projects in a few different ways. See <a href="/docs/building-vanilla">Building with Vanilla</a> and <a href="/docs/customising-vanilla">Customising Vanilla</a> for more in-depth setup instructions.</p></div>
     </div>
   </div>
 </div>
@@ -145,9 +145,9 @@
 
 <div class="p-strip is-shallow l-full-width">
   <div class="l-main">
-    <div class="row">
-      <div class="col-6 col-medium-3"><h2>Install</h2></div>
-      <div class="col-6 col-medium-3">
+    <div class="row--4-cols-medium">
+      <div class="col-6 col-medium-2"><h2>Install</h2></div>
+      <div class="col-6 col-medium-2">
         <p>You can use Vanilla in your projects in a few different ways. See <a href="/docs/building-vanilla">Building with Vanilla</a> and <a href="/docs/customising-vanilla">Customising Vanilla</a> for more in-depth setup instructions.</p>
 
         <p>The recommended way to get Vanilla is with <a href="https://www.yarnpkg.com/">yarn</a>:</p>
@@ -180,9 +180,9 @@
 
 <div class="p-strip is-shallow l-full-width">
   <div class="l-main">
-    <div class="row">
-      <div class="col-6 col-medium-3"><h2>Hotlink</h2></div>
-      <div class="col-6 col-medium-3">
+    <div class="row--4-cols-medium">
+      <div class="col-6 col-medium-2"><h2>Hotlink</h2></div>
+      <div class="col-6 col-medium-2">
         <p>You can add Vanilla directly to your markup:</p>
         <pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-3.8.1.min.css" /&gt;</code></pre>
       </div>
@@ -192,9 +192,9 @@
 
 <div class="p-strip--highlighted is-shallow l-full-width">
   <div class="l-main">
-    <div class="row">
-      <div class="col-6 col-medium-3"><h2>Download</h2></div>
-      <div class="col-6 col-medium-3">
+    <div class="row--4-cols-medium">
+      <div class="col-6 col-medium-2"><h2>Download</h2></div>
+      <div class="col-6 col-medium-2">
         <p>Download the latest version of Vanilla from GitHub.</p>
         <p><a class="p-button--positive" href="https://github.com/canonical/vanilla-framework/archive/v3.8.1.zip">Download v3.8.1</a></p>
         <p>See the <a href="https://github.com/canonical/vanilla-framework/releases">release notes</a> for details on the latest updates.</p>
@@ -205,9 +205,9 @@
 
 <div class="p-strip is-shallow l-full-width">
   <div class="l-main">
-    <div class="row">
-      <div class="col-6 col-medium-3"><h2>Local development</h2></div>
-      <div class="col-6 col-medium-3">
+    <div class="row--4-cols-medium">
+      <div class="col-6 col-medium-2"><h2>Local development</h2></div>
+      <div class="col-6 col-medium-2">
         <p>To make improvements to Vanilla itself, please follow the instructions on the project’s <a href="https://github.com/canonical/vanilla-framework#vanilla-framework">README.md</a>.</p>
         <ul class="p-inline-list">
           <li class="p-inline-list__item"><i class="p-list__icon--slack"></i><a href="https://vanillaframework.slack.com/">Join our channel</a></li>

--- a/templates/docs/examples/layouts/full-width/default.html
+++ b/templates/docs/examples/layouts/full-width/default.html
@@ -134,7 +134,7 @@
 
 <div class="p-strip--highlighted is-shallow l-full-width">
   <div class="l-main">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-6 col-medium-2"><h1 class="p-heading--2">Get started</h1></div>
       <div class="col-6 col-medium-2"><p>You can use Vanilla in your projects in a few different ways. See <a href="/docs/building-vanilla">Building with Vanilla</a> and <a href="/docs/customising-vanilla">Customising Vanilla</a> for more in-depth setup instructions.</p></div>
     </div>
@@ -145,7 +145,7 @@
 
 <div class="p-strip is-shallow l-full-width">
   <div class="l-main">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-6 col-medium-2"><h2>Install</h2></div>
       <div class="col-6 col-medium-2">
         <p>You can use Vanilla in your projects in a few different ways. See <a href="/docs/building-vanilla">Building with Vanilla</a> and <a href="/docs/customising-vanilla">Customising Vanilla</a> for more in-depth setup instructions.</p>
@@ -180,7 +180,7 @@
 
 <div class="p-strip is-shallow l-full-width">
   <div class="l-main">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-6 col-medium-2"><h2>Hotlink</h2></div>
       <div class="col-6 col-medium-2">
         <p>You can add Vanilla directly to your markup:</p>
@@ -192,7 +192,7 @@
 
 <div class="p-strip--highlighted is-shallow l-full-width">
   <div class="l-main">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-6 col-medium-2"><h2>Download</h2></div>
       <div class="col-6 col-medium-2">
         <p>Download the latest version of Vanilla from GitHub.</p>
@@ -205,7 +205,7 @@
 
 <div class="p-strip is-shallow l-full-width">
   <div class="l-main">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-6 col-medium-2"><h2>Local development</h2></div>
       <div class="col-6 col-medium-2">
         <p>To make improvements to Vanilla itself, please follow the instructions on the project’s <a href="https://github.com/canonical/vanilla-framework#vanilla-framework">README.md</a>.</p>

--- a/templates/docs/examples/layouts/full-width/no-sidebar.html
+++ b/templates/docs/examples/layouts/full-width/no-sidebar.html
@@ -77,9 +77,9 @@
 
 <div class="p-strip--highlighted is-shallow l-full-width">
   <div class="l-main">
-    <div class="row">
-      <div class="col-6 col-medium-3"><h1 class="p-heading--2">Get started</h1></div>
-      <div class="col-6 col-medium-3"><p>You can use Vanilla in your projects in a few different ways. See <a href="/docs/building-vanilla">Building with Vanilla</a> and <a href="/docs/customising-vanilla">Customising Vanilla</a> for more in-depth setup instructions.</p></div>
+    <div class="row--4-cols-medium">
+      <div class="col-6 col-medium-2"><h1 class="p-heading--2">Get started</h1></div>
+      <div class="col-6 col-medium-2"><p>You can use Vanilla in your projects in a few different ways. See <a href="/docs/building-vanilla">Building with Vanilla</a> and <a href="/docs/customising-vanilla">Customising Vanilla</a> for more in-depth setup instructions.</p></div>
     </div>
   </div>
 </div>
@@ -88,9 +88,9 @@
 
 <div class="p-strip is-shallow l-full-width">
   <div class="l-main">
-    <div class="row">
-      <div class="col-6 col-medium-3"><h2>Install</h2></div>
-      <div class="col-6 col-medium-3">
+    <div class="row--4-cols-medium">
+      <div class="col-6 col-medium-2"><h2>Install</h2></div>
+      <div class="col-6 col-medium-2">
         <p>You can use Vanilla in your projects in a few different ways. See <a href="/docs/building-vanilla">Building with Vanilla</a> and <a href="/docs/customising-vanilla">Customising Vanilla</a> for more in-depth setup instructions.</p>
 
         <p>The recommended way to get Vanilla is with <a href="https://www.yarnpkg.com/">yarn</a>:</p>
@@ -123,9 +123,9 @@
 
 <div class="p-strip is-shallow l-full-width">
   <div class="l-main">
-    <div class="row">
-      <div class="col-6 col-medium-3"><h2>Hotlink</h2></div>
-      <div class="col-6 col-medium-3">
+    <div class="row--4-cols-medium">
+      <div class="col-6 col-medium-2"><h2>Hotlink</h2></div>
+      <div class="col-6 col-medium-2">
         <p>You can add Vanilla directly to your markup:</p>
         <pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-3.8.1.min.css" /&gt;</code></pre>
       </div>
@@ -135,9 +135,9 @@
 
 <div class="p-strip--highlighted is-shallow l-full-width">
   <div class="l-main">
-    <div class="row">
-      <div class="col-6 col-medium-3"><h2>Download</h2></div>
-      <div class="col-6 col-medium-3">
+    <div class="row--4-cols-medium">
+      <div class="col-6 col-medium-2"><h2>Download</h2></div>
+      <div class="col-6 col-medium-2">
         <p>Download the latest version of Vanilla from GitHub.</p>
         <p><a class="p-button--positive" href="https://github.com/canonical/vanilla-framework/archive/v3.8.1.zip">Download v3.8.1</a></p>
         <p>See the <a href="https://github.com/canonical/vanilla-framework/releases">release notes</a> for details on the latest updates.</p>
@@ -148,9 +148,9 @@
 
 <div class="p-strip is-shallow l-full-width">
   <div class="l-main">
-    <div class="row">
-      <div class="col-6 col-medium-3"><h2>Local development</h2></div>
-      <div class="col-6 col-medium-3">
+    <div class="row--4-cols-medium">
+      <div class="col-6 col-medium-2"><h2>Local development</h2></div>
+      <div class="col-6 col-medium-2">
         <p>To make improvements to Vanilla itself, please follow the instructions on the project’s <a href="https://github.com/canonical/vanilla-framework#vanilla-framework">README.md</a>.</p>
         <ul class="p-inline-list">
           <li class="p-inline-list__item"><i class="p-list__icon--slack"></i><a href="https://vanillaframework.slack.com/">Join our channel</a></li>

--- a/templates/docs/examples/layouts/full-width/no-sidebar.html
+++ b/templates/docs/examples/layouts/full-width/no-sidebar.html
@@ -77,7 +77,7 @@
 
 <div class="p-strip--highlighted is-shallow l-full-width">
   <div class="l-main">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-6 col-medium-2"><h1 class="p-heading--2">Get started</h1></div>
       <div class="col-6 col-medium-2"><p>You can use Vanilla in your projects in a few different ways. See <a href="/docs/building-vanilla">Building with Vanilla</a> and <a href="/docs/customising-vanilla">Customising Vanilla</a> for more in-depth setup instructions.</p></div>
     </div>
@@ -88,7 +88,7 @@
 
 <div class="p-strip is-shallow l-full-width">
   <div class="l-main">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-6 col-medium-2"><h2>Install</h2></div>
       <div class="col-6 col-medium-2">
         <p>You can use Vanilla in your projects in a few different ways. See <a href="/docs/building-vanilla">Building with Vanilla</a> and <a href="/docs/customising-vanilla">Customising Vanilla</a> for more in-depth setup instructions.</p>
@@ -123,7 +123,7 @@
 
 <div class="p-strip is-shallow l-full-width">
   <div class="l-main">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-6 col-medium-2"><h2>Hotlink</h2></div>
       <div class="col-6 col-medium-2">
         <p>You can add Vanilla directly to your markup:</p>
@@ -135,7 +135,7 @@
 
 <div class="p-strip--highlighted is-shallow l-full-width">
   <div class="l-main">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-6 col-medium-2"><h2>Download</h2></div>
       <div class="col-6 col-medium-2">
         <p>Download the latest version of Vanilla from GitHub.</p>
@@ -148,7 +148,7 @@
 
 <div class="p-strip is-shallow l-full-width">
   <div class="l-main">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-6 col-medium-2"><h2>Local development</h2></div>
       <div class="col-6 col-medium-2">
         <p>To make improvements to Vanilla itself, please follow the instructions on the project’s <a href="https://github.com/canonical/vanilla-framework#vanilla-framework">README.md</a>.</p>

--- a/templates/docs/examples/layouts/sticky-footer.html
+++ b/templates/docs/examples/layouts/sticky-footer.html
@@ -26,7 +26,7 @@
   </div>
 
   <footer class="l-footer--sticky p-strip--highlighted">
-    <nav class="row" aria-label="Footer">
+    <nav class="row--4-cols-medium" aria-label="Footer">
       <div class="has-cookie">
         <p>© 2020 Canonical Ltd. <a href="#">Ubuntu</a> and <a href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>
         <ul class="p-inline-list--middot">

--- a/templates/docs/examples/layouts/sticky-footer.html
+++ b/templates/docs/examples/layouts/sticky-footer.html
@@ -26,7 +26,7 @@
   </div>
 
   <footer class="l-footer--sticky p-strip--highlighted">
-    <nav class="row--4-cols-medium" aria-label="Footer">
+    <nav class="p-row" aria-label="Footer">
       <div class="has-cookie">
         <p>© 2020 Canonical Ltd. <a href="#">Ubuntu</a> and <a href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>
         <ul class="p-inline-list--middot">

--- a/templates/docs/examples/patterns/card/content-bleed.html
+++ b/templates/docs/examples/patterns/card/content-bleed.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_card{% endblock %}
 
 {% block content %}
-<div class="row--4-cols-medium">
+<div class="p-row">
   <div class="col-5">
     <div class="p-card u-no-padding">
       <img class="p-card__image" src="https://assets.ubuntu.com/v1/0f33d832-The-State-of-Robotics.jpg" />

--- a/templates/docs/examples/patterns/card/content-bleed.html
+++ b/templates/docs/examples/patterns/card/content-bleed.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_card{% endblock %}
 
 {% block content %}
-<div class="row">
+<div class="row--4-cols-medium">
   <div class="col-5">
     <div class="p-card u-no-padding">
       <img class="p-card__image" src="https://assets.ubuntu.com/v1/0f33d832-The-State-of-Robotics.jpg" />

--- a/templates/docs/examples/patterns/card/image.html
+++ b/templates/docs/examples/patterns/card/image.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_card{% endblock %}
 
 {% block content %}
-<div class="row--4-cols-medium">
+<div class="p-row">
     <div class="col-4">
         <div class="p-card">
             <div class="p-card__content">

--- a/templates/docs/examples/patterns/card/image.html
+++ b/templates/docs/examples/patterns/card/image.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_card{% endblock %}
 
 {% block content %}
-<div class="row">
+<div class="row--4-cols-medium">
     <div class="col-4">
         <div class="p-card">
             <div class="p-card__content">

--- a/templates/docs/examples/patterns/card/overlay.html
+++ b/templates/docs/examples/patterns/card/overlay.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <section class="p-strip--image" style="background-image:url('https://assets.ubuntu.com/v1/0a98afcd-screenshot_desktop.jpg')">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-6 col-start-large-7">
       <div class="p-card--overlay">
         <h2>Web browsing</h2>

--- a/templates/docs/examples/patterns/card/overlay.html
+++ b/templates/docs/examples/patterns/card/overlay.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <section class="p-strip--image" style="background-image:url('https://assets.ubuntu.com/v1/0a98afcd-screenshot_desktop.jpg')">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-6 col-start-large-7">
       <div class="p-card--overlay">
         <h2>Web browsing</h2>

--- a/templates/docs/examples/patterns/divider/default.html
+++ b/templates/docs/examples/patterns/divider/default.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_divider{% endblock %}
 
 {% block content %}
-<div class="row p-divider">
+<div class="row--4-cols-medium p-divider">
   <div class="col-4 p-divider__block">
     <h2>Lorem ipsum</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit.</p>

--- a/templates/docs/examples/patterns/divider/default.html
+++ b/templates/docs/examples/patterns/divider/default.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_divider{% endblock %}
 
 {% block content %}
-<div class="row--4-cols-medium p-divider">
+<div class="p-row p-divider">
   <div class="col-4 p-divider__block">
     <h2>Lorem ipsum</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit.</p>

--- a/templates/docs/examples/patterns/empty-state/user-triggered.html
+++ b/templates/docs/examples/patterns/empty-state/user-triggered.html
@@ -17,7 +17,7 @@
   </div>
 </section>
 <section id="search-results" class="p-strip is-shallow">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-4 col-medium-2">
       <div class="p-heading--4">
         Why not try widening your search?<br> You can do this by:
@@ -34,7 +34,7 @@
   <div class="u-fixed-width">
     <hr />
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-4 col-medium-2">
       <div class="p-heading--4">Still no luck?</div>
     </div>

--- a/templates/docs/examples/patterns/empty-state/user-triggered.html
+++ b/templates/docs/examples/patterns/empty-state/user-triggered.html
@@ -17,13 +17,13 @@
   </div>
 </section>
 <section id="search-results" class="p-strip is-shallow">
-  <div class="row">
-    <div class="col-4 col-medium-3">
+  <div class="row--4-cols-medium">
+    <div class="col-4 col-medium-2">
       <div class="p-heading--4">
         Why not try widening your search?<br> You can do this by:
       </div>
     </div>
-    <div class="col-4 col-medium-3">
+    <div class="col-4 col-medium-2">
       <ul class="p-list">
         <li class="p-list__item is-ticked">Adding alternative words or phrases</li>
         <li class="p-list__item is-ticked">Using individual words instead of phrases</li>
@@ -34,11 +34,11 @@
   <div class="u-fixed-width">
     <hr />
   </div>
-  <div class="row">
-    <div class="col-4 col-medium-3">
+  <div class="row--4-cols-medium">
+    <div class="col-4 col-medium-2">
       <div class="p-heading--4">Still no luck?</div>
     </div>
-    <div class="col-6 col-medium-3">
+    <div class="col-6 col-medium-2">
       <p class="u-no-margin--bottom">
         <a href="#">Visit the Ubuntu homepage</a>
       </p>

--- a/templates/docs/examples/patterns/forms/_form-stacked.html
+++ b/templates/docs/examples/patterns/forms/_form-stacked.html
@@ -1,5 +1,5 @@
 <form class="p-form p-form--stacked">
-  <div class="p-form__group row--4-cols-medium">
+  <div class="p-form__group p-row">
 
     <div class="col-4">
       <label for="full-name-stacked" class="p-form__label">Full name</label>
@@ -11,7 +11,7 @@
       </div>
     </div>
   </div>
-  <div class="p-form__group row--4-cols-medium">
+  <div class="p-form__group p-row">
 
     <div class="col-4">
       <label for="username-stacked" class="p-form__label">Username</label>
@@ -26,7 +26,7 @@
       </div>
     </div>
   </div>
-  <div class="p-form__group row--4-cols-medium p-form-validation is-error">
+  <div class="p-form__group p-row p-form-validation is-error">
 
     <div class="col-4">
       <label for="username-stacked-error" class="p-form__label is-required">Email address</label>
@@ -39,7 +39,7 @@
       </div>
     </div>
   </div>
-  <div class="p-form__group row--4-cols-medium">
+  <div class="p-form__group p-row">
 
     <div class="col-4">
       <label for="address-optional-stacked0" class="p-form__label">Address line 1</label>
@@ -51,7 +51,7 @@
       </div>
     </div>
   </div>
-  <div class="p-form__group row--4-cols-medium">
+  <div class="p-form__group p-row">
 
     <div class="col-4">
       <label for="address-optional-stacked1" class="p-form__label">Address line 2</label>
@@ -63,7 +63,7 @@
       </div>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-12">
       <button class="p-button--positive u-float-right" name="add-details">Add details</button>
     </div>

--- a/templates/docs/examples/patterns/forms/_form-stacked.html
+++ b/templates/docs/examples/patterns/forms/_form-stacked.html
@@ -1,5 +1,5 @@
 <form class="p-form p-form--stacked">
-  <div class="p-form__group row">
+  <div class="p-form__group row--4-cols-medium">
 
     <div class="col-4">
       <label for="full-name-stacked" class="p-form__label">Full name</label>
@@ -11,7 +11,7 @@
       </div>
     </div>
   </div>
-  <div class="p-form__group row">
+  <div class="p-form__group row--4-cols-medium">
 
     <div class="col-4">
       <label for="username-stacked" class="p-form__label">Username</label>
@@ -26,7 +26,7 @@
       </div>
     </div>
   </div>
-  <div class="p-form__group row p-form-validation is-error">
+  <div class="p-form__group row--4-cols-medium p-form-validation is-error">
 
     <div class="col-4">
       <label for="username-stacked-error" class="p-form__label is-required">Email address</label>
@@ -39,7 +39,7 @@
       </div>
     </div>
   </div>
-  <div class="p-form__group row">
+  <div class="p-form__group row--4-cols-medium">
 
     <div class="col-4">
       <label for="address-optional-stacked0" class="p-form__label">Address line 1</label>
@@ -51,7 +51,7 @@
       </div>
     </div>
   </div>
-  <div class="p-form__group row">
+  <div class="p-form__group row--4-cols-medium">
 
     <div class="col-4">
       <label for="address-optional-stacked1" class="p-form__label">Address line 2</label>
@@ -63,7 +63,7 @@
       </div>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-12">
       <button class="p-button--positive u-float-right" name="add-details">Add details</button>
     </div>

--- a/templates/docs/examples/patterns/forms/tick-variants.html
+++ b/templates/docs/examples/patterns/forms/tick-variants.html
@@ -6,7 +6,7 @@
 {% block content %}
 <form>
 
-<div class="row">
+<div class="row--4-cols-medium">
   <div class="col-6">
     <h3>.p-checkbox component</h3>
 

--- a/templates/docs/examples/patterns/forms/tick-variants.html
+++ b/templates/docs/examples/patterns/forms/tick-variants.html
@@ -6,7 +6,7 @@
 {% block content %}
 <form>
 
-<div class="row--4-cols-medium">
+<div class="p-row">
   <div class="col-6">
     <h3>.p-checkbox component</h3>
 

--- a/templates/docs/examples/patterns/grid/4-columns-medium-6-columns-medium-comparison-responsive.html
+++ b/templates/docs/examples/patterns/grid/4-columns-medium-6-columns-medium-comparison-responsive.html
@@ -10,7 +10,7 @@
     <section>
       <p>All breakpoints given</p>
       {{ grid_example(
-        row_class="row--4-cols-medium",
+        row_class="p-row",
         show_row_class=True,
         columns=[
           {
@@ -69,7 +69,7 @@
     <section>
       <p>Missing large breakpoint</p>
       {{ grid_example(
-        row_class="row--4-cols-medium",
+        row_class="p-row",
         show_row_class=True,
         columns=[
           {
@@ -126,7 +126,7 @@
     <section>
       <p>Missing medium breakpoint</p>
       {{ grid_example(
-        row_class="row--4-cols-medium",
+        row_class="p-row",
         show_row_class=True,
         columns=[
           {
@@ -179,7 +179,7 @@
     <section>
       <p>Missing small breakpoint</p>
       {{ grid_example(
-        row_class="row--4-cols-medium",
+        row_class="p-row",
         show_row_class=True,
         columns=[
           {
@@ -232,7 +232,7 @@
     <section>
       <p>Large only</p>
       {{ grid_example(
-        row_class="row--4-cols-medium",
+        row_class="p-row",
         show_row_class=True,
         columns=[
           {
@@ -279,7 +279,7 @@
     <section>
       <p>Medium only</p>
       {{ grid_example(
-        row_class="row--4-cols-medium",
+        row_class="p-row",
         show_row_class=True,
         columns=[
           {
@@ -326,7 +326,7 @@
     <section>
       <p>Small only</p>
       {{ grid_example(
-        row_class="row--4-cols-medium",
+        row_class="p-row",
         show_row_class=True,
         columns=[
           {

--- a/templates/docs/examples/patterns/grid/4-columns-medium-6-columns-medium-comparison-responsive.html
+++ b/templates/docs/examples/patterns/grid/4-columns-medium-6-columns-medium-comparison-responsive.html
@@ -1,0 +1,373 @@
+{% extends "_layouts/examples.html" %}
+{% from "docs/examples/patterns/grid/_grid-example.jinja" import grid_example %}
+
+{% block title %}Grid / Medium responsive / 4 columns & 6 columns comparison{% endblock %}
+
+{% block standalone_css %}patterns_grid{% endblock %}
+
+{% block content %}
+  <div class="grid-demo">
+    <section>
+      <p>All breakpoints given</p>
+      {{ grid_example(
+        row_class="row--4-cols-medium",
+        show_row_class=True,
+        columns=[
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 4},
+              {'name': 'medium', 'num_columns': 1},
+              {'name': 'small', 'num_columns': 2},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 3},
+              {'name': 'medium', 'num_columns': 2},
+              {'name': 'small', 'num_columns': 1},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 5},
+              {'name': 'medium', 'num_columns': 1},
+              {'name': 'small', 'num_columns': 1},
+            ]
+          },
+        ]
+      ) }}
+      {{ grid_example(
+        row_class="row",
+        show_row_class=True,
+        columns=[
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 4},
+              {'name': 'medium', 'num_columns': 2},
+              {'name': 'small', 'num_columns': 2},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 3},
+              {'name': 'medium', 'num_columns': 2},
+              {'name': 'small', 'num_columns': 1},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 5},
+              {'name': 'medium', 'num_columns': 2},
+              {'name': 'small', 'num_columns': 1},
+            ]
+          },
+        ]
+      ) }}
+      <hr class="is-muted">
+    </section>
+
+    <section>
+      <p>Missing large breakpoint</p>
+      {{ grid_example(
+        row_class="row--4-cols-medium",
+        show_row_class=True,
+        columns=[
+          {
+            'breakpoints': [
+              {'name': 'medium', 'num_columns': 1},
+              {'name': 'small', 'num_columns': 2},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 3},
+              {'name': 'medium', 'num_columns': 2},
+              {'name': 'small', 'num_columns': 1},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 5},
+              {'name': 'medium', 'num_columns': 1},
+              {'name': 'small', 'num_columns': 1},
+            ]
+          },
+        ]
+      ) }}
+      {{ grid_example(
+        row_class="row",
+        show_row_class=True,
+        columns=[
+          {
+            'breakpoints': [
+              {'name': 'medium', 'num_columns': 2},
+              {'name': 'small', 'num_columns': 2},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 3},
+              {'name': 'medium', 'num_columns': 2},
+              {'name': 'small', 'num_columns': 1},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 5},
+              {'name': 'medium', 'num_columns': 2},
+              {'name': 'small', 'num_columns': 1},
+            ]
+          },
+        ]
+      ) }}
+      <hr class="is-muted">
+    </section>
+
+    <section>
+      <p>Missing medium breakpoint</p>
+      {{ grid_example(
+        row_class="row--4-cols-medium",
+        show_row_class=True,
+        columns=[
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 4},
+              {'name': 'small', 'num_columns': 2},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 3},
+              {'name': 'small', 'num_columns': 1},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 5},
+              {'name': 'small', 'num_columns': 1},
+            ]
+          },
+        ]
+      ) }}
+      {{ grid_example(
+        row_class="row",
+        show_row_class=True,
+        columns=[
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 4},
+              {'name': 'small', 'num_columns': 2},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 3},
+              {'name': 'small', 'num_columns': 1},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 5},
+              {'name': 'small', 'num_columns': 1},
+            ]
+          },
+        ]
+      ) }}
+      <hr class="is-muted">
+    </section>
+
+    <section>
+      <p>Missing small breakpoint</p>
+      {{ grid_example(
+        row_class="row--4-cols-medium",
+        show_row_class=True,
+        columns=[
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 4},
+              {'name': 'medium', 'num_columns': 1},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 3},
+              {'name': 'medium', 'num_columns': 2},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 5},
+              {'name': 'medium', 'num_columns': 1},
+            ]
+          },
+        ]
+      ) }}
+      {{ grid_example(
+        row_class="row",
+        show_row_class=True,
+        columns=[
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 4},
+              {'name': 'medium', 'num_columns': 2},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 3},
+              {'name': 'medium', 'num_columns': 2},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 5},
+              {'name': 'medium', 'num_columns': 2},
+            ]
+          },
+        ]
+      ) }}
+      <hr class="is-muted">
+    </section>
+
+    <section>
+      <p>Large only</p>
+      {{ grid_example(
+        row_class="row--4-cols-medium",
+        show_row_class=True,
+        columns=[
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 4},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 3},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 5},
+            ]
+          },
+        ]
+      ) }}
+      {{ grid_example(
+        row_class="row",
+        show_row_class=True,
+        columns=[
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 4},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 3},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'large', 'num_columns': 5},
+            ]
+          },
+        ]
+      ) }}
+      <hr class="is-muted">
+    </section>
+
+    <section>
+      <p>Medium only</p>
+      {{ grid_example(
+        row_class="row--4-cols-medium",
+        show_row_class=True,
+        columns=[
+          {
+            'breakpoints': [
+              {'name': 'medium', 'num_columns': 1},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'medium', 'num_columns': 2},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'medium', 'num_columns': 1},
+            ]
+          },
+        ]
+      ) }}
+      {{ grid_example(
+        row_class="row",
+        show_row_class=True,
+        columns=[
+          {
+            'breakpoints': [
+              {'name': 'medium', 'num_columns': 2},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'medium', 'num_columns': 2},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'medium', 'num_columns': 2},
+            ]
+          },
+        ]
+      ) }}
+      <hr class="is-muted">
+    </section>
+
+    <section>
+      <p>Small only</p>
+      {{ grid_example(
+        row_class="row--4-cols-medium",
+        show_row_class=True,
+        columns=[
+          {
+            'breakpoints': [
+              {'name': 'small', 'num_columns': 2},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'small', 'num_columns': 1},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'small', 'num_columns': 1},
+            ]
+          },
+        ]
+      ) }}
+      {{ grid_example(
+        row_class="row",
+        show_row_class=True,
+        columns=[
+          {
+            'breakpoints': [
+              {'name': 'small', 'num_columns': 2},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'small', 'num_columns': 1},
+            ]
+          },
+          {
+            'breakpoints': [
+              {'name': 'small', 'num_columns': 1},
+            ]
+          },
+        ]
+      ) }}
+      <hr class="is-muted">
+    </section>
+  </div>
+{% endblock %}

--- a/templates/docs/examples/patterns/grid/4-columns-medium-mixed-responsive.html
+++ b/templates/docs/examples/patterns/grid/4-columns-medium-mixed-responsive.html
@@ -8,7 +8,7 @@
 {% block content %}
   <div class="grid-demo">
     {{ grid_example(
-        row_class="row--4-cols-medium",
+        row_class="p-row",
         columns=[
           {'breakpoints': [
             {'name': 'large', 'num_columns': 4},

--- a/templates/docs/examples/patterns/grid/4-columns-medium-mixed-responsive.html
+++ b/templates/docs/examples/patterns/grid/4-columns-medium-mixed-responsive.html
@@ -1,0 +1,31 @@
+{% extends "_layouts/examples.html" %}
+{% from "docs/examples/patterns/grid/_grid-example.jinja" import grid_example %}
+
+{% block title %}Grid / 4 columns on medium / Mixed responsive{% endblock %}
+
+{% block standalone_css %}patterns_grid{% endblock %}
+
+{% block content %}
+  <div class="grid-demo">
+    {{ grid_example(
+        row_class="row--4-cols-medium",
+        columns=[
+          {'breakpoints': [
+            {'name': 'large', 'num_columns': 4},
+            {'name': 'medium', 'num_columns': 1},
+            {'name': 'small', 'num_columns': 1},
+          ]},
+          {'breakpoints': [
+            {'name': 'large', 'num_columns': 6},
+            {'name': 'medium', 'num_columns': 2},
+            {'name': 'small', 'num_columns': 1},
+          ]},
+          {'breakpoints': [
+            {'name': 'large', 'num_columns': 2},
+            {'name': 'medium', 'num_columns': 1},
+            {'name': 'small', 'num_columns': 2},
+          ]}
+        ]
+      ) }}
+  </div>
+{% endblock %}

--- a/templates/docs/examples/patterns/grid/4-columns-medium-nested-responsive.html
+++ b/templates/docs/examples/patterns/grid/4-columns-medium-nested-responsive.html
@@ -14,7 +14,7 @@
           'breakpoints': [
             {'name': 'large', 'num_columns': 4},
             {'name': 'medium', 'num_columns': 2},
-            {'name': 'small', 'num_columns': 3}
+            {'name': 'small', 'num_columns': 2}
           ],
           'nested_columns': [
             {
@@ -28,7 +28,7 @@
               'breakpoints': [
                 {'name': 'large', 'num_columns': 2},
                 {'name': 'medium', 'num_columns': 1},
-                {'name': 'small', 'num_columns': 2}
+                {'name': 'small', 'num_columns': 1}
               ]
             }
           ]
@@ -36,15 +36,15 @@
         {
           'breakpoints': [
             {'name': 'large', 'num_columns': 6},
-            {'name': 'medium', 'num_columns': 2},
+            {'name': 'medium', 'num_columns': 1},
             {'name': 'small', 'num_columns': 1}
           ]
         },
         {
           'breakpoints': [
             {'name': 'large', 'num_columns': 2},
-            {'name': 'medium', 'num_columns': 0},
-            {'name': 'small', 'num_columns': 0}
+            {'name': 'medium', 'num_columns': 1},
+            {'name': 'small', 'num_columns': 1}
           ]
         }
       ]

--- a/templates/docs/examples/patterns/grid/4-columns-medium-nested-responsive.html
+++ b/templates/docs/examples/patterns/grid/4-columns-medium-nested-responsive.html
@@ -8,7 +8,7 @@
 {% block content %}
   <div class="grid-demo">
     {{ grid_example(
-      row_class="row--4-cols-medium",
+      row_class="p-row",
       columns=[
         {
           'breakpoints': [

--- a/templates/docs/examples/patterns/grid/4-columns-medium-nested-responsive.html
+++ b/templates/docs/examples/patterns/grid/4-columns-medium-nested-responsive.html
@@ -1,0 +1,53 @@
+{% extends "_layouts/examples.html" %}
+{% from "docs/examples/patterns/grid/_grid-example.jinja" import grid_example %}
+
+{% block title %}Grid / 4 columns on medium / Nested{% endblock %}
+
+{% block standalone_css %}patterns_grid{% endblock %}
+
+{% block content %}
+  <div class="grid-demo">
+    {{ grid_example(
+      row_class="row--4-cols-medium",
+      columns=[
+        {
+          'breakpoints': [
+            {'name': 'large', 'num_columns': 4},
+            {'name': 'medium', 'num_columns': 2},
+            {'name': 'small', 'num_columns': 3}
+          ],
+          'nested_columns': [
+            {
+              'breakpoints': [
+                {'name': 'large', 'num_columns': 2},
+                {'name': 'medium', 'num_columns': 1},
+                {'name': 'small', 'num_columns': 1}
+              ]
+            },
+            {
+              'breakpoints': [
+                {'name': 'large', 'num_columns': 2},
+                {'name': 'medium', 'num_columns': 1},
+                {'name': 'small', 'num_columns': 2}
+              ]
+            }
+          ]
+        },
+        {
+          'breakpoints': [
+            {'name': 'large', 'num_columns': 6},
+            {'name': 'medium', 'num_columns': 2},
+            {'name': 'small', 'num_columns': 1}
+          ]
+        },
+        {
+          'breakpoints': [
+            {'name': 'large', 'num_columns': 2},
+            {'name': 'medium', 'num_columns': 0},
+            {'name': 'small', 'num_columns': 0}
+          ]
+        }
+      ]
+    ) }}
+  </div>
+{% endblock %}

--- a/templates/docs/examples/patterns/grid/4-columns-medium-offsets-responsive.html
+++ b/templates/docs/examples/patterns/grid/4-columns-medium-offsets-responsive.html
@@ -8,7 +8,7 @@
 {% block content %}
   <div class="grid-demo">
     {{ grid_example(
-      row_class="row--4-cols-medium",
+      row_class="p-row",
       columns=[
         {
           'breakpoints': [

--- a/templates/docs/examples/patterns/grid/4-columns-medium-offsets-responsive.html
+++ b/templates/docs/examples/patterns/grid/4-columns-medium-offsets-responsive.html
@@ -1,0 +1,30 @@
+{% extends "_layouts/examples.html" %}
+{% from "docs/examples/patterns/grid/_grid-example.jinja" import grid_example %}
+
+{% block title %}Grid / 4 columns on medium / Offsets{% endblock %}
+
+{% block standalone_css %}patterns_grid{% endblock %}
+
+{% block content %}
+  <div class="grid-demo">
+    {{ grid_example(
+      row_class="row--4-cols-medium",
+      columns=[
+        {
+          'breakpoints': [
+            {'name': 'large', 'num_columns': 6, 'start': 4},
+            {'name': 'medium', 'num_columns': 1, 'start': 3},
+            {'name': 'small', 'num_columns': 1, 'start': 1}
+          ]
+        },
+        {
+          'breakpoints': [
+            {'name': 'large', 'num_columns': 3, 'start': 10},
+            {'name': 'medium', 'num_columns': 1, 'start': 4},
+            {'name': 'small', 'num_columns': 2, 'start': 3}
+          ]
+        }
+      ]
+    ) }}
+  </div>
+{% endblock %}

--- a/templates/docs/examples/patterns/grid/4-columns-medium-reordering-responsive.html
+++ b/templates/docs/examples/patterns/grid/4-columns-medium-reordering-responsive.html
@@ -1,0 +1,37 @@
+{% extends "_layouts/examples.html" %}
+{% from "docs/examples/patterns/grid/_grid-example.jinja" import grid_example %}
+
+{% block title %}Grid / 4 columns on medium / Reordering{% endblock %}
+
+{% block standalone_css %}patterns_grid{% endblock %}
+
+{% block content %}
+  <div class="grid-demo">
+    {{ grid_example(
+      row_class="row--4-cols-medium",
+      columns=[
+        {
+          'breakpoints': [
+            {'name': 'large', 'num_columns': 3, 'order': 3},
+            {'name': 'medium', 'num_columns': 2, 'order': 1},
+            {'name': 'small', 'num_columns': 1, 'order': 1}
+          ]
+        },
+        {
+          'breakpoints': [
+            {'name': 'large', 'num_columns': 4, 'order': 2},
+            {'name': 'medium', 'num_columns': 1, 'order': 3},
+            {'name': 'small', 'num_columns': 1, 'order': 2}
+          ]
+        },
+        {
+          'breakpoints': [
+            {'name': 'large', 'num_columns': 5, 'order': 1},
+            {'name': 'medium', 'num_columns': 1, 'order': 2},
+            {'name': 'small', 'num_columns': 2, 'order': 3}
+          ]
+        }
+      ]
+    ) }}
+  </div>
+{% endblock %}

--- a/templates/docs/examples/patterns/grid/4-columns-medium-reordering-responsive.html
+++ b/templates/docs/examples/patterns/grid/4-columns-medium-reordering-responsive.html
@@ -8,7 +8,7 @@
 {% block content %}
   <div class="grid-demo">
     {{ grid_example(
-      row_class="row--4-cols-medium",
+      row_class="p-row",
       columns=[
         {
           'breakpoints': [

--- a/templates/docs/examples/patterns/grid/4-columns-medium-responsive.html
+++ b/templates/docs/examples/patterns/grid/4-columns-medium-responsive.html
@@ -1,0 +1,25 @@
+{% extends "_layouts/examples.html" %}
+{% from "docs/examples/patterns/grid/_grid-example.jinja" import grid_example %}
+
+{% block title %}Grid / 4 columns on medium{% endblock %}
+
+{% block standalone_css %}patterns_grid{% endblock %}
+
+{% block content %}
+  <div class="grid-demo">
+    {{ grid_example(
+        row_class="row--4-cols-medium",
+        columns=[
+          {'breakpoints': [
+            {'name': 'medium', 'num_columns': 1}
+          ]},
+          {'breakpoints': [
+            {'name': 'medium', 'num_columns': 2}
+          ]},
+          {'breakpoints': [
+            {'name': 'medium', 'num_columns': 1}
+          ]}
+        ]
+      ) }}
+  </div>
+{% endblock %}

--- a/templates/docs/examples/patterns/grid/4-columns-medium-responsive.html
+++ b/templates/docs/examples/patterns/grid/4-columns-medium-responsive.html
@@ -8,7 +8,7 @@
 {% block content %}
   <div class="grid-demo">
     {{ grid_example(
-        row_class="row--4-cols-medium",
+        row_class="p-row",
         columns=[
           {'breakpoints': [
             {'name': 'medium', 'num_columns': 1}

--- a/templates/docs/examples/patterns/grid/_grid-example.jinja
+++ b/templates/docs/examples/patterns/grid/_grid-example.jinja
@@ -5,24 +5,24 @@
   {%- endif -%}
   <div class="{{ row_class }}">
     {%- for column in columns -%}
-      {% set column_classes = [] %}
+      {%- set column_classes = [] -%}
       {%- for breakpoint in column.breakpoints -%}
-        {% if breakpoint.num_columns > 0 %}
+        {%- if breakpoint.num_columns > 0 -%}
           {% set span_class_name = col_class_prefix + breakpoint.name + '-' + (breakpoint.num_columns | string) %}
           {%- if breakpoint.name == 'large' -%}
-            {% set span_class_name = span_class_name | replace('-large', '') %}
+            {%- set span_class_name = span_class_name | replace('-large', '') -%}
           {%- endif -%}
         {% else %}
           {% set span_class_name = 'u-hide--' + breakpoint.name %}
         {%- endif -%}
-        {{ column_classes.append(span_class_name) or "" }}
+        {{- column_classes.append(span_class_name) or "" -}}
         {%- if 'start' in breakpoint and breakpoint.start > 0 -%}
           {% set offset_class_name = col_class_prefix + 'start-' + breakpoint.name + '-' + (breakpoint.start | string) %}
-          {{ column_classes.append(offset_class_name) or "" }}
+          {{- column_classes.append(offset_class_name) or "" -}}
         {%- endif -%}
         {%- if 'order' in breakpoint and breakpoint.order > 0 -%}
           {% set order_class_name = col_class_prefix + 'order-' + breakpoint.name + '-' + (breakpoint.order | string) %}
-          {{ column_classes.append(order_class_name) or "" }}
+          {{- column_classes.append(order_class_name) or "" -}}
         {%- endif -%}
       {%- endfor -%}
       <div class="{{ column_classes | join(' ') }}">

--- a/templates/docs/examples/patterns/grid/_grid-example.jinja
+++ b/templates/docs/examples/patterns/grid/_grid-example.jinja
@@ -1,0 +1,37 @@
+{%- macro grid_example(columns=[], row_class="row", is_nested=False, show_row_class=False) -%}
+  {% set col_class_prefix="col-" %}
+  {%- if not is_nested and show_row_class -%}
+    <p>.{{ row_class }}</p>
+  {%- endif -%}
+  <div class="{{ row_class }}">
+    {%- for column in columns -%}
+      {% set column_classes = [] %}
+      {%- for breakpoint in column.breakpoints -%}
+        {% if breakpoint.num_columns > 0 %}
+          {% set span_class_name = col_class_prefix + breakpoint.name + '-' + (breakpoint.num_columns | string) %}
+          {%- if breakpoint.name == 'large' -%}
+            {% set span_class_name = span_class_name | replace('-large', '') %}
+          {%- endif -%}
+        {% else %}
+          {% set span_class_name = 'u-hide--' + breakpoint.name %}
+        {%- endif -%}
+        {{ column_classes.append(span_class_name) or "" }}
+        {%- if 'start' in breakpoint and breakpoint.start > 0 -%}
+          {% set offset_class_name = col_class_prefix + 'start-' + breakpoint.name + '-' + (breakpoint.start | string) %}
+          {{ column_classes.append(offset_class_name) or "" }}
+        {%- endif -%}
+        {%- if 'order' in breakpoint and breakpoint.order > 0 -%}
+          {% set order_class_name = col_class_prefix + 'order-' + breakpoint.name + '-' + (breakpoint.order | string) %}
+          {{ column_classes.append(order_class_name) or "" }}
+        {%- endif -%}
+      {%- endfor -%}
+      <div class="{{ column_classes | join(' ') }}">
+        {%- if 'nested_columns' in column and column.nested_columns | length > 0 -%}
+          {{ grid_example(columns=column.nested_columns, row_class=row_class, is_nested=True) }}
+        {%- else -%}
+          .{{ column_classes | join ('.') }}
+        {%- endif -%}
+      </div>
+    {%- endfor -%}
+  </div>
+{%- endmacro -%}

--- a/templates/docs/examples/patterns/grid/bordered.html
+++ b/templates/docs/examples/patterns/grid/bordered.html
@@ -5,12 +5,12 @@
 
 {% block content %}
 <div class="grid-demo">
-  <div class="row--4-cols-medium is-bordered">
+  <div class="p-row is-bordered">
     <div class="col-12">
       <span>.col-12</span>
     </div>
   </div>
-  <div class="row--4-cols-medium is-bordered">
+  <div class="p-row is-bordered">
     <div class="col-11">
       <span>.col-11</span>
     </div>
@@ -18,7 +18,7 @@
       <span>.col-1</span>
     </div>
   </div>
-  <div class="row--4-cols-medium is-bordered">
+  <div class="p-row is-bordered">
     <div class="col-10">
       <span>.col-10</span>
     </div>
@@ -26,7 +26,7 @@
       <span>.col-2</span>
     </div>
   </div>
-  <div class="row--4-cols-medium is-bordered">
+  <div class="p-row is-bordered">
     <div class="col-9">
       <span>.col-9</span>
     </div>
@@ -34,7 +34,7 @@
       <span>.col-9</span>
     </div>
   </div>
-  <div class="row--4-cols-medium is-bordered">
+  <div class="p-row is-bordered">
     <div class="col-8">
       <span>.col-8</span>
     </div>
@@ -42,7 +42,7 @@
       <span>.col-4</span>
     </div>
   </div>
-  <div class="row--4-cols-medium is-bordered">
+  <div class="p-row is-bordered">
     <div class="col-7">
       <span>.col-7</span>
     </div>
@@ -50,7 +50,7 @@
       <span>.col-5</span>
     </div>
   </div>
-  <div class="row--4-cols-medium is-bordered">
+  <div class="p-row is-bordered">
     <div class="col-6">
       <span>.col-6</span>
     </div>
@@ -58,7 +58,7 @@
       <span>.col-6</span>
     </div>
   </div>
-  <div class="row--4-cols-medium is-bordered">
+  <div class="p-row is-bordered">
     <div class="col-5">
       <span>.col-5</span>
     </div>
@@ -66,7 +66,7 @@
       <span>.col-7</span>
     </div>
   </div>
-  <div class="row--4-cols-medium is-bordered">
+  <div class="p-row is-bordered">
     <div class="col-4">
       <span>.col-4</span>
     </div>
@@ -74,7 +74,7 @@
       <span>.col-8</span>
     </div>
   </div>
-  <div class="row--4-cols-medium is-bordered">
+  <div class="p-row is-bordered">
     <div class="col-3">
       <span>.col-3</span>
     </div>
@@ -82,7 +82,7 @@
       <span>.col-9</span>
     </div>
   </div>
-  <div class="row--4-cols-medium is-bordered">
+  <div class="p-row is-bordered">
     <div class="col-2">
       <span>.col-2</span>
     </div>
@@ -90,7 +90,7 @@
       <span>.col-10</span>
     </div>
   </div>
-  <div class="row--4-cols-medium is-bordered">
+  <div class="p-row is-bordered">
     <div class="col-1">
       <span>.col-1</span>
     </div>

--- a/templates/docs/examples/patterns/grid/bordered.html
+++ b/templates/docs/examples/patterns/grid/bordered.html
@@ -5,12 +5,12 @@
 
 {% block content %}
 <div class="grid-demo">
-  <div class="row is-bordered">
+  <div class="row--4-cols-medium is-bordered">
     <div class="col-12">
       <span>.col-12</span>
     </div>
   </div>
-  <div class="row is-bordered">
+  <div class="row--4-cols-medium is-bordered">
     <div class="col-11">
       <span>.col-11</span>
     </div>
@@ -18,7 +18,7 @@
       <span>.col-1</span>
     </div>
   </div>
-  <div class="row is-bordered">
+  <div class="row--4-cols-medium is-bordered">
     <div class="col-10">
       <span>.col-10</span>
     </div>
@@ -26,7 +26,7 @@
       <span>.col-2</span>
     </div>
   </div>
-  <div class="row is-bordered">
+  <div class="row--4-cols-medium is-bordered">
     <div class="col-9">
       <span>.col-9</span>
     </div>
@@ -34,7 +34,7 @@
       <span>.col-9</span>
     </div>
   </div>
-  <div class="row is-bordered">
+  <div class="row--4-cols-medium is-bordered">
     <div class="col-8">
       <span>.col-8</span>
     </div>
@@ -42,7 +42,7 @@
       <span>.col-4</span>
     </div>
   </div>
-  <div class="row is-bordered">
+  <div class="row--4-cols-medium is-bordered">
     <div class="col-7">
       <span>.col-7</span>
     </div>
@@ -50,7 +50,7 @@
       <span>.col-5</span>
     </div>
   </div>
-  <div class="row is-bordered">
+  <div class="row--4-cols-medium is-bordered">
     <div class="col-6">
       <span>.col-6</span>
     </div>
@@ -58,7 +58,7 @@
       <span>.col-6</span>
     </div>
   </div>
-  <div class="row is-bordered">
+  <div class="row--4-cols-medium is-bordered">
     <div class="col-5">
       <span>.col-5</span>
     </div>
@@ -66,7 +66,7 @@
       <span>.col-7</span>
     </div>
   </div>
-  <div class="row is-bordered">
+  <div class="row--4-cols-medium is-bordered">
     <div class="col-4">
       <span>.col-4</span>
     </div>
@@ -74,7 +74,7 @@
       <span>.col-8</span>
     </div>
   </div>
-  <div class="row is-bordered">
+  <div class="row--4-cols-medium is-bordered">
     <div class="col-3">
       <span>.col-3</span>
     </div>
@@ -82,7 +82,7 @@
       <span>.col-9</span>
     </div>
   </div>
-  <div class="row is-bordered">
+  <div class="row--4-cols-medium is-bordered">
     <div class="col-2">
       <span>.col-2</span>
     </div>
@@ -90,7 +90,7 @@
       <span>.col-10</span>
     </div>
   </div>
-  <div class="row is-bordered">
+  <div class="row--4-cols-medium is-bordered">
     <div class="col-1">
       <span>.col-1</span>
     </div>

--- a/templates/docs/examples/patterns/grid/combined.html
+++ b/templates/docs/examples/patterns/grid/combined.html
@@ -26,5 +26,11 @@
 <section>{% include 'docs/examples/patterns/grid/nested-small.html' %}</section>
 <section>{% include 'docs/examples/patterns/grid/offsets.html' %}</section>
 <section>{% include 'docs/examples/patterns/grid/responsive.html' %}</section>
+<section>{% include 'docs/examples/patterns/grid/4-columns-medium-responsive.html' %}</section>
+<section>{% include 'docs/examples/patterns/grid/4-columns-medium-mixed-responsive.html' %}</section>
+<section>{% include 'docs/examples/patterns/grid/4-columns-medium-6-columns-medium-comparison-responsive.html' %}</section>
+<section>{% include 'docs/examples/patterns/grid/4-columns-medium-reordering-responsive.html' %}</section>
+<section>{% include 'docs/examples/patterns/grid/4-columns-medium-offsets-responsive.html' %}</section>
+<section>{% include 'docs/examples/patterns/grid/4-columns-medium-nested-responsive.html' %}</section>
 {% endwith %}
 {% endblock %}

--- a/templates/docs/examples/patterns/grid/combined.html
+++ b/templates/docs/examples/patterns/grid/combined.html
@@ -32,5 +32,6 @@
 <section>{% include 'docs/examples/patterns/grid/4-columns-medium-reordering-responsive.html' %}</section>
 <section>{% include 'docs/examples/patterns/grid/4-columns-medium-offsets-responsive.html' %}</section>
 <section>{% include 'docs/examples/patterns/grid/4-columns-medium-nested-responsive.html' %}</section>
+<section>{% include 'docs/examples/patterns/grid/legacy.html' %}</section>
 {% endwith %}
 {% endblock %}

--- a/templates/docs/examples/patterns/grid/default.html
+++ b/templates/docs/examples/patterns/grid/default.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="grid-demo">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-1 col-medium-1 col-small-1">
       <span>.col-1</span>
     </div>

--- a/templates/docs/examples/patterns/grid/empty-columns.html
+++ b/templates/docs/examples/patterns/grid/empty-columns.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="grid-demo">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-8">
       .col-8
     </div>
@@ -13,22 +13,22 @@
       .col-4
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
       <div class="col-7">
         .col-7
       </div>
       <div class="col-4">
-        <div class="row">
+        <div class="row--4-cols-medium">
           <div class="col-3 col-start-large-2">.col-3 .col-start-large-2 inside .col-4</div>
         </div>
       </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
       <div class="col-7">
         .col-7
       </div>
       <div class="col-4">
-        <div class="row">
+        <div class="row--4-cols-medium">
           <div class="col-3">.col-3 inside .col-4</div>
         </div>
       </div>

--- a/templates/docs/examples/patterns/grid/empty-columns.html
+++ b/templates/docs/examples/patterns/grid/empty-columns.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="grid-demo">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-8">
       .col-8
     </div>
@@ -13,22 +13,22 @@
       .col-4
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
       <div class="col-7">
         .col-7
       </div>
       <div class="col-4">
-        <div class="row--4-cols-medium">
+        <div class="p-row">
           <div class="col-3 col-start-large-2">.col-3 .col-start-large-2 inside .col-4</div>
         </div>
       </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
       <div class="col-7">
         .col-7
       </div>
       <div class="col-4">
-        <div class="row--4-cols-medium">
+        <div class="p-row">
           <div class="col-3">.col-3 inside .col-4</div>
         </div>
       </div>

--- a/templates/docs/examples/patterns/grid/full.html
+++ b/templates/docs/examples/patterns/grid/full.html
@@ -5,12 +5,12 @@
 
 {% block content %}
 <div class="grid-demo">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-12">
       <span>.col-12</span>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-11">
       <span>.col-11</span>
     </div>
@@ -18,7 +18,7 @@
       <span>.col-1</span>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-10">
       <span>.col-10</span>
     </div>
@@ -26,7 +26,7 @@
       <span>.col-2</span>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-9">
       <span>.col-9</span>
     </div>
@@ -34,7 +34,7 @@
       <span>.col-3</span>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-8">
       <span>.col-8</span>
     </div>
@@ -42,7 +42,7 @@
       <span>.col-4</span>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-7">
       <span>.col-7</span>
     </div>
@@ -50,7 +50,7 @@
       <span>.col-5</span>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-6">
       <span>.col-6</span>
     </div>
@@ -58,7 +58,7 @@
       <span>.col-6</span>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-5">
       <span>.col-5</span>
     </div>
@@ -66,7 +66,7 @@
       <span>.col-7</span>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-4">
       <span>.col-4</span>
     </div>
@@ -74,7 +74,7 @@
       <span>.col-8</span>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-3">
       <span>.col-3</span>
     </div>
@@ -82,7 +82,7 @@
       <span>.col-9</span>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-2">
       <span>.col-2</span>
     </div>
@@ -90,7 +90,7 @@
       <span>.col-10</span>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-1">
       <span>.col-1</span>
     </div>
@@ -98,7 +98,7 @@
       <span>.col-11</span>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-1">
       <span>.col-1</span>
     </div>
@@ -136,7 +136,7 @@
       <span>.col-1</span>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-2">
       <span>.col-2</span>
     </div>
@@ -156,7 +156,7 @@
       <span>.col-2</span>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-3">
       <span>.col-3</span>
     </div>
@@ -170,7 +170,7 @@
       <span>.col-3</span>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-4">
       <span>.col-4</span>
     </div>

--- a/templates/docs/examples/patterns/grid/full.html
+++ b/templates/docs/examples/patterns/grid/full.html
@@ -5,12 +5,12 @@
 
 {% block content %}
 <div class="grid-demo">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-12">
       <span>.col-12</span>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-11">
       <span>.col-11</span>
     </div>
@@ -18,7 +18,7 @@
       <span>.col-1</span>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-10">
       <span>.col-10</span>
     </div>
@@ -26,7 +26,7 @@
       <span>.col-2</span>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-9">
       <span>.col-9</span>
     </div>
@@ -34,7 +34,7 @@
       <span>.col-3</span>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-8">
       <span>.col-8</span>
     </div>
@@ -42,7 +42,7 @@
       <span>.col-4</span>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-7">
       <span>.col-7</span>
     </div>
@@ -50,7 +50,7 @@
       <span>.col-5</span>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-6">
       <span>.col-6</span>
     </div>
@@ -58,7 +58,7 @@
       <span>.col-6</span>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-5">
       <span>.col-5</span>
     </div>
@@ -66,7 +66,7 @@
       <span>.col-7</span>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-4">
       <span>.col-4</span>
     </div>
@@ -74,7 +74,7 @@
       <span>.col-8</span>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-3">
       <span>.col-3</span>
     </div>
@@ -82,7 +82,7 @@
       <span>.col-9</span>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-2">
       <span>.col-2</span>
     </div>
@@ -90,7 +90,7 @@
       <span>.col-10</span>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-1">
       <span>.col-1</span>
     </div>
@@ -98,7 +98,7 @@
       <span>.col-11</span>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-1">
       <span>.col-1</span>
     </div>
@@ -136,7 +136,7 @@
       <span>.col-1</span>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-2">
       <span>.col-2</span>
     </div>
@@ -156,7 +156,7 @@
       <span>.col-2</span>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-3">
       <span>.col-3</span>
     </div>
@@ -170,7 +170,7 @@
       <span>.col-3</span>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-4">
       <span>.col-4</span>
     </div>

--- a/templates/docs/examples/patterns/grid/incorrect-empty-columns.html
+++ b/templates/docs/examples/patterns/grid/incorrect-empty-columns.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="grid-demo">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-1">
       .col-1
     </div>
@@ -43,12 +43,12 @@
       .col-1
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
       <div class="col-7">
         .col-7
       </div>
       <div class="col-4">
-        <div class="row--4-cols-medium">
+        <div class="p-row">
           <div class="col-3 col-start-large-7">.col-3 .col-start-large-7</div>
         </div>
       </div>

--- a/templates/docs/examples/patterns/grid/incorrect-empty-columns.html
+++ b/templates/docs/examples/patterns/grid/incorrect-empty-columns.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="grid-demo">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-1">
       .col-1
     </div>
@@ -43,12 +43,12 @@
       .col-1
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
       <div class="col-7">
         .col-7
       </div>
       <div class="col-4">
-        <div class="row">
+        <div class="row--4-cols-medium">
           <div class="col-3 col-start-large-7">.col-3 .col-start-large-7</div>
         </div>
       </div>

--- a/templates/docs/examples/patterns/grid/legacy.html
+++ b/templates/docs/examples/patterns/grid/legacy.html
@@ -1,11 +1,11 @@
 {% extends "_layouts/examples.html" %}
-{% block title %}Grid / Default{% endblock %}
+{% block title %}Grid / Legacy{% endblock %}
 
 {% block standalone_css %}patterns_grid{% endblock %}
 
 {% block content %}
 <div class="grid-demo">
-  <div class="p-row">
+  <div class="row">
     <div class="col-1 col-medium-1 col-small-1">
       <span>.col-1</span>
     </div>

--- a/templates/docs/examples/patterns/hero/hero-404.html
+++ b/templates/docs/examples/patterns/hero/hero-404.html
@@ -16,7 +16,7 @@
                 <p class="p-heading--2">We can't find the page you're looking for.
                     <a href="#">File a bug</a> if you think this might be an error.</p>
             </div>
-            <div class="row--4-cols-medium">
+            <div class="p-row">
                 <div class="col-6">
                     <form class="p-search-box u-text-max-width">
                         <label class="u-off-screen" for="search">Search</label>

--- a/templates/docs/examples/patterns/hero/hero-404.html
+++ b/templates/docs/examples/patterns/hero/hero-404.html
@@ -16,7 +16,7 @@
                 <p class="p-heading--2">We can't find the page you're looking for.
                     <a href="#">File a bug</a> if you think this might be an error.</p>
             </div>
-            <div class="row">
+            <div class="row--4-cols-medium">
                 <div class="col-6">
                     <form class="p-search-box u-text-max-width">
                         <label class="u-off-screen" for="search">Search</label>

--- a/templates/docs/examples/patterns/hero/hero-nested-grid.html
+++ b/templates/docs/examples/patterns/hero/hero-nested-grid.html
@@ -15,7 +15,7 @@
             </div>
         </div>
         <div class="col">
-            <div class="row--4-cols-medium">
+            <div class="p-row">
                 <div class="col-6">
                     <div class="p-section--shallow">
                         <h1>What is Kubeflow?</h1>

--- a/templates/docs/examples/patterns/hero/hero-nested-grid.html
+++ b/templates/docs/examples/patterns/hero/hero-nested-grid.html
@@ -15,7 +15,7 @@
             </div>
         </div>
         <div class="col">
-            <div class="row">
+            <div class="row--4-cols-medium">
                 <div class="col-6">
                     <div class="p-section--shallow">
                         <h1>What is Kubeflow?</h1>

--- a/templates/docs/examples/patterns/hero/hero-sections-search.html
+++ b/templates/docs/examples/patterns/hero/hero-sections-search.html
@@ -14,7 +14,7 @@
             <div class="p-section--shallow">
                 <p>Canonical's network of Ubuntu partners spans the full range of our product suite. We offer partner programmes for public clouds, IHVs/OEMs, desktop, channel/resellers and global systems integrators.</p>
             </div>
-            <div class="row--4-cols-medium">
+            <div class="p-row">
                 <div class="col-6">
                     <form class="p-search-box u-text-max-width">
                         <label class="u-off-screen" for="search">Search</label>

--- a/templates/docs/examples/patterns/hero/hero-sections-search.html
+++ b/templates/docs/examples/patterns/hero/hero-sections-search.html
@@ -14,7 +14,7 @@
             <div class="p-section--shallow">
                 <p>Canonical's network of Ubuntu partners spans the full range of our product suite. We offer partner programmes for public clouds, IHVs/OEMs, desktop, channel/resellers and global systems integrators.</p>
             </div>
-            <div class="row">
+            <div class="row--4-cols-medium">
                 <div class="col-6">
                     <form class="p-search-box u-text-max-width">
                         <label class="u-off-screen" for="search">Search</label>

--- a/templates/docs/examples/patterns/rule/muted.html
+++ b/templates/docs/examples/patterns/rule/muted.html
@@ -9,7 +9,7 @@
   <div class="row--25-75">
     <div class="col">
       <hr class="p-rule">
-      <div class="row--4-cols-medium">
+      <div class="p-row">
         <div class="col-6">
           <h2>Infrastructure, <br>your way</h2>
           <p>Flexible and engineered for efficiency. <br>From small, private clouds on rails to clouds at any scale.</p>

--- a/templates/docs/examples/patterns/rule/muted.html
+++ b/templates/docs/examples/patterns/rule/muted.html
@@ -9,7 +9,7 @@
   <div class="row--25-75">
     <div class="col">
       <hr class="p-rule">
-      <div class="row">
+      <div class="row--4-cols-medium">
         <div class="col-6">
           <h2>Infrastructure, <br>your way</h2>
           <p>Flexible and engineered for efficiency. <br>From small, private clouds on rails to clouds at any scale.</p>

--- a/templates/docs/examples/patterns/side-navigation/default.html
+++ b/templates/docs/examples/patterns/side-navigation/default.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_side-navigation{% endblock %}
 
 {% block content %}
-<div class="row">
+<div class="row--4-cols-medium">
   <div class="col-4">
       {% include "docs/examples/patterns/side-navigation/_default.html" %}
   </div>

--- a/templates/docs/examples/patterns/side-navigation/default.html
+++ b/templates/docs/examples/patterns/side-navigation/default.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_side-navigation{% endblock %}
 
 {% block content %}
-<div class="row--4-cols-medium">
+<div class="p-row">
   <div class="col-4">
       {% include "docs/examples/patterns/side-navigation/_default.html" %}
   </div>

--- a/templates/docs/examples/patterns/side-navigation/expandable.html
+++ b/templates/docs/examples/patterns/side-navigation/expandable.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_side-navigation{% endblock %}
 
 {% block content %}
-<div class="row">
+<div class="row--4-cols-medium">
    <div class="col-4">
     {% include "docs/examples/patterns/side-navigation/_expandable.html" %}
   </div>

--- a/templates/docs/examples/patterns/side-navigation/expandable.html
+++ b/templates/docs/examples/patterns/side-navigation/expandable.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_side-navigation{% endblock %}
 
 {% block content %}
-<div class="row--4-cols-medium">
+<div class="p-row">
    <div class="col-4">
     {% include "docs/examples/patterns/side-navigation/_expandable.html" %}
   </div>

--- a/templates/docs/examples/patterns/strips/accent.html
+++ b/templates/docs/examples/patterns/strips/accent.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <section class="p-strip--accent">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-8">
       <h1>Still running Ubuntu 14.04 LTS?</h1>
       <p>Learn how to maintain ongoing security compliance for your Ubuntu 14.04 LTS systems.</p>

--- a/templates/docs/examples/patterns/strips/accent.html
+++ b/templates/docs/examples/patterns/strips/accent.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <section class="p-strip--accent">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-8">
       <h1>Still running Ubuntu 14.04 LTS?</h1>
       <p>Learn how to maintain ongoing security compliance for your Ubuntu 14.04 LTS systems.</p>

--- a/templates/docs/examples/patterns/strips/image.html
+++ b/templates/docs/examples/patterns/strips/image.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <section class="p-strip--image is-light" style="background-image:url('https://assets.ubuntu.com/v1/1d2ab6ba-suru-background.png')">
-  <div class="row u-vertically-center">
+  <div class="row--4-cols-medium u-vertically-center">
     <div class="col-8">
       <h1>Get started with big software, fast</h1>
       <p>conjure-up lets you summon up a big-software stack as a “spell” — a model of the stack, combined with extra know-how to get you from an installed stack to a fully usable one. Start using your big software instead of learning how to deploy
@@ -18,8 +18,8 @@
 </section>
 
 <section class="p-strip--image is-dark" style="background-image:url('https://assets.ubuntu.com/v1/9b68976e-Aubergine_suru_background_2.png')">
-  <div class="row">
-    <div class="row u-vertically-center">
+  <div class="row--4-cols-medium">
+    <div class="row--4-cols-medium u-vertically-center">
       <div class="col-8">
         <h1>We are Canonical</h1>
         <p>It is our mission to make open source software available to people everywhere. We believe the best way to fuel innovation is to give the innovators the technology they need.</p>

--- a/templates/docs/examples/patterns/strips/image.html
+++ b/templates/docs/examples/patterns/strips/image.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <section class="p-strip--image is-light" style="background-image:url('https://assets.ubuntu.com/v1/1d2ab6ba-suru-background.png')">
-  <div class="row--4-cols-medium u-vertically-center">
+  <div class="p-row u-vertically-center">
     <div class="col-8">
       <h1>Get started with big software, fast</h1>
       <p>conjure-up lets you summon up a big-software stack as a “spell” — a model of the stack, combined with extra know-how to get you from an installed stack to a fully usable one. Start using your big software instead of learning how to deploy
@@ -18,8 +18,8 @@
 </section>
 
 <section class="p-strip--image is-dark" style="background-image:url('https://assets.ubuntu.com/v1/9b68976e-Aubergine_suru_background_2.png')">
-  <div class="row--4-cols-medium">
-    <div class="row--4-cols-medium u-vertically-center">
+  <div class="p-row">
+    <div class="p-row u-vertically-center">
       <div class="col-8">
         <h1>We are Canonical</h1>
         <p>It is our mission to make open source software available to people everywhere. We believe the best way to fuel innovation is to give the innovators the technology they need.</p>

--- a/templates/docs/examples/patterns/strips/is-bordered.html
+++ b/templates/docs/examples/patterns/strips/is-bordered.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <section class="p-strip is-bordered">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-8">
       <h2>The node lifecycle</h2>
       <p>Each machine (“node”) managed by MAAS goes through a lifecycle — from its enlistment or onboarding to MAAS, through commissioning when we inventory and can setup firmware or other hardware-specific elements, then allocation to a user and deployment, and finally they are released back to the pool or retired altogether.</p>

--- a/templates/docs/examples/patterns/strips/is-bordered.html
+++ b/templates/docs/examples/patterns/strips/is-bordered.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <section class="p-strip is-bordered">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-8">
       <h2>The node lifecycle</h2>
       <p>Each machine (“node”) managed by MAAS goes through a lifecycle — from its enlistment or onboarding to MAAS, through commissioning when we inventory and can setup firmware or other hardware-specific elements, then allocation to a user and deployment, and finally they are released back to the pool or retired altogether.</p>

--- a/templates/docs/examples/patterns/strips/strips-dark.html
+++ b/templates/docs/examples/patterns/strips/strips-dark.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="p-strip--dark">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-12">
       <p>This is a dark row</p>
     </div>

--- a/templates/docs/examples/patterns/strips/strips-dark.html
+++ b/templates/docs/examples/patterns/strips/strips-dark.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="p-strip--dark">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-12">
       <p>This is a dark row</p>
     </div>

--- a/templates/docs/examples/patterns/strips/strips-light.html
+++ b/templates/docs/examples/patterns/strips/strips-light.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="p-strip--light">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-12">
       <p>This is a light row</p>
     </div>

--- a/templates/docs/examples/patterns/strips/strips-light.html
+++ b/templates/docs/examples/patterns/strips/strips-light.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="p-strip--light">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-12">
       <p>This is a light row</p>
     </div>

--- a/templates/docs/examples/patterns/strips/suru-topped.html
+++ b/templates/docs/examples/patterns/strips/suru-topped.html
@@ -5,13 +5,13 @@
 
 {% block content %}
 <section class="p-strip--suru-topped">
-  <div class="row--4-cols-medium u-vertically-center">
+  <div class="p-row u-vertically-center">
     <div class="col-8">
       <h1>Accessibility guidelines</h1>
     </div>
   </div>
 </section>
-<div class="row--4-cols-medium">
+<div class="p-row">
 	<div class="col-8">
 		<h4>Vanilla aims to be as inclusive as possible.</h4>
 		<p>While traditionally accessibility focuses on making the web more accessible for users with permanent disabilities, a focus on accessibility can deliver an improved user experience for everyone, including those with a temporary or circumstantial disability.</p>

--- a/templates/docs/examples/patterns/strips/suru-topped.html
+++ b/templates/docs/examples/patterns/strips/suru-topped.html
@@ -5,13 +5,13 @@
 
 {% block content %}
 <section class="p-strip--suru-topped">
-  <div class="row u-vertically-center">
+  <div class="row--4-cols-medium u-vertically-center">
     <div class="col-8">
       <h1>Accessibility guidelines</h1>
     </div>
   </div>
 </section>
-<div class="row">
+<div class="row--4-cols-medium">
 	<div class="col-8">
 		<h4>Vanilla aims to be as inclusive as possible.</h4>
 		<p>While traditionally accessibility focuses on making the web more accessible for users with permanent disabilities, a focus on accessibility can deliver an improved user experience for everyone, including those with a temporary or circumstantial disability.</p>

--- a/templates/docs/examples/patterns/strips/suru.html
+++ b/templates/docs/examples/patterns/strips/suru.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <section class="p-strip--suru">
-  <div class="row--4-cols-medium u-vertically-center">
+  <div class="p-row u-vertically-center">
     <div class="col-8">
       <h1>A simple, extensible CSS framework</h1>
       <p>Backed by open-source code and written in Sass by the Canonical Web Team.</p>

--- a/templates/docs/examples/patterns/strips/suru.html
+++ b/templates/docs/examples/patterns/strips/suru.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <section class="p-strip--suru">
-  <div class="row u-vertically-center">
+  <div class="row--4-cols-medium u-vertically-center">
     <div class="col-8">
       <h1>A simple, extensible CSS framework</h1>
       <p>Backed by open-source code and written in Sass by the Canonical Web Team.</p>

--- a/templates/docs/examples/patterns/tables/table-expanding.html
+++ b/templates/docs/examples/patterns/tables/table-expanding.html
@@ -30,7 +30,7 @@
                     data-hidden-text="Show">Show</button>
             </td>
             <td id="expanded-row" class="p-table__expanding-panel" aria-hidden="true">
-                <div class="row">
+                <div class="row--4-cols-medium">
                     <div class="col-8">
                         <h4>Expanding table cell</h4>
                         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae
@@ -51,7 +51,7 @@
                     data-hidden-text="Show">Show</button>
             </td>
             <td id="expanded-row-2" class="p-table__expanding-panel" aria-hidden="true">
-                <div class="row">
+                <div class="row--4-cols-medium">
                     <div class="col-8">
                         <h4>Expanding table cell</h4>
                         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae
@@ -72,7 +72,7 @@
                     data-hidden-text="Show">Show</button>
             </td>
             <td id="expanded-row-3" class="p-table__expanding-panel" aria-hidden="true">
-                <div class="row">
+                <div class="row--4-cols-medium">
                     <div class="col-8">
                         <h4>Expanding table cell</h4>
                         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae

--- a/templates/docs/examples/patterns/tables/table-expanding.html
+++ b/templates/docs/examples/patterns/tables/table-expanding.html
@@ -30,7 +30,7 @@
                     data-hidden-text="Show">Show</button>
             </td>
             <td id="expanded-row" class="p-table__expanding-panel" aria-hidden="true">
-                <div class="row--4-cols-medium">
+                <div class="p-row">
                     <div class="col-8">
                         <h4>Expanding table cell</h4>
                         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae
@@ -51,7 +51,7 @@
                     data-hidden-text="Show">Show</button>
             </td>
             <td id="expanded-row-2" class="p-table__expanding-panel" aria-hidden="true">
-                <div class="row--4-cols-medium">
+                <div class="p-row">
                     <div class="col-8">
                         <h4>Expanding table cell</h4>
                         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae
@@ -72,7 +72,7 @@
                     data-hidden-text="Show">Show</button>
             </td>
             <td id="expanded-row-3" class="p-table__expanding-panel" aria-hidden="true">
-                <div class="row--4-cols-medium">
+                <div class="p-row">
                     <div class="col-8">
                         <h4>Expanding table cell</h4>
                         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur cum dicta beatae

--- a/templates/docs/examples/standalone.html
+++ b/templates/docs/examples/standalone.html
@@ -8,14 +8,14 @@
 
 {% block body %}
 <main id="main-content" class="p-strip">
-    <div class="row">
+    <div class="row--4-cols-medium">
       <div class="col-12">
         <h1>Standalone component examples</h1>
         <hr />
         <p>Examples below use CSS built with single pattern included with base styles instead of the whole Vanilla framework CSS file.</p>
       </div>
     </div>
-    <div class="row">
+    <div class="row--4-cols-medium">
       <div class="col-3">
         <h2>Base elements</h2>
         <nav aria-label="Documentation: base elements">

--- a/templates/docs/examples/standalone.html
+++ b/templates/docs/examples/standalone.html
@@ -8,14 +8,14 @@
 
 {% block body %}
 <main id="main-content" class="p-strip">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-12">
         <h1>Standalone component examples</h1>
         <hr />
         <p>Examples below use CSS built with single pattern included with base styles instead of the whole Vanilla framework CSS file.</p>
       </div>
     </div>
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-3">
         <h2>Base elements</h2>
         <nav aria-label="Documentation: base elements">

--- a/templates/docs/examples/templates/maas-docs-grid.html
+++ b/templates/docs/examples/templates/maas-docs-grid.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 <header id="navigation" class="p-navigation is-dark">
-  <div class="p-navigation__row row">
+  <div class="p-navigation__row row--4-cols-medium">
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a href="#" class="p-navigation__item">
@@ -43,7 +43,7 @@
 </header>
 
 <section id="search-docs" class="p-strip--highlighted is-shallow">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <form class="p-search-box u-no-margin--bottom">
       <input aria-label="search" type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="" autocomplete="on">
       <button type="reset" class="p-search-box__reset" name="close"><i class="p-icon--close">Close</i></button>
@@ -54,7 +54,7 @@
 </section>
 
 <div class="p-strip is-shallow">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <aside class="col-3">
       <nav class="p-side-navigation" id="drawer" aria-label="Example side">
         <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
@@ -320,7 +320,7 @@
 </div>
 
 <footer class="p-strip">
-  <nav class="row" aria-label="Footer">
+  <nav class="row--4-cols-medium" aria-label="Footer">
     <div class="has-cookie">
       <p>© 2020 Canonical Ltd. <a href="#">Ubuntu</a> and <a href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>
       <ul class="p-inline-list--middot">

--- a/templates/docs/examples/templates/maas-docs-grid.html
+++ b/templates/docs/examples/templates/maas-docs-grid.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 <header id="navigation" class="p-navigation is-dark">
-  <div class="p-navigation__row row--4-cols-medium">
+  <div class="p-navigation__row p-row">
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a href="#" class="p-navigation__item">
@@ -43,7 +43,7 @@
 </header>
 
 <section id="search-docs" class="p-strip--highlighted is-shallow">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <form class="p-search-box u-no-margin--bottom">
       <input aria-label="search" type="search" class="p-search-box__input" name="q" placeholder="Search documentation" required="" autocomplete="on">
       <button type="reset" class="p-search-box__reset" name="close"><i class="p-icon--close">Close</i></button>
@@ -54,7 +54,7 @@
 </section>
 
 <div class="p-strip is-shallow">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <aside class="col-3">
       <nav class="p-side-navigation" id="drawer" aria-label="Example side">
         <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
@@ -320,7 +320,7 @@
 </div>
 
 <footer class="p-strip">
-  <nav class="row--4-cols-medium" aria-label="Footer">
+  <nav class="p-row" aria-label="Footer">
     <div class="has-cookie">
       <p>© 2020 Canonical Ltd. <a href="#">Ubuntu</a> and <a href="#">Canonical</a> are registered trademarks of Canonical Ltd.</p>
       <ul class="p-inline-list--middot">

--- a/templates/docs/examples/templates/maas-layout.html
+++ b/templates/docs/examples/templates/maas-layout.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <header id="navigation" class="p-navigation">
-  <div class="row p-navigation__row">
+  <div class="row--4-cols-medium p-navigation__row">
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
@@ -46,7 +46,7 @@
   </div>
 </header>
 <div class="p-strip--highlighted is-shallow">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-8">
       <h1 class="p-heading--3">Machines</h1>
     </div>
@@ -76,7 +76,7 @@
 </div>
 <div class="p-strip is-shallow">
   <nav class="p-tabs" aria-label="Example tabs">
-    <div class="row">
+    <div class="row--4-cols-medium">
       <ul class="p-tabs__list" role="tablist">
         <li class="p-tabs__item" role="presentation">
           <a href="#section1" class="p-tabs__link" tabindex="0" aria-controls="section1" aria-selected="true">Section
@@ -91,7 +91,7 @@
       </ul>
     </div>
   </nav>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-3">
       <div class="">
         <h4 class="u-sv-1">Filter by</h4>
@@ -207,7 +207,7 @@
 </div>
 <hr />
 <footer class="p-strip">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <p>© 2017 Company name and logo are registered trademarks of Company Ltd.</p>
     <nav aria-label="Example footer">
       <ul class="p-inline-list--middot">

--- a/templates/docs/examples/templates/maas-layout.html
+++ b/templates/docs/examples/templates/maas-layout.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <header id="navigation" class="p-navigation">
-  <div class="row--4-cols-medium p-navigation__row">
+  <div class="p-row p-navigation__row">
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__item" href="#">
@@ -46,7 +46,7 @@
   </div>
 </header>
 <div class="p-strip--highlighted is-shallow">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-8">
       <h1 class="p-heading--3">Machines</h1>
     </div>
@@ -76,7 +76,7 @@
 </div>
 <div class="p-strip is-shallow">
   <nav class="p-tabs" aria-label="Example tabs">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <ul class="p-tabs__list" role="tablist">
         <li class="p-tabs__item" role="presentation">
           <a href="#section1" class="p-tabs__link" tabindex="0" aria-controls="section1" aria-selected="true">Section
@@ -91,7 +91,7 @@
       </ul>
     </div>
   </nav>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-3">
       <div class="">
         <h4 class="u-sv-1">Filter by</h4>
@@ -207,7 +207,7 @@
 </div>
 <hr />
 <footer class="p-strip">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <p>© 2017 Company name and logo are registered trademarks of Company Ltd.</p>
     <nav aria-label="Example footer">
       <ul class="p-inline-list--middot">

--- a/templates/docs/examples/templates/responsive.html
+++ b/templates/docs/examples/templates/responsive.html
@@ -22,7 +22,7 @@
     <h4>Grid</h4>
   </div>
   <div class="grid-demo">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-1 col-medium-1 col-small-1">
       </div>
       <div class="col-1 col-medium-1 col-small-1">
@@ -52,7 +52,7 @@
 </div>
 
 <div class="p-strip is-shallow">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-6 col-medium-2">
       <h4>Hide utilities</h4>
       <p><code>u-hide--small</code>: <span class="u-hide--small">hidden when grid is 4 cols</span></p>

--- a/templates/docs/examples/templates/responsive.html
+++ b/templates/docs/examples/templates/responsive.html
@@ -22,7 +22,7 @@
     <h4>Grid</h4>
   </div>
   <div class="grid-demo">
-    <div class="row">
+    <div class="row--4-cols-medium">
       <div class="col-1 col-medium-1 col-small-1">
       </div>
       <div class="col-1 col-medium-1 col-small-1">
@@ -52,14 +52,14 @@
 </div>
 
 <div class="p-strip is-shallow">
-  <div class="row">
-    <div class="col-6 col-medium-3">
+  <div class="row--4-cols-medium">
+    <div class="col-6 col-medium-2">
       <h4>Hide utilities</h4>
       <p><code>u-hide--small</code>: <span class="u-hide--small">hidden when grid is 4 cols</span></p>
       <p><code>u-hide--medium</code>: <span class="u-hide--medium">hidden when grid is 6 cols</span></p>
       <p><code>u-hide--large</code>: <span class="u-hide--large">hidden when grid is 12 cols</span></p>
     </div>
-    <div class="col-6 col-medium-3">
+    <div class="col-6 col-medium-2">
       <h4>Show utilities</h4>
       <p><code>u-show--small</code>: <span class="u-hide u-show--small">visible when grid is 4 cols</span></p>
       <p><code>u-show--medium</code>: <span class="u-hide u-show--medium">visible when grid is 6 cols</span></p>

--- a/templates/docs/examples/templates/snapcraft-publicise.html
+++ b/templates/docs/examples/templates/snapcraft-publicise.html
@@ -149,7 +149,7 @@
   </section>
 
   <div class="p-strip is-shallow">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-3">
         <nav class="p-side-navigation" aria-label="Example side navigation">
           <ul class="p-side-navigation__list">
@@ -168,10 +168,10 @@
 
       <div class="col-9">
 
-        <div class="row--4-cols-medium">
+        <div class="p-row">
           <h4>Promote your snap using Snap Store badges</h4>
         </div>
-        <div class="row--4-cols-medium">
+        <div class="p-row">
           <div class="col-2">
             <label for="select-language">Language:</label>
           </div>
@@ -194,16 +194,16 @@
           </div>
         </div>
 
-        <div class="row--4-cols-medium">
+        <div class="p-row">
           <hr />
         </div>
 
         <div id="en_content" class="js-language-content">
-          <div class="row--4-cols-medium">
+          <div class="p-row">
             <div class="col-2">
             </div>
             <div class="col-7">
-              <div class="row--4-cols-medium">
+              <div class="p-row">
                 <div class="col-5">
                   <p class="snapcraft-publicise__images">
 
@@ -216,7 +216,7 @@
             </div>
           </div>
 
-          <div class="row--4-cols-medium">
+          <div class="p-row">
             <div class="col-2">
               <label>HTML:</label>
             </div>
@@ -227,7 +227,7 @@
             </div>
           </div>
 
-          <div class="row--4-cols-medium">
+          <div class="p-row">
             <div class="col-2">
               <label>Markdown:</label>
             </div>
@@ -236,15 +236,15 @@
             </div>
           </div>
 
-          <div class="row--4-cols-medium">
+          <div class="p-row">
             <hr />
           </div>
 
-          <div class="row--4-cols-medium">
+          <div class="p-row">
             <div class="col-2">
             </div>
             <div class="col-7">
-              <div class="row--4-cols-medium">
+              <div class="p-row">
                 <div class="col-5">
                   <p class="snapcraft-publicise__images">
 
@@ -257,7 +257,7 @@
             </div>
           </div>
 
-          <div class="row--4-cols-medium">
+          <div class="p-row">
             <div class="col-2">
               <label>HTML:</label>
             </div>
@@ -268,7 +268,7 @@
             </div>
           </div>
 
-          <div class="row--4-cols-medium">
+          <div class="p-row">
             <div class="col-2">
               <label>Markdown:</label>
             </div>
@@ -278,11 +278,11 @@
           </div>
         </div>
 
-        <div class="row--4-cols-medium">
+        <div class="p-row">
           <hr />
         </div>
 
-        <div class="row--4-cols-medium">
+        <div class="p-row">
           <div class="col-2">
             Download all:
           </div>
@@ -300,7 +300,7 @@
 </div>
 
 <footer class="p-strip--highlighted p-sticky-footer" id="footer">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-9">
       <p>
         <a class="p-link--soft" href="#">Back to top<i class="p-icon--top"></i></a>

--- a/templates/docs/examples/templates/snapcraft-publicise.html
+++ b/templates/docs/examples/templates/snapcraft-publicise.html
@@ -149,7 +149,7 @@
   </section>
 
   <div class="p-strip is-shallow">
-    <div class="row">
+    <div class="row--4-cols-medium">
       <div class="col-3">
         <nav class="p-side-navigation" aria-label="Example side navigation">
           <ul class="p-side-navigation__list">
@@ -168,10 +168,10 @@
 
       <div class="col-9">
 
-        <div class="row">
+        <div class="row--4-cols-medium">
           <h4>Promote your snap using Snap Store badges</h4>
         </div>
-        <div class="row">
+        <div class="row--4-cols-medium">
           <div class="col-2">
             <label for="select-language">Language:</label>
           </div>
@@ -194,16 +194,16 @@
           </div>
         </div>
 
-        <div class="row">
+        <div class="row--4-cols-medium">
           <hr />
         </div>
 
         <div id="en_content" class="js-language-content">
-          <div class="row">
+          <div class="row--4-cols-medium">
             <div class="col-2">
             </div>
             <div class="col-7">
-              <div class="row">
+              <div class="row--4-cols-medium">
                 <div class="col-5">
                   <p class="snapcraft-publicise__images">
 
@@ -216,7 +216,7 @@
             </div>
           </div>
 
-          <div class="row">
+          <div class="row--4-cols-medium">
             <div class="col-2">
               <label>HTML:</label>
             </div>
@@ -227,7 +227,7 @@
             </div>
           </div>
 
-          <div class="row">
+          <div class="row--4-cols-medium">
             <div class="col-2">
               <label>Markdown:</label>
             </div>
@@ -236,15 +236,15 @@
             </div>
           </div>
 
-          <div class="row">
+          <div class="row--4-cols-medium">
             <hr />
           </div>
 
-          <div class="row">
+          <div class="row--4-cols-medium">
             <div class="col-2">
             </div>
             <div class="col-7">
-              <div class="row">
+              <div class="row--4-cols-medium">
                 <div class="col-5">
                   <p class="snapcraft-publicise__images">
 
@@ -257,7 +257,7 @@
             </div>
           </div>
 
-          <div class="row">
+          <div class="row--4-cols-medium">
             <div class="col-2">
               <label>HTML:</label>
             </div>
@@ -268,7 +268,7 @@
             </div>
           </div>
 
-          <div class="row">
+          <div class="row--4-cols-medium">
             <div class="col-2">
               <label>Markdown:</label>
             </div>
@@ -278,11 +278,11 @@
           </div>
         </div>
 
-        <div class="row">
+        <div class="row--4-cols-medium">
           <hr />
         </div>
 
-        <div class="row">
+        <div class="row--4-cols-medium">
           <div class="col-2">
             Download all:
           </div>
@@ -300,7 +300,7 @@
 </div>
 
 <footer class="p-strip--highlighted p-sticky-footer" id="footer">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-9">
       <p>
         <a class="p-link--soft" href="#">Back to top<i class="p-icon--top"></i></a>

--- a/templates/docs/examples/templates/tick-elements.html
+++ b/templates/docs/examples/templates/tick-elements.html
@@ -5,9 +5,9 @@
 
 <div class="p-strip">
   <div class="p-strip is-shallow u-no-padding--top">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
     </div>
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <div class="col-3">
         <form>
           <label class="p-checkbox">
@@ -90,7 +90,7 @@
     </div>
   </div>
   <div class="p-strip is-shallow u-no-padding--top">
-    <div class="row--4-cols-medium">
+    <div class="p-row">
       <hr />
       <p>In padded containers (table cells, some list items), checkboxes and labels need to align with text not wrapped in a tag. Use <code>.p-checkbox--inline</code> or <code>.p-radio--inline</code> elements to achieve that.</p>
     </div>

--- a/templates/docs/examples/templates/tick-elements.html
+++ b/templates/docs/examples/templates/tick-elements.html
@@ -5,9 +5,9 @@
 
 <div class="p-strip">
   <div class="p-strip is-shallow u-no-padding--top">
-    <div class="row">
+    <div class="row--4-cols-medium">
     </div>
-    <div class="row">
+    <div class="row--4-cols-medium">
       <div class="col-3">
         <form>
           <label class="p-checkbox">
@@ -90,7 +90,7 @@
     </div>
   </div>
   <div class="p-strip is-shallow u-no-padding--top">
-    <div class="row">
+    <div class="row--4-cols-medium">
       <hr />
       <p>In padded containers (table cells, some list items), checkboxes and labels need to align with text not wrapped in a tag. Use <code>.p-checkbox--inline</code> or <code>.p-radio--inline</code> elements to achieve that.</p>
     </div>

--- a/templates/docs/examples/templates/typographic-spacing.html
+++ b/templates/docs/examples/templates/typographic-spacing.html
@@ -7,7 +7,7 @@
     display: flex;
     justify-content: space-between;
   }
-  [class^='row'] {
+  .row, .p-row {
     max-width: 100vw;
   }
 </style>
@@ -694,13 +694,13 @@
 <hr />
 <!-- <p>Headings preceding block level element</p> -->
 <div class="p-strip--highlighted is-shallow">
-  <div class="row--4-cols-medium" style="max-width: 100%">
+  <div class="p-row" style="max-width: 100%">
     <p>Headings preceding block level element</p>
   </div>
-  <div class="row--4-cols-medium" style="max-width: 100%">
+  <div class="p-row" style="max-width: 100%">
     <hr />
   </div>
-  <div class="row--4-cols-medium" style="max-width: 100%">
+  <div class="p-row" style="max-width: 100%">
     <div class="col-2">
       <h1>H1</h1>
       <div class="p-card">
@@ -752,10 +752,10 @@
 </div>
 <!-- blog text -->
 <div class="p-strip is-shallow">
-  <div class="row--4-cols-medium" style="max-width: 100%">
+  <div class="p-row" style="max-width: 100%">
     <hr />
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.
       Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo.
       Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat
@@ -931,7 +931,7 @@
   </div>
 </div>
 <hr />
-<div class="row--4-cols-medium">
+<div class="p-row">
   <div class="col-6 p-strip is-shallow">
     <h1>
       Headings and paragraphs are siblings, p + h* rules apply
@@ -1036,7 +1036,7 @@
   </div>
 </div>
 <hr />
-<div class="row--4-cols-medium">
+<div class="p-row">
   <div class="col-6">
     <h3>List styles and spacing</h3>
     <p>This is just a line of text before unordered list:</p>
@@ -1065,7 +1065,7 @@
   </div>
 </div>
 <hr />
-<div class="row--4-cols-medium">
+<div class="p-row">
   <a target="_blank" rel="noopener noreferrer"
     href="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg">
     <img
@@ -1074,7 +1074,7 @@
   </a>
   <h3>This is a heading following an image</h3>
 </div>
-<div class="row--4-cols-medium">
+<div class="p-row">
   <div class="col-2">
     <h1>Heading</h1>
     <div class="p-strip is-dark">

--- a/templates/docs/examples/templates/typographic-spacing.html
+++ b/templates/docs/examples/templates/typographic-spacing.html
@@ -7,7 +7,7 @@
     display: flex;
     justify-content: space-between;
   }
-  .row {
+  [class^='row'] {
     max-width: 100vw;
   }
 </style>
@@ -694,13 +694,13 @@
 <hr />
 <!-- <p>Headings preceding block level element</p> -->
 <div class="p-strip--highlighted is-shallow">
-  <div class="row" style="max-width: 100%">
+  <div class="row--4-cols-medium" style="max-width: 100%">
     <p>Headings preceding block level element</p>
   </div>
-  <div class="row" style="max-width: 100%">
+  <div class="row--4-cols-medium" style="max-width: 100%">
     <hr />
   </div>
-  <div class="row" style="max-width: 100%">
+  <div class="row--4-cols-medium" style="max-width: 100%">
     <div class="col-2">
       <h1>H1</h1>
       <div class="p-card">
@@ -752,10 +752,10 @@
 </div>
 <!-- blog text -->
 <div class="p-strip is-shallow">
-  <div class="row" style="max-width: 100%">
+  <div class="row--4-cols-medium" style="max-width: 100%">
     <hr />
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id venenatis turpis, ac tincidunt neque.
       Vestibulum dapibus sollicitudin tortor vel lacinia. Etiam et purus eu mi vehicula rhoncus non sit amet justo.
       Vestibulum quam elit, rhoncus a dolor ac, scelerisque aliquam tellus. Donec eget nisl odio. Suspendisse feugiat
@@ -806,8 +806,8 @@
   </div>
 </div>
 <section class="p-strip is-bordered">
-  <div class="row u-equal-height">
-    <div class="col-9">
+  <div class="row--75-25-on-large u-equal-height">
+    <div class="col">
       <h1>Canonical’s AI and ML solutions feature…</h1>
       <p class="p-heading--2">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
       <p>Canonical’s AI solutions such as <a href="#">Kubeflow</a> on Ubuntu give you the flexibility to place
@@ -820,14 +820,14 @@
       <p><a href="#">Contact us for machine learning, deep learning and AI
           consulting&nbsp;›</a></p>
     </div>
-    <div class="col-3 u-vertically-center u-align--center u-hide--small">
+    <div class="col u-vertically-center u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="">
     </div>
   </div>
 </section>
 <section class="p-strip is-bordered">
-  <div class="row u-equal-height">
-    <div class="col-9">
+  <div class="row--75-25-on-large u-equal-height">
+    <div class="col">
       <h1>Canonical’s AI and ML solutions feature…</h1>
       <p class="p-heading--3">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
       <p>Canonical’s AI solutions such as <a href="#">Kubeflow</a> on Ubuntu give you the flexibility to place
@@ -838,14 +838,14 @@
         startups.</p>
       <button>Contact us</button>
     </div>
-    <div class="col-3 u-vertically-center u-align--center u-hide--small">
+    <div class="col u-vertically-center u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="">
     </div>
   </div>
 </section>
 <section class="p-strip is-bordered">
-  <div class="row u-equal-height">
-    <div class="col-9">
+  <div class="row--75-25-on-large u-equal-height">
+    <div class="col">
       <h1>Canonical’s AI and ML solutions feature…</h1>
       <p class="p-heading--4">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
       <p>Canonical’s AI solutions such as <a href="#">Kubeflow</a> on Ubuntu give you the flexibility to place
@@ -856,14 +856,14 @@
         startups.</p>
       <button>Contact us</button>
     </div>
-    <div class="col-3 u-vertically-center u-align--center u-hide--small">
+    <div class="col u-vertically-center u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="">
     </div>
   </div>
 </section>
 <section class="p-strip is-bordered">
-  <div class="row u-equal-height">
-    <div class="col-9">
+  <div class="row--75-25-on-large u-equal-height">
+    <div class="col">
       <h2>Canonical’s AI and ML solutions feature…</h2>
       <p class="p-heading--3">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
       <p>Canonical’s AI solutions such as <a href="#">Kubeflow</a> on Ubuntu give you the flexibility to place
@@ -874,14 +874,14 @@
         startups.</p>
       <button>Contact us</button>
     </div>
-    <div class="col-3 u-vertically-center u-align--center u-hide--small">
+    <div class="col u-vertically-center u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="">
     </div>
   </div>
 </section>
 <section class="p-strip is-bordered">
-  <div class="row u-equal-height">
-    <div class="col-9">
+  <div class="row--75-25-on-large u-equal-height">
+    <div class="col">
       <h2>Canonical’s AI and ML solutions feature…</h2>
       <p class="p-heading--4">Architectural freedom. Fully automated operations. Accelerated Deep Learning</p>
       <p>Canonical’s AI solutions such as <a href="#">Kubeflow</a> on Ubuntu give you the flexibility to place
@@ -892,7 +892,7 @@
         startups.</p>
       <button>Contact us</button>
     </div>
-    <div class="col-3 u-vertically-center u-align--center u-hide--small">
+    <div class="col u-vertically-center u-align--center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/7d33e0a1-AI+illustration+hero.svg" alt="">
     </div>
   </div>
@@ -931,7 +931,7 @@
   </div>
 </div>
 <hr />
-<div class="row">
+<div class="row--4-cols-medium">
   <div class="col-6 p-strip is-shallow">
     <h1>
       Headings and paragraphs are siblings, p + h* rules apply
@@ -1036,7 +1036,7 @@
   </div>
 </div>
 <hr />
-<div class="row">
+<div class="row--4-cols-medium">
   <div class="col-6">
     <h3>List styles and spacing</h3>
     <p>This is just a line of text before unordered list:</p>
@@ -1065,7 +1065,7 @@
   </div>
 </div>
 <hr />
-<div class="row">
+<div class="row--4-cols-medium">
   <a target="_blank" rel="noopener noreferrer"
     href="https://assets.ubuntu.com/v1/06153e05-screenshot-tv-homepage-wide-image-900x334.jpg">
     <img
@@ -1074,7 +1074,7 @@
   </a>
   <h3>This is a heading following an image</h3>
 </div>
-<div class="row">
+<div class="row--4-cols-medium">
   <div class="col-2">
     <h1>Heading</h1>
     <div class="p-strip is-dark">

--- a/templates/docs/examples/templates/vertical-spacing.html
+++ b/templates/docs/examples/templates/vertical-spacing.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="p-strip is-bordered is-deep">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-4">
       <h2>Guidelines</h2>
       <p>If you are contributing to Vanilla, make sure to read and follow these guidelines.</p>
@@ -25,12 +25,12 @@
   </div>
 </div>
 <section class="p-strip is-dark">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-12">
       <h2>Title</h2>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-6">
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
         magna aliqua. Ut enim ad minim veniam</p>
@@ -43,7 +43,7 @@
   </div>
 </section>
 <section class="p-strip is-bordered">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-4 p-card">
       <p class="p-card__content">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
         incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
@@ -57,7 +57,7 @@
         incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-12">
       <button class="p-button">Default button</button>
     </div>
@@ -67,7 +67,7 @@
   <div class="row p-divider">
     <div class="col-9 p-divider__block">
       <h2>Latest news from Insights</h2>
-      <div class="row--4-cols-medium">
+      <div class="p-row">
         <div class="col-3">
           <h3>Kernel Team Summary – September 13, 2017</h3>
           <p><time pubdate="" datetime="Wed, 13 Sep 2017 19:46:56 +0000">13 September 2017</time></p>
@@ -90,7 +90,7 @@
   </div>
 </section>
 <section class="p-strip">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-8">
       <h2>Manage your servers without leaving your seat</h2>
       <p>Use the Web <abbr title="User interface">UI</abbr> or the command line (<abbr

--- a/templates/docs/examples/templates/vertical-spacing.html
+++ b/templates/docs/examples/templates/vertical-spacing.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="p-strip is-bordered is-deep">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-4">
       <h2>Guidelines</h2>
       <p>If you are contributing to Vanilla, make sure to read and follow these guidelines.</p>
@@ -25,12 +25,12 @@
   </div>
 </div>
 <section class="p-strip is-dark">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-12">
       <h2>Title</h2>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-6">
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
         magna aliqua. Ut enim ad minim veniam</p>
@@ -43,7 +43,7 @@
   </div>
 </section>
 <section class="p-strip is-bordered">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-4 p-card">
       <p class="p-card__content">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
         incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
@@ -57,7 +57,7 @@
         incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam</p>
     </div>
   </div>
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-12">
       <button class="p-button">Default button</button>
     </div>
@@ -67,7 +67,7 @@
   <div class="row p-divider">
     <div class="col-9 p-divider__block">
       <h2>Latest news from Insights</h2>
-      <div class="row">
+      <div class="row--4-cols-medium">
         <div class="col-3">
           <h3>Kernel Team Summary – September 13, 2017</h3>
           <p><time pubdate="" datetime="Wed, 13 Sep 2017 19:46:56 +0000">13 September 2017</time></p>
@@ -90,7 +90,7 @@
   </div>
 </section>
 <section class="p-strip">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-8">
       <h2>Manage your servers without leaving your seat</h2>
       <p>Use the Web <abbr title="User interface">UI</abbr> or the command line (<abbr

--- a/templates/docs/examples/utilities/align-by-baseline.html
+++ b/templates/docs/examples/utilities/align-by-baseline.html
@@ -2,7 +2,7 @@
 {% block title %}Align paragraph, small, extra small text by baseline{% endblock %}
 
 {% block content %}
-<div class="row">
+<div class="row--4-cols-medium">
   <div class="col-2">
     <p>paragraph</p>
   </div>

--- a/templates/docs/examples/utilities/align-by-baseline.html
+++ b/templates/docs/examples/utilities/align-by-baseline.html
@@ -2,7 +2,7 @@
 {% block title %}Align paragraph, small, extra small text by baseline{% endblock %}
 
 {% block content %}
-<div class="row--4-cols-medium">
+<div class="p-row">
   <div class="col-2">
     <p>paragraph</p>
   </div>

--- a/templates/docs/examples/utilities/fixed-width-container-nesting.html
+++ b/templates/docs/examples/utilities/fixed-width-container-nesting.html
@@ -9,14 +9,14 @@
 </div>
 
 <div class="u-fixed-width">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-12">
       <code>row</code>  nested in <code>u-fixed-width</code> container should not add additional padding.
     </div>
   </div>
 </div>
 
-<div class="row">
+<div class="row--4-cols-medium">
   <div class="col-12">
       <div class="u-fixed-width">
         <code>u-fixed-width</code> container nested in <code>row</code> should not add additional padding.

--- a/templates/docs/examples/utilities/fixed-width-container-nesting.html
+++ b/templates/docs/examples/utilities/fixed-width-container-nesting.html
@@ -9,14 +9,14 @@
 </div>
 
 <div class="u-fixed-width">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-12">
       <code>row</code>  nested in <code>u-fixed-width</code> container should not add additional padding.
     </div>
   </div>
 </div>
 
-<div class="row--4-cols-medium">
+<div class="p-row">
   <div class="col-12">
       <div class="u-fixed-width">
         <code>u-fixed-width</code> container nested in <code>row</code> should not add additional padding.

--- a/templates/docs/examples/utilities/image-position/bottom-left.html
+++ b/templates/docs/examples/utilities/image-position/bottom-left.html
@@ -3,11 +3,11 @@
 
 {% block content %}
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
-  <div class="row">
-    <div class="col-6">
+  <div class="row--50-50-on-large">
+    <div class="col">
       <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="" class="u-image-position--bottom u-image-position--left" />
     </div>
-    <div class="col-6">
+    <div class="col">
       <h2>Fast, secure and simple, Ubuntu powers millions of PCs worldwide</h2>
       <p>Download the latest version of Ubuntu, for desktop PCs and laptops.</p>
     </div>

--- a/templates/docs/examples/utilities/image-position/bottom-right.html
+++ b/templates/docs/examples/utilities/image-position/bottom-right.html
@@ -3,12 +3,12 @@
 
 {% block content %}
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
-  <div class="row">
-    <div class="col-6">
+  <div class="row--50-50-on-large">
+    <div class="col">
       <h2>Fast, secure and simple, Ubuntu powers millions of PCs worldwide</h2>
       <p>Download the latest version of Ubuntu, for desktop PCs and laptops.</p>
     </div>
-    <div class="col-6">
+    <div class="col">
       <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="" class="u-image-position--bottom u-image-position--right" />
     </div>
   </div>

--- a/templates/docs/examples/utilities/image-position/bottom.html
+++ b/templates/docs/examples/utilities/image-position/bottom.html
@@ -3,12 +3,12 @@
 
 {% block content %}
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
-  <div class="row">
-    <div class="col-6">
+  <div class="row--50-50-on-large">
+    <div class="col">
       <h2>Fast, secure and simple, Ubuntu powers millions of PCs worldwide</h2>
       <p>Download the latest version of Ubuntu, for desktop PCs and laptops.</p>
     </div>
-    <div class="col-6">
+    <div class="col">
       <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="" class="u-image-position--bottom" />
     </div>
   </div>

--- a/templates/docs/examples/utilities/image-position/left.html
+++ b/templates/docs/examples/utilities/image-position/left.html
@@ -3,11 +3,11 @@
 
 {% block content %}
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
-  <div class="row">
-    <div class="col-6">
+  <div class="row--50-50-on-large">
+    <div class="col">
       <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="" class="u-image-position--left" />
     </div>
-    <div class="col-6">
+    <div class="col">
       <h2>Fast, secure and simple, Ubuntu powers millions of PCs worldwide</h2>
       <p>Download the latest version of Ubuntu, for desktop PCs and laptops.</p>
     </div>

--- a/templates/docs/examples/utilities/image-position/right.html
+++ b/templates/docs/examples/utilities/image-position/right.html
@@ -3,12 +3,12 @@
 
 {% block content %}
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
-  <div class="row">
-    <div class="col-6">
+  <div class="row--50-50-on-large">
+    <div class="col">
       <h2>Fast, secure and simple, Ubuntu powers millions of PCs worldwide</h2>
       <p>Download the latest version of Ubuntu, for desktop PCs and laptops.</p>
     </div>
-    <div class="col-6">
+    <div class="col">
       <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="" class="u-image-position--right" />
     </div>
   </div>

--- a/templates/docs/examples/utilities/image-position/top-left.html
+++ b/templates/docs/examples/utilities/image-position/top-left.html
@@ -3,11 +3,11 @@
 
 {% block content %}
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
-  <div class="row">
-    <div class="col-6">
+  <div class="row--50-50-on-large">
+    <div class="col">
       <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="" class="u-image-position--top u-image-position--left" />
     </div>
-    <div class="col-6">
+    <div class="col">
       <h2>Fast, secure and simple, Ubuntu powers millions of PCs worldwide</h2>
       <p>Download the latest version of Ubuntu, for desktop PCs and laptops.</p>
     </div>

--- a/templates/docs/examples/utilities/image-position/top-right.html
+++ b/templates/docs/examples/utilities/image-position/top-right.html
@@ -3,12 +3,12 @@
 
 {% block content %}
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
-  <div class="row">
-    <div class="col-6">
+  <div class="row--50-50-on-large">
+    <div class="col">
       <h2>Fast, secure and simple, Ubuntu powers millions of PCs worldwide</h2>
       <p>Download the latest version of Ubuntu, for desktop PCs and laptops.</p>
     </div>
-    <div class="col-6">
+    <div class="col">
       <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="" class="u-image-position--top u-image-position--right" />
     </div>
   </div>

--- a/templates/docs/examples/utilities/image-position/top.html
+++ b/templates/docs/examples/utilities/image-position/top.html
@@ -3,12 +3,12 @@
 
 {% block content %}
 <section class="p-strip u-image-position" style="border: 1px solid #cdcdcd;">
-  <div class="row">
-    <div class="col-6">
+  <div class="row--50-50-on-large">
+    <div class="col">
       <h2>Fast, secure and simple, Ubuntu powers millions of PCs worldwide</h2>
       <p>Download the latest version of Ubuntu, for desktop PCs and laptops.</p>
     </div>
-    <div class="col-6">
+    <div class="col">
       <img src="https://assets.ubuntu.com/v1/c6504e94-Dell_XPS_Laptop_Front-Desktop.png?h=200" alt="" class="u-image-position--top" />
     </div>
   </div>

--- a/templates/docs/layouts/brochure.html
+++ b/templates/docs/layouts/brochure.html
@@ -44,7 +44,7 @@
 </section>
 
 <section class="p-section">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <hr class="p-rule">
   </div>
   <div class="row--25-75">
@@ -76,7 +76,7 @@
 </section>
 
 <section class="p-section">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <hr class="p-rule">
   </div>
   <div class="row--25-75">
@@ -105,7 +105,7 @@
 </section>
 
 <section class="p-section">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <hr class="p-rule">
   </div>
   <div class="row--25-75">
@@ -123,7 +123,7 @@
 </section>
 
 <section class="p-section">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <hr class="p-rule">
   </div>
   <div class="row--25-75">

--- a/templates/docs/layouts/brochure.html
+++ b/templates/docs/layouts/brochure.html
@@ -44,7 +44,7 @@
 </section>
 
 <section class="p-section">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <hr class="p-rule">
   </div>
   <div class="row--25-75">
@@ -76,7 +76,7 @@
 </section>
 
 <section class="p-section">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <hr class="p-rule">
   </div>
   <div class="row--25-75">
@@ -105,7 +105,7 @@
 </section>
 
 <section class="p-section">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <hr class="p-rule">
   </div>
   <div class="row--25-75">
@@ -123,7 +123,7 @@
 </section>
 
 <section class="p-section">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <hr class="p-rule">
   </div>
   <div class="row--25-75">

--- a/templates/docs/patterns/grid/index.md
+++ b/templates/docs/patterns/grid/index.md
@@ -6,7 +6,10 @@ context:
 
 ## Structure
 
-Vanilla has a responsive grid with the following columns and gutters:
+### Default grid
+
+The default grid uses the `.p-row` class. There are a multiple of 4 columns on every breakpoint.
+It has the following columns and gutters:
 
 <table>
   <thead>
@@ -25,13 +28,10 @@ Vanilla has a responsive grid with the following columns and gutters:
       <td>1.0rem</td>
     </tr>
     <tr>
-      <td rowspan="2"><code>$breakpoint-small</code> - <code>$breakpoint-large</code></td>
-      <td>6 (using <code>.row</code>)</td>
-      <td rowspan="2">2.0rem</td>
-      <td rowspan="2">1.5rem</td>
-    </tr>
-    <tr>
-      <td>4 (using <code>.row--4-cols-medium</code> - see <a href="#4-column-grid-on-medium-screens">docs</a>).</td>
+      <td><code>$breakpoint-small</code> - <code>$breakpoint-large</code></td>
+      <td>4</td>
+      <td>2.0rem</td>
+      <td>1.5rem</td>
     </tr>
     <tr>
       <td>Greater than <code>$breakpoint-large</code></td>
@@ -42,9 +42,60 @@ Vanilla has a responsive grid with the following columns and gutters:
   </tbody>
 </table>
 
-<br>
+<div class="embedded-example"><a href="/docs/examples/patterns/grid/default/" class="js-example">
+    View example of the default grid
+</a></div>
 
-- The page structure must be laid out using rows (`.row`)
+### Legacy grid
+
+<div class="p-notification--caution">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">Deprecated</h5>
+    <span class="p-notification__message">The legacy grid has been deprecated. It will be removed in v5. Use the <a href="#default-grid">default grid</a> instead.</span>
+  </div>
+</div>
+
+The legacy grid uses the `.row` class. It behaves nearly the same as the [default grid](#default-grid),
+but it has 6 columns on medium screens instead of 4. It has the following columns and gutters:
+
+<table>
+  <thead>
+    <tr>
+      <th style="width: 50ch">Screen size (px)</th>
+      <th>Columns</th>
+      <th>Grid gap (gutters)</th>
+      <th>Outer margins</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Less than <code>$breakpoint-small</code></td>
+      <td>4</td>
+      <td>1.5rem</td>
+      <td>1.0rem</td>
+    </tr>
+    <tr>
+      <td><code>$breakpoint-small</code> - <code>$breakpoint-large</code></td>
+      <td>6</td>
+      <td>2.0rem</td>
+      <td>1.5rem</td>
+    </tr>
+    <tr>
+      <td>Greater than <code>$breakpoint-large</code></td>
+      <td>12</td>
+      <td>2.0rem</td>
+      <td>1.5rem</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="embedded-example"><a href="/docs/examples/patterns/grid/legacy/" class="js-example">
+    View example of the legacy grid
+</a></div>
+
+### Guidelines
+
+- The page structure must be laid out using rows (`.p-row`)
 - All content must be within columns (`.col-*`)
 - Only columns should be direct children of a row
 
@@ -52,32 +103,6 @@ Layouts can be created combining rows with different number of columns to an ide
 column containing text should span a minimum of 3 columns.
 
 Read also: [Breakpoints](/docs/settings/breakpoint-settings)
-
-<div class="embedded-example"><a href="/docs/examples/patterns/grid/default/" class="js-example">
-    View example of the default grid
-</a></div>
-
-## 4-column grid on medium screens
-
-<div class="p-notification--positive">
-  <div class="p-notification__content">
-    <h3 class="p-notification__title">New</h3>
-    <p class="p-notification__message">
-      Vanilla is moving towards a layout where each breakpoint has a multiple of 4 columns.<br>
-      The 6 column grid on medium screens is deprecated and should be replaced with the 4 column grid.<br>
-      The default <code>.row</code> class has 6 columns on medium screens, but this will be changed to 4 columns in v5.
-    </p>
-  </div>
-</div>
-
-To use a multiple of 4 columns on every breakpoint, use the `.row--4-col` class at every level of grid nesting. The same
-`.col-*` classes can be used as in the default grid.
-
-`.row--4-cols-medium` has the same grid behaviour as `.row` but with 4 columns on the medium breakpoint instead of 6.
-
-<div class="embedded-example"><a href="/docs/examples/patterns/grid/4-columns-medium-responsive" class="js-example">
-    View example of the 4-column grid
-</a></div>
 
 ## Common patterns
 
@@ -109,7 +134,7 @@ columns in a 50% container, etc). Specifying more columns than are available lea
     <h5 class="p-notification__title">Nesting</h5>
     <p class="p-notification__message">
       These common patterns are meant for top level rows only and are <strong>not intended to be nested</strong>. You should not nest <code>row--50-50</code> inside another column.
-      For nested rows, use the standard <code>.row--4-cols-medium</code> class, as described in <a href="#nested-columns">section about nested columns</a> later on this page.</p>
+      For nested rows, use the standard <code>.p-row</code> class, as described in <a href="#nested-columns">section about nested columns</a> later on this page.</p>
   </div>
 </div>
 
@@ -208,7 +233,7 @@ columns on medium screen, and stacking all 4 columns on top of each other on sma
 ## Fixed width containers
 
 If you only want to constrain content so it matches the grid's fixed width, you can use the utility `.u-fixed-width`. It
-behaves as a grid `.row--4-cols-medium` with a single 12 column container inside:
+behaves as a grid `.p-row` with a single 12 column container inside:
 
 <div class="embedded-example"><a href="/docs/examples/utilities/fixed-width-container/" class="js-example">
     View example of a fixed width container
@@ -216,10 +241,10 @@ behaves as a grid `.row--4-cols-medium` with a single 12 column container inside
 
 ## Nested columns
 
-Columns can be nested infinitely by adding `.row--4-cols-medium` classes within columns. When nesting, remember to:
+Columns can be nested infinitely by adding `.p-row` classes within columns. When nesting, remember to:
 
 - keep track of the context (available columns), which is equal to the number of columns spanned by the parent element.
-- Ensure `.col-*` classes are direct descendants of `.row--4-cols-medium` classes. Failing to do so will result in a
+- Ensure `.col-*` classes are direct descendants of `.p-row` classes. Failing to do so will result in a
   broken layout.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/grid/4-columns-medium-nested-responsive/" class="js-example">

--- a/templates/docs/patterns/grid/index.md
+++ b/templates/docs/patterns/grid/index.md
@@ -276,7 +276,7 @@ and importing instructions.
 You can use grid in React by installing our react-component library and importing `Row` and `Col` components.
 
 [See the documentation for our React
-`Row` component](https://canonical.github.io/react-components/?path=/docs/row--default-story#row)
+`Row` component](https://canonical.github.io/react-components/?path=/docs/components-row--docs)
 
 [See the documentation for our React
-`Col` component](https://canonical.github.io/react-components/?path=/docs/col--default-story#col)
+`Col` component](https://canonical.github.io/react-components/?path=/docs/components-col--docs)

--- a/templates/docs/patterns/grid/index.md
+++ b/templates/docs/patterns/grid/index.md
@@ -31,7 +31,7 @@ Vanilla has a responsive grid with the following columns and gutters:
       <td rowspan="2">1.5rem</td>
     </tr>
     <tr>
-      <td>4 (using <code>.row--4-cols</code> - see <a href="#4-column-grid-on-medium-screens">docs</a>).</td>
+      <td>4 (using <code>.row--4-cols-medium</code> - see <a href="#4-column-grid-on-medium-screens">docs</a>).</td>
     </tr>
     <tr>
       <td>Greater than <code>$breakpoint-large</code></td>
@@ -48,7 +48,8 @@ Vanilla has a responsive grid with the following columns and gutters:
 - All content must be within columns (`.col-*`)
 - Only columns should be direct children of a row
 
-Layouts can be created combining rows with different number of columns to an ideal maximum of 4 columns per row. Each column containing text should span a minimum of 3 columns.
+Layouts can be created combining rows with different number of columns to an ideal maximum of 4 columns per row. Each
+column containing text should span a minimum of 3 columns.
 
 Read also: [Breakpoints](/docs/settings/breakpoint-settings)
 
@@ -58,10 +59,21 @@ Read also: [Breakpoints](/docs/settings/breakpoint-settings)
 
 ## 4-column grid on medium screens
 
-Vanilla is moving towards a layout where each breakpoint has a multiple of 4 columns. This allows for more consistency in layouts and easier design decisions.
-Currently, `.row` has 6 columns on medium screens, but this will be changed to 4 columns in the future.
-To use a multiple of 4 columns on every breakpoint, use the `.row--4-col` class at every level of grid nesting. The same `.col-*` classes can be used as in the default grid.
-`.row--4-col` has the same grid behaviour as `.row` but with 4 columns on the medium breakpoint instead of 6.
+<div class="p-notification--positive">
+  <div class="p-notification__content">
+    <h3 class="p-notification__title">New</h3>
+    <p class="p-notification__message">
+      Vanilla is moving towards a layout where each breakpoint has a multiple of 4 columns.<br>
+      The 6 column grid on medium screens is deprecated and should be replaced with the 4 column grid.<br>
+      The default <code>.row</code> class has 6 columns on medium screens, but this will be changed to 4 columns in v5.
+    </p>
+  </div>
+</div>
+
+To use a multiple of 4 columns on every breakpoint, use the `.row--4-col` class at every level of grid nesting. The same
+`.col-*` classes can be used as in the default grid.
+
+`.row--4-cols-medium` has the same grid behaviour as `.row` but with 4 columns on the medium breakpoint instead of 6.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/grid/4-columns-medium-responsive" class="js-example">
     View example of the 4-column grid
@@ -69,9 +81,14 @@ To use a multiple of 4 columns on every breakpoint, use the `.row--4-col` class 
 
 ## Common patterns
 
-On top of the regular row and column classes, we provide shortcut classes to help you build [often used layouts](/docs/layouts/brochure). Instead of specifying columns at each breakpoint, use one of these classes on the grid container, and the child elements will be arranged automatically as long as they have the `col` class.
+On top of the regular row and column classes, we provide shortcut classes to help you
+build [often used layouts](/docs/layouts/brochure). Instead of specifying columns at each breakpoint, use one of these
+classes on the grid container, and the child elements will be arranged automatically as long as they have the `col`
+class.
 
-N.B.: the shortcut classes are not nestable. If you need further subdivision inside a shortcut class, please use the regular grid classes. Take care to specify a number of columns that is available (e.g. 3 columns in a 25% container, 6 columns in a 50% container, etc). Specifying more columns than are available leads to misalignemnts.
+N.B.: the shortcut classes are not nestable. If you need further subdivision inside a shortcut class, please use the
+regular grid classes. Take care to specify a number of columns that is available (e.g. 3 columns in a 25% container, 6
+columns in a 50% container, etc). Specifying more columns than are available leads to misalignemnts.
 
 |                         | Large screens | Medium screens | Small screens   |
 | ----------------------- | ------------- | -------------- | --------------- |
@@ -92,7 +109,7 @@ N.B.: the shortcut classes are not nestable. If you need further subdivision ins
     <h5 class="p-notification__title">Nesting</h5>
     <p class="p-notification__message">
       These common patterns are meant for top level rows only and are <strong>not intended to be nested</strong>. You should not nest <code>row--50-50</code> inside another column.
-      For nested rows, use the standard <code>.row</code> class, as described in <a href="#nested-columns">section about nested columns</a> later on this page.</p>
+      For nested rows, use the standard <code>.row--4-cols-medium</code> class, as described in <a href="#nested-columns">section about nested columns</a> later on this page.</p>
   </div>
 </div>
 
@@ -107,7 +124,8 @@ N.B.: the shortcut classes are not nestable. If you need further subdivision ins
 
 ### 50/50
 
-The default variant of 50/50 split sets the layout on large and medium screens, stacking both columns on top of each other on small screens.
+The default variant of 50/50 split sets the layout on large and medium screens, stacking both columns on top of each
+other on small screens.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/grid/50-50/" class="js-example">
     View example of 50/50 grid layout
@@ -115,7 +133,8 @@ The default variant of 50/50 split sets the layout on large and medium screens, 
 
 ### 25/75
 
-The default variant of 25/75 split sets the layout on large and medium screens, stacking both columns on top of each other on small screens.
+The default variant of 25/75 split sets the layout on large and medium screens, stacking both columns on top of each
+other on small screens.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/grid/25-75/" class="js-example">
     View example of 25/75 grid layout
@@ -123,7 +142,8 @@ The default variant of 25/75 split sets the layout on large and medium screens, 
 
 ### 75/25
 
-The default variant of 75/25 split sets the layout on large and medium screens, stacking both columns on top of each other on small screens.
+The default variant of 75/25 split sets the layout on large and medium screens, stacking both columns on top of each
+other on small screens.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/grid/75-25/" class="js-example">
     View example of 75/25 grid layout
@@ -131,11 +151,16 @@ The default variant of 75/25 split sets the layout on large and medium screens, 
 
 ### Responsive 50/50, 25/75, and 75/25
 
-The default `.row--50-50`, `.row--25-75`, and `.row--75-25` splits provide the most common default layouts for all screen sizes, as described in the table above.
+The default `.row--50-50`, `.row--25-75`, and `.row--75-25` splits provide the most common default layouts for all
+screen sizes, as described in the table above.
 
-To have more direct control over the layout on different screen sizes, you can use the responsive variants of these classes: `.row--50-50-on-medium`, `.row--25-75-on-medium`, and `.row--75-25-on-medium` will only apply given layout on medium screens, while `.row--50-50-on-large`, `.row--25-75-on-large`, and `.row--75-25-on-large` will only apply given layout on large screens.
+To have more direct control over the layout on different screen sizes, you can use the responsive variants of these
+classes: `.row--50-50-on-medium`, `.row--25-75-on-medium`, and `.row--75-25-on-medium` will only apply given layout on
+medium screens, while `.row--50-50-on-large`, `.row--25-75-on-large`, and `.row--75-25-on-large` will only apply given
+layout on large screens.
 
-For example, to only have 25/75 split on large screens, you can use `.row--25-75-on-large`. This is usually useful when main large column splits further with nested grid that would require full width of the page on medium screens.
+For example, to only have 25/75 split on large screens, you can use `.row--25-75-on-large`. This is usually useful when
+main large column splits further with nested grid that would require full width of the page on medium screens.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/grid/25-75-responsive-large/" class="js-example">
     View example of 25/75 grid layout
@@ -147,7 +172,8 @@ This can also be accomplished with the 75/25 split using `.row--75-25-on-large`.
     View example of 75/25 grid layout
 </a></div>
 
-By utilising the responsive variants, you can also create mixed layouts with 50/50 splits on medium screens and 25/75 or 75/25 on large screens, without the need to nest grids.
+By utilising the responsive variants, you can also create mixed layouts with 50/50 splits on medium screens and 25/75 or
+75/25 on large screens, without the need to nest grids.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/grid/25-75-mixed-responsive/" class="js-example">
     View example of 25/75 mixed with 50/50 grid layout
@@ -157,11 +183,14 @@ By utilising the responsive variants, you can also create mixed layouts with 50/
     View example of 75/25 mixed with 50/50 grid layout
 </a></div>
 
-<span class="p-status-label--negative">Removed</span> The `.is-split-on-medium` class has been removed in Vanilla 4.6.0 as `.row--25-75` how implements same responsive behaviour by default. If you want to only use 25/75 split on large screens, use `.row--25-75-on-large`.
+<span class="p-status-label--negative">Removed</span> The `.is-split-on-medium` class has been removed in Vanilla 4.6.0
+as `.row--25-75` how implements same responsive behaviour by default. If you want to only use 25/75 split on large
+screens, use `.row--25-75-on-large`.
 
 ### 25/25/50
 
-The row with 25/25/50 split sets this layout on large screens only, switching to 50/50 stacked on top of full width column on medium screen, and stacking all 3 columns on top of each other on small screens.
+The row with 25/25/50 split sets this layout on large screens only, switching to 50/50 stacked on top of full width
+column on medium screen, and stacking all 3 columns on top of each other on small screens.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/grid/25-25-50/" class="js-example">
     View example of 25/25/50 grid layout
@@ -169,7 +198,8 @@ The row with 25/25/50 split sets this layout on large screens only, switching to
 
 ### 25/25/25/25
 
-The row with 25/25/25/25 split sets this layout on large screens only, switching to 50/50 stacked on top of 50/50 columns on medium screen, and stacking all 4 columns on top of each other on small screens.
+The row with 25/25/25/25 split sets this layout on large screens only, switching to 50/50 stacked on top of 50/50
+columns on medium screen, and stacking all 4 columns on top of each other on small screens.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/grid/25-25-25-25/" class="js-example">
     View example of 25/25/25/25 grid layout
@@ -177,7 +207,8 @@ The row with 25/25/25/25 split sets this layout on large screens only, switching
 
 ## Fixed width containers
 
-If you only want to constrain content so it matches the grid's fixed width, you can use the utility `.u-fixed-width`. It behaves as a grid `.row` with a single 12 column container inside:
+If you only want to constrain content so it matches the grid's fixed width, you can use the utility `.u-fixed-width`. It
+behaves as a grid `.row--4-cols-medium` with a single 12 column container inside:
 
 <div class="embedded-example"><a href="/docs/examples/utilities/fixed-width-container/" class="js-example">
     View example of a fixed width container
@@ -185,12 +216,13 @@ If you only want to constrain content so it matches the grid's fixed width, you 
 
 ## Nested columns
 
-Columns can be nested infinitely by adding `.row` classes within columns. When nesting, remember to:
+Columns can be nested infinitely by adding `.row--4-cols-medium` classes within columns. When nesting, remember to:
 
 - keep track of the context (available columns), which is equal to the number of columns spanned by the parent element.
-- Ensure `.col-*` classes are direct descendants of `.row` classes. Failing to do so will result in a broken layout.
+- Ensure `.col-*` classes are direct descendants of `.row--4-cols-medium` classes. Failing to do so will result in a
+  broken layout.
 
-<div class="embedded-example"><a href="/docs/examples/patterns/grid/nested/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/grid/4-columns-medium-nested-responsive/" class="js-example">
     View example of the nested columns within the grid
 </a></div>
 
@@ -206,7 +238,11 @@ To leave gap columns, use `col-start-{breakpoint}{index}`, e.g.: `col-start-larg
     View example of the empty columns within the grid
 </a></div>
 
-Please note, specifying a value that exceeds the available number of columns will result in incorrect offsets. This happens because the grid implicitly creates additional columns to accommodate the grid-column-start property. You should always keep track of how many available columns you have, especially when nesting. In the example below, we are indicating we want a `div` to span 3 columns, and start at position 7. This requires 10 total columns inside a `div` spanning only 4.
+Please note, specifying a value that exceeds the available number of columns will result in incorrect offsets. This
+happens because the grid implicitly creates additional columns to accommodate the grid-column-start property. You should
+always keep track of how many available columns you have, especially when nesting. In the example below, we are
+indicating we want a `div` to span 3 columns, and start at position 7. This requires 10 total columns inside a `div`
+spanning only 4.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/grid/incorrect-empty-columns/" class="js-example">
 View example of the incorrect column offset within a nested grid
@@ -214,7 +250,9 @@ View example of the incorrect column offset within a nested grid
 
 ## Breaking out of the grid
 
-In some cases, there might be a good reason to break out of the constraints of a 12 column grid and allow content to bleed into the page margins. Vanilla provides a separate [fluid breakout layout](/docs/layouts/fluid-breakout) for this purpose.
+In some cases, there might be a good reason to break out of the constraints of a 12 column grid and allow content to
+bleed into the page margins. Vanilla provides a separate [fluid breakout layout](/docs/layouts/fluid-breakout) for this
+purpose.
 
 ## Import
 
@@ -224,17 +262,21 @@ To import just this component into your project, copy the snippet below and incl
 // import Vanilla and include base mixins
 // this only needs to happen once in a given project
 @import 'vanilla-framework';
+
 @include vf-base;
 
 @include vf-p-grid;
 ```
 
-For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
+For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides
+and importing instructions.
 
 ## React
 
 You can use grid in React by installing our react-component library and importing `Row` and `Col` components.
 
-[See the documentation for our React `Row` component](https://canonical.github.io/react-components/?path=/docs/row--default-story#row)
+[See the documentation for our React
+`Row` component](https://canonical.github.io/react-components/?path=/docs/row--default-story#row)
 
-[See the documentation for our React `Col` component](https://canonical.github.io/react-components/?path=/docs/col--default-story#col)
+[See the documentation for our React
+`Col` component](https://canonical.github.io/react-components/?path=/docs/col--default-story#col)

--- a/templates/docs/patterns/grid/index.md
+++ b/templates/docs/patterns/grid/index.md
@@ -25,10 +25,13 @@ Vanilla has a responsive grid with the following columns and gutters:
       <td>1.0rem</td>
     </tr>
     <tr>
-      <td><code>$breakpoint-small</code> - <code>$breakpoint-large</code></td>
-      <td>6</td>
-      <td>2.0rem</td>
-      <td>1.5rem</td>
+      <td rowspan="2"><code>$breakpoint-small</code> - <code>$breakpoint-large</code></td>
+      <td>6 (using <code>.row</code>)</td>
+      <td rowspan="2">2.0rem</td>
+      <td rowspan="2">1.5rem</td>
+    </tr>
+    <tr>
+      <td>4 (using <code>.row--4-cols</code> - see <a href="#4-column-grid-on-medium-screens">docs</a>).</td>
     </tr>
     <tr>
       <td>Greater than <code>$breakpoint-large</code></td>
@@ -51,6 +54,17 @@ Read also: [Breakpoints](/docs/settings/breakpoint-settings)
 
 <div class="embedded-example"><a href="/docs/examples/patterns/grid/default/" class="js-example">
     View example of the default grid
+</a></div>
+
+## 4-column grid on medium screens
+
+Vanilla is moving towards a layout where each breakpoint has a multiple of 4 columns. This allows for more consistency in layouts and easier design decisions.
+Currently, `.row` has 6 columns on medium screens, but this will be changed to 4 columns in the future.
+To use a multiple of 4 columns on every breakpoint, use the `.row--4-col` class at every level of grid nesting. The same `.col-*` classes can be used as in the default grid.
+`.row--4-col` has the same grid behaviour as `.row` but with 4 columns on the medium breakpoint instead of 6.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/grid/4-columns-medium-responsive" class="js-example">
+    View example of the 4-column grid
 </a></div>
 
 ## Common patterns

--- a/templates/docs/whats-new.html
+++ b/templates/docs/whats-new.html
@@ -86,7 +86,7 @@ To see what changed in Vanilla v3, see the <a href="/docs/changelog-v3">changelo
 
 <h2>Status key</h2>
 
-<div class="row--4-cols-medium">
+<div class="p-row">
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
       <span class="p-status-label--positive">New</span>

--- a/templates/docs/whats-new.html
+++ b/templates/docs/whats-new.html
@@ -86,7 +86,7 @@ To see what changed in Vanilla v3, see the <a href="/docs/changelog-v3">changelo
 
 <h2>Status key</h2>
 
-<div class="row">
+<div class="row--4-cols-medium">
   <div class="col-3 u-equal-height">
     <div class="p-card--highlighted">
       <span class="p-status-label--positive">New</span>

--- a/templates/index.html
+++ b/templates/index.html
@@ -93,17 +93,17 @@
 </div>
 
 <div id="quick-start" class="p-strip">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-12">
       <h2>Quick start</h2>
     </div>
   </div>
-  <div class="row">
-    <div class="col-6 col-medium-3">
+  <div class="row--4-cols-medium">
+    <div class="col-6 col-medium-2">
       <p>The recommended method of including Vanilla Framework in your project is via <a href="https://www.npmjs.com/package/vanilla-framework">npm</a> or <a href="https://yarnpkg.com/package/vanilla-framework">yarn</a>. You can then simply include the framework in your SCSS files and compile.</p>
       <p>For other methods, please see the <a href="/docs">advanced usage docs.</a></p>
     </div>
-    <div class="col-6 col-medium-3">
+    <div class="col-6 col-medium-2">
       <pre><code>yarn add sass vanilla-framework</code></pre>
       <pre><code><span class="token keyword">@import</span> <span class="token string">"vanilla-framework"</span><span class="token punctuation">;</span><br><span class="token keyword">@include</span> vanilla<span class="token punctuation">;</span></code></pre>
     </div>
@@ -115,8 +115,8 @@
 </div>
 
 <div class="p-strip">
-  <div class="row u-equal-height">
-    <div class="col-6 col-medium-3">
+  <div class="row--4-cols-medium u-equal-height">
+    <div class="col-6 col-medium-2">
       <h2>Guidelines</h2>
       <p>If you are <a href="https://vanillaframework.io/contribute">contributing to Vanilla</a>, make sure to read and follow these guidelines.</p>
       <ul class="p-list--divided">
@@ -128,7 +128,7 @@
         </li>
       </ul>
     </div>
-    <div class="col-6 col-medium-3 u-vertically-center u-align--center">
+    <div class="col-6 col-medium-2 u-vertically-center u-align--center">
       {{ image (
         url="https://assets.ubuntu.com/v1/af1e0f04-guidelines-illustration.svg",
         alt="",
@@ -181,12 +181,12 @@
 </div>
 
 <div class="p-strip">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-4">
       <h2>Latest news from our blog</h2>
     </div>
     <div class="col-8">
-      <div id="articles" class="row">
+      <div id="articles" class="row--4-cols-medium">
         <p><i class="p-icon--spinner u-animation--spin"></i> Loading...</p>
       </div>
       <div class="u-fixed-width"><a href="https://ubuntu.com/blog/topics/design" class="p-button">View more from our blog</a></div>
@@ -277,7 +277,7 @@
 </div>
 
 <div class="p-strip">
-  <div class="row">
+  <div class="row--4-cols-medium">
     <div class="col-3">
       <h2>Contribute</h2>
       <p><a class="github-button" href="https://github.com/canonical/vanilla-framework" data-size="large" data-show-count="true" aria-label="Follow @vanilla-framework on GitHub">Follow @vanilla-framework</a></p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -93,12 +93,12 @@
 </div>
 
 <div id="quick-start" class="p-strip">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-12">
       <h2>Quick start</h2>
     </div>
   </div>
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-6 col-medium-2">
       <p>The recommended method of including Vanilla Framework in your project is via <a href="https://www.npmjs.com/package/vanilla-framework">npm</a> or <a href="https://yarnpkg.com/package/vanilla-framework">yarn</a>. You can then simply include the framework in your SCSS files and compile.</p>
       <p>For other methods, please see the <a href="/docs">advanced usage docs.</a></p>
@@ -115,7 +115,7 @@
 </div>
 
 <div class="p-strip">
-  <div class="row--4-cols-medium u-equal-height">
+  <div class="p-row u-equal-height">
     <div class="col-6 col-medium-2">
       <h2>Guidelines</h2>
       <p>If you are <a href="https://vanillaframework.io/contribute">contributing to Vanilla</a>, make sure to read and follow these guidelines.</p>
@@ -181,12 +181,12 @@
 </div>
 
 <div class="p-strip">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-4">
       <h2>Latest news from our blog</h2>
     </div>
     <div class="col-8">
-      <div id="articles" class="row--4-cols-medium">
+      <div id="articles" class="p-row">
         <p><i class="p-icon--spinner u-animation--spin"></i> Loading...</p>
       </div>
       <div class="u-fixed-width"><a href="https://ubuntu.com/blog/topics/design" class="p-button">View more from our blog</a></div>
@@ -277,7 +277,7 @@
 </div>
 
 <div class="p-strip">
-  <div class="row--4-cols-medium">
+  <div class="p-row">
     <div class="col-3">
       <h2>Contribute</h2>
       <p><a class="github-button" href="https://github.com/canonical/vanilla-framework" data-size="large" data-show-count="true" aria-label="Follow @vanilla-framework on GitHub">Follow @vanilla-framework</a></p>

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -12,7 +12,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Stylesheet size',
       benchmark: 150000,
-      threshold: 435000,
+      threshold: 445000,
       result: results['total-stylesheet-size'],
     },
     {


### PR DESCRIPTION
## Done

Implements the 4-column grid on medium, with `.row--4-cols`.

`.row--4-cols` is a grid row that shares most of the behavior of `.row`, but has 4 columns on medium screens, instead of 6.

Fixes [WD-14972](https://warthogs.atlassian.net/browse/WD-14972)

## QA

- Review all 4-column-medium examples. Be sure to verify that they look correct on all breakpoints.
  - [4 columns on medium](https://vanilla-framework-5352.demos.haus/docs/examples/patterns/grid/4-columns-medium-responsive?theme=light)
  - [4 columns on medium, mixed responsive](https://vanilla-framework-5352.demos.haus/docs/examples/patterns/grid/4-columns-medium-mixed-responsive?theme=light)
  - [4 columns on medium, with offsets](https://vanilla-framework-5352.demos.haus/docs/examples/patterns/grid/4-columns-medium-offsets-responsive?theme=light)
  - [4 columns on medium, with reordering](https://vanilla-framework-5352.demos.haus/docs/examples/patterns/grid/4-columns-medium-reordering-responsive?theme=light)
  - [4 columns on medium, with nesting](https://vanilla-framework-5352.demos.haus/docs/examples/patterns/grid/4-columns-medium-nested-responsive?theme=light)
  - [Comparison of 4-columns on medium and 6-columns on medium](https://vanilla-framework-5352.demos.haus/docs/examples/patterns/grid/4-columns-medium-6-columns-medium-comparison-responsive?theme=light)
- Review [4 col medium grid docs](https://vanilla-framework-5352.demos.haus/docs/patterns/grid#4-column-grid)
- Review [4.17.0 release notes](https://vanilla-framework-5352.demos.haus/docs/whats-new)


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
![image](https://github.com/user-attachments/assets/b21477d6-6b79-432a-adfa-3b974ab69944)


[WD-14972]: https://warthogs.atlassian.net/browse/WD-14972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ