### PR TITLE
fix(skip-link): give the skip link a more modern styling

### DIFF
--- a/scss/_patterns_links.scss
+++ b/scss/_patterns_links.scss
@@ -34,6 +34,7 @@
   }
 
   .p-link--skip {
+    background: $colors--theme--background-alt;
     color: $colors--theme--link-default;
     display: block;
     left: -999px;
@@ -43,10 +44,10 @@
     &:focus {
       @include vf-focus-themed;
 
-      left: 0;
-      padding: $spv--x-small;
-      position: relative;
-      top: 0;
+      left: $sph--small;
+      padding: $spv--large $sph--large;
+      position: fixed;
+      top: $spv--small;
       z-index: 999999;
     }
   }


### PR DESCRIPTION
## Done

- Updated style for the "skip link" pattern - see comparison screenshots below.

Fixes #5356

## QA

- Open [demo](https://vanilla-framework-5371.demos.haus/docs/patterns/links#skip-link) for the skip link pattern
- Click inside the iframe of the example, then press SHIFT + TAB to make the skip link appear
- Check the new appearance of the skip link

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

Before:

![image](https://github.com/user-attachments/assets/7098e99f-93fb-426b-a95c-138a3da070d9)

After:

![image](https://github.com/user-attachments/assets/fb38c07e-05f9-4289-9986-f024488650c2)