### PR TITLE
Add Color primitive/palette Design Tokens

### DIFF
--- a/tokens/color/palette.json
+++ b/tokens/color/palette.json
@@ -271,6 +271,172 @@
           "themeable": false,
           "$value": "rgba(125, 66, 184, 1)"
         }
+      },
+      "gray": {
+        "white": {
+          "themeable": false,
+          "$value": "rgba(255, 255, 255, 1)"
+        },
+        "1": {
+          "themeable": false,
+          "$value": "rgba(247, 247, 247, 1)"
+        },
+        "2": {
+          "themeable": false,
+          "$value": "rgba(245, 245, 245, 1)"
+        },
+        "3": {
+          "themeable": false,
+          "$value": "rgba(243, 243, 243, 1)"
+        },
+        "4": {
+          "themeable": false,
+          "$value": "rgba(242, 242, 242, 1)"
+        },
+        "5": {
+          "themeable": false,
+          "$value": "rgba(236, 236, 236, 1)"
+        },
+        "6": {
+          "themeable": false,
+          "$value": "rgba(235, 235, 235, 1)"
+        },
+        "7": {
+          "themeable": false,
+          "$value": "rgba(233, 233, 233, 1)"
+        },
+        "8": {
+          "themeable": false,
+          "$value": "rgba(231, 231, 231, 1)"
+        },
+        "9": {
+          "themeable": false,
+          "$value": "rgba(229, 229, 229, 1)"
+        },
+        "10": {
+          "themeable": false,
+          "$value": "rgba(224, 224, 224, 1)"
+        },
+        "11": {
+          "themeable": false,
+          "$value": "rgba(222, 222, 222, 1)"
+        },
+        "12": {
+          "themeable": false,
+          "$value": "rgba(219, 219, 219, 1)"
+        },
+        "13": {
+          "themeable": false,
+          "$value": "rgba(218, 218, 218, 1)"
+        },
+        "14": {
+          "themeable": false,
+          "$value": "rgba(217, 217, 217, 1)"
+        },
+        "15": {
+          "themeable": false,
+          "$value": "rgba(204, 204, 204, 1)"
+        },
+        "16": {
+          "themeable": false,
+          "$value": "rgba(201, 201, 201, 1)"
+        },
+        "17": {
+          "themeable": false,
+          "$value": "rgba(194, 194, 194, 1)"
+        },
+        "18": {
+          "themeable": false,
+          "$value": "rgba(168, 168, 168, 1)"
+        },
+        "19": {
+          "themeable": false,
+          "$value": "rgba(166, 166, 166, 1)"
+        },
+        "20": {
+          "themeable": false,
+          "$value": "rgba(146, 146, 146, 1)"
+        },
+        "21": {
+          "themeable": false,
+          "$value": "rgba(112, 112, 112, 1)"
+        },
+        "22": {
+          "themeable": false,
+          "$value": "rgba(107, 107, 107, 1)"
+        },
+        "23": {
+          "themeable": false,
+          "$value": "rgba(102, 102, 102, 1)"
+        },
+        "24": {
+          "themeable": false,
+          "$value": "rgba(97, 97, 97, 1)"
+        },
+        "25": {
+          "themeable": false,
+          "$value": "rgba(92, 92, 92, 1)"
+        },
+        "26": {
+          "themeable": false,
+          "$value": "rgba(81, 81, 81, 1)"
+        },
+        "27": {
+          "themeable": false,
+          "$value": "rgba(71, 71, 71, 1)"
+        },
+        "28": {
+          "themeable": false,
+          "$value": "rgba(64, 64, 64, 1)"
+        },
+        "29": {
+          "themeable": false,
+          "$value": "rgba(61, 61, 61, 1)"
+        },
+        "30": {
+          "themeable": false,
+          "$value": "rgba(60, 60, 60, 1)"
+        },
+        "31": {
+          "themeable": false,
+          "$value": "rgba(55, 55, 55, 1)"
+        },
+        "32": {
+          "themeable": false,
+          "$value": "rgba(49, 49, 49, 1)"
+        },
+        "33": {
+          "themeable": false,
+          "$value": "rgba(47, 47, 47, 1)"
+        },
+        "34": {
+          "themeable": false,
+          "$value": "rgba(45, 45, 45, 1)"
+        },
+        "35": {
+          "themeable": false,
+          "$value": "rgba(38, 38, 38, 1)"
+        },
+        "36": {
+          "themeable": false,
+          "$value": "rgba(32, 32, 32, 1)"
+        },
+        "37": {
+          "themeable": false,
+          "$value": "rgba(17, 17, 17, 1)"
+        },
+        "38": {
+          "themeable": false,
+          "$value": "rgba(17, 17, 17, 0.85)"
+        },
+        "black": {
+          "themeable": false,
+          "$value": "rgba(0, 0, 0, 1)"
+        }
+      },
+      "transparent": {
+        "themeable": false,
+        "$value": "rgba(0, 0, 0, 0)"
       }
     }
   }


### PR DESCRIPTION
## Done

- Added color primitive/palette Design Tokens

Fixes [WD-15297](https://warthogs.atlassian.net/browse/WD-15297)

## QA

- Open [Design Tokens Sheet](https://docs.google.com/spreadsheets/d/1AY6BLFU-Cnj48ggHUnNVlWRxwWZ6Z-66s7jxJC1HLSU/edit?usp=sharing)
- Compare Design Tokens in this PR to all color palette tokens in Primitives worksheet
- Ensure there's a matching token for each row in the worksheet

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [X] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [X] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [X] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


[WD-15297]: https://warthogs.atlassian.net/browse/WD-15297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ