### PR TITLE
Update remaining legacy components to use new theme colours.

### DIFF
--- a/scss/_layouts_full-width.scss
+++ b/scss/_layouts_full-width.scss
@@ -19,7 +19,7 @@
     }
 
     .l-full-width__sidebar {
-      background: $color-light;
+      background: $colors--theme--background-alt;
 
       // height of top navigation, as padding applied to .p-navigation__link + line-heigh of the anchor text inside
       $navigation-top-height: $spv--large * 2 + map-get($line-heights, default-text);

--- a/scss/_patterns_badge.scss
+++ b/scss/_patterns_badge.scss
@@ -3,10 +3,10 @@
 @mixin vf-p-badge {
   %vf-badge {
     @extend %x-small-text;
-    background-color: $colors--light-theme--text-default;
+    background-color: $colors--theme--text-default; // inverse the theme by using the text color
     border-radius: 1rem;
     box-sizing: content-box;
-    color: $color-x-light;
+    color: $colors--theme--background-default; // inverse the theme by using the baackground color
     margin-bottom: 0;
     max-width: 4ch;
     overflow: hidden;
@@ -19,7 +19,8 @@
   }
 
   .p-badge--negative {
-    background-color: $color-negative;
+    background-color: $colors--theme--button-negative-default;
+    color: $colors--theme--button-negative-text;
   }
 
   .p-chip,

--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -110,7 +110,7 @@ $aspect-ratios: (
   // Deprecated; will be removed in v5
   .p-image--bordered {
     border: {
-      color: $color-mid-light;
+      color: $colors--theme--border-low-contrast;
       style: solid;
       width: 1px;
     }
@@ -118,6 +118,6 @@ $aspect-ratios: (
 
   // Deprecated; will be removed in v5
   .p-image--shadowed {
-    box-shadow: 0 1px 5px 1px color.scale($color-mid-light, $alpha: -80%);
+    box-shadow: $box-shadow;
   }
 }


### PR DESCRIPTION
## Done

Updates couple remaining small components (badge, deprecated image options, deprecated full-width layout) to use new theming variables.

Fixes https://warthogs.atlassian.net/browse/WD-11862
Fixes https://warthogs.atlassian.net/browse/WD-11870
Fixes https://warthogs.atlassian.net/browse/WD-11884

## QA

- Check updated components, make sure they work well in all themes:
  - badge (https://vanilla-framework-5377.demos.haus/docs/examples/patterns/badge/colors?theme=light)
  - image (border): https://vanilla-framework-5377.demos.haus/docs/examples/patterns/image/bordered?theme=light
  - full width layout: https://vanilla-framework-5377.demos.haus/docs/examples/layouts/full-width/default?theme=light
