### PR TITLE
Add `sass` as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.17.0",
+  "version": "4.17.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"
@@ -80,5 +80,8 @@
     "stylelint-prettier": "5.0.2",
     "svgo": "3.3.2",
     "yaml": "2.5.1"
+  },
+  "peerDependencies": {
+    "sass": "^1.79.0"
   }
 }


### PR DESCRIPTION
## Done

Adds `sass` as a peer dependency. This should help flag incompatible installations of `sass`, as our [recently added usage](https://github.com/canonical/vanilla-framework/pull/5370) of `color.scale` [requires version 1.70](https://sass-lang.com/documentation/modules/color/#channel).

Fixes [MM thread](https://chat.canonical.com/canonical/pl/xq3fh15uqfriuj9bfuyfro5yde)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
