### PR TITLE
Change links for react components

### DIFF
--- a/templates/docs/base/code.md
+++ b/templates/docs/base/code.md
@@ -110,4 +110,4 @@ View example of the code snippet with a border
 
 You can use code snippet in React by installing our react-component library and importing code snippet component.
 
-[See the documentation for our React `CodeSnippet` component](https://canonical.github.io/react-components/?path=/docs/codesnippet--default-story#code-snippet)
+[See the documentation for our React `CodeSnippet` component](https://canonical.github.io/react-components/?path=/docs/components-codesnippet--docs)

--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -254,6 +254,6 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use forms in React by installing our react-component library and importing `Form` and `Input` component.
 
-[See the documentation for our React `Form` component](https://canonical.github.io/react-components/?path=/docs/form--default-story#form)
+[See the documentation for our React `Form` component](https://canonical.github.io/react-components/?path=/docs/components-form--docs)
 
-[See the documentation for our React `Input` component](https://canonical.github.io/react-components/?path=/docs/input--text-input#input)
+[See the documentation for our React `Input` component](https://canonical.github.io/react-components/?path=/docs/components-input--docs)

--- a/templates/docs/base/tables.md
+++ b/templates/docs/base/tables.md
@@ -106,6 +106,6 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use tables in React by installing our react-component library and importing `MainTable` or `ModularTable` component.
 
-[See the documentation for our React `MainTable` component](https://canonical.github.io/react-components/?path=/docs/maintable--default-story#maintable)
+[See the documentation for our React `MainTable` component](https://canonical.github.io/react-components/?path=/docs/components-maintable--docs)
 
-[See the documentation for our React `ModularTable` component](https://canonical.github.io/react-components/?path=/docs/modulartable--default-story)
+[See the documentation for our React `ModularTable` component](https://canonical.github.io/react-components/?path=/docs/components-modulartable--docs)

--- a/templates/docs/patterns/accordion/index.md
+++ b/templates/docs/patterns/accordion/index.md
@@ -64,4 +64,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use accordion in React by installing our react-component library and importing `Accordion` component.
 
-[See the documentation for our React `Accordion` component](https://canonical.github.io/react-components/?path=/docs/accordion--default-story#accordion)
+[See the documentation for our React `Accordion` component](https://canonical.github.io/react-components/?path=/docs/components-accordion--docs)

--- a/templates/docs/patterns/buttons/index.md
+++ b/templates/docs/patterns/buttons/index.md
@@ -89,7 +89,7 @@ View example of the icon button pattern
 
 In cases where a button needs to indicate that an action is occurring (e.g. saving data, processing a payment) while also preventing user interaction, the state class `is-processing` can be added to a disabled button to maintain full opacity.
 
-When replacing a label in a button with a loading icon make sure to keep the width of the button the same to avoid content moving around. The example below has a snippet of JavaScript to demo how to achieve that or you can use the [`ActionButton` React component](https://canonical.github.io/react-components/?path=/docs/actionbutton--default-story) that has this functionality built-in.
+When replacing a label in a button with a loading icon make sure to keep the width of the button the same to avoid content moving around. The example below has a snippet of JavaScript to demo how to achieve that or you can use the [`ActionButton` React component](https://canonical.github.io/react-components/?path=/docs/components-actionbutton--docs) that has this functionality built-in.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/buttons/processing/" class="js-example">
 View example of the processing button pattern
@@ -134,6 +134,6 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use buttons in React by installing our react-component library and importing `Button` or `ActionButton` component.
 
-[See the documentation for our React `Button` component](https://canonical.github.io/react-components/?path=/docs/button--base#button)
+[See the documentation for our React `Button` component](https://canonical.github.io/react-components/?path=/docs/components-button--docs)
 
-[See the documentation for our React `ActionButton` component](https://canonical.github.io/react-components/?path=/docs/actionbutton--default-story#actionbutton)
+[See the documentation for our React `ActionButton` component](https://canonical.github.io/react-components/?path=/docs/components-actionbutton--docs)

--- a/templates/docs/patterns/card/index.md
+++ b/templates/docs/patterns/card/index.md
@@ -73,4 +73,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use cards in React by installing our react-component library and importing `Card` component.
 
-[See the documentation for our React `Card` component](https://canonical.github.io/react-components/?path=/docs/card--default-story)
+[See the documentation for our React `Card` component](https://canonical.github.io/react-components/?path=/docs/components-card--docs)

--- a/templates/docs/patterns/chip/index.md
+++ b/templates/docs/patterns/chip/index.md
@@ -75,4 +75,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use chips in React by installing our react-component library and importing `Chip` component.
 
-[See the documentation for our React `Chip` component](https://canonical.github.io/react-components/?path=/docs/chip--default-story#chip)
+[See the documentation for our React `Chip` component](https://canonical.github.io/react-components/?path=/docs/components-chip--docs)

--- a/templates/docs/patterns/contextual-menu/index.md
+++ b/templates/docs/patterns/contextual-menu/index.md
@@ -75,7 +75,7 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use contextual menu in React by installing our react-component library and importing `ContextualMenu` component.
 
-[See the documentation for our React `ContextualMenu` component](https://canonical.github.io/react-components/?path=/docs/contextualmenu--default-story#contextual-menu)
+[See the documentation for our React `ContextualMenu` component](https://canonical.github.io/react-components/?path=/docs/components-contextualmenu--docs)
 
 ## Related
 

--- a/templates/docs/patterns/grid/index.md
+++ b/templates/docs/patterns/grid/index.md
@@ -221,6 +221,6 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use grid in React by installing our react-component library and importing `Row` and `Col` components.
 
-[See the documentation for our React `Row` component](https://canonical.github.io/react-components/?path=/docs/row--default-story#row)
+[See the documentation for our React `Row` component](https://canonical.github.io/react-components/?path=/docs/components-row--docs)
 
-[See the documentation for our React `Col` component](https://canonical.github.io/react-components/?path=/docs/col--default-story#col)
+[See the documentation for our React `Col` component](https://canonical.github.io/react-components/?path=/docs/components-col--docs)

--- a/templates/docs/patterns/links/index.md
+++ b/templates/docs/patterns/links/index.md
@@ -86,4 +86,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use links in React by installing our react-component library and importing `Link` component.
 
-[See the documentation for our React `Link` component](https://canonical.github.io/react-components/?path=/docs/link--default-story#link)
+[See the documentation for our React `Link` component](https://canonical.github.io/react-components/?path=/docs/components-link--docs)

--- a/templates/docs/patterns/lists/index.md
+++ b/templates/docs/patterns/lists/index.md
@@ -210,4 +210,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use lists in React by installing our react-component library and importing `List` component.
 
-[See the documentation for our React `List` component](https://canonical.github.io/react-components/?path=/docs/list--default-story#list)
+[See the documentation for our React `List` component](https://canonical.github.io/react-components/?path=/docs/components-list--docs)

--- a/templates/docs/patterns/modal/index.md
+++ b/templates/docs/patterns/modal/index.md
@@ -45,4 +45,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use modal dialogs in React by installing our react-component library and importing `Modal` component.
 
-[See the documentation for our React `Modal` component](https://canonical.github.io/react-components/?path=/docs/modal--default-story#modal)
+[See the documentation for our React `Modal` component](https://canonical.github.io/react-components/?path=/docs/components-modal--docs)

--- a/templates/docs/patterns/notification/index.md
+++ b/templates/docs/patterns/notification/index.md
@@ -117,7 +117,7 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use notifications in React by installing our react-component library and importing `Notification` component.
 
-[See the documentation for our React `Notification` component](https://canonical.github.io/react-components/?path=/docs/notification--default-story#notification)
+[See the documentation for our React `Notification` component](https://canonical.github.io/react-components/?path=/docs/components-notification--docs)
 
 ## Related components
 

--- a/templates/docs/patterns/pagination/index.md
+++ b/templates/docs/patterns/pagination/index.md
@@ -82,6 +82,6 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use pagination in React by installing our react-component library and importing `Pagination` or `ArticlePagination` component.
 
-[See the documentation for our React `Pagination` component](https://canonical.github.io/react-components/?path=/docs/pagination--default-story#pagination)
+[See the documentation for our React `Pagination` component](https://canonical.github.io/react-components/?path=/docs/components-pagination--docs)
 
-[See the documentation for our React `ArticlePagination` component](https://canonical.github.io/react-components/?path=/docs/articlepagination--default-story#articlepagination)
+[See the documentation for our React `ArticlePagination` component](https://canonical.github.io/react-components/?path=/docs/components-articlepagination--docs)

--- a/templates/docs/patterns/search-and-filter.md
+++ b/templates/docs/patterns/search-and-filter.md
@@ -84,4 +84,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use search and filter in React by installing our react-component library and importing `SearchAndFilter` component.
 
-[See the documentation for our React `SearchAndFilter` component](https://canonical.github.io/react-components/?path=/docs/search-and-filter--default-story#search-and-filter)
+[See the documentation for our React `SearchAndFilter` component](https://canonical.github.io/react-components/?path=/docs/components-searchandfilter--docs)

--- a/templates/docs/patterns/search-box/index.md
+++ b/templates/docs/patterns/search-box/index.md
@@ -61,7 +61,7 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use search box in React by installing our react-component library and importing `SearchBox` component.
 
-[See the documentation for our React `SearchBox` component](https://canonical.github.io/react-components/?path=/docs/searchbox--default-story#searchbox)
+[See the documentation for our React `SearchBox` component](https://canonical.github.io/react-components/?path=/docs/components-searchbox--docs)
 
 ## Related
 

--- a/templates/docs/patterns/slider/index.md
+++ b/templates/docs/patterns/slider/index.md
@@ -30,4 +30,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use slider in React by installing our react-component library and importing `Slider` component.
 
-[See the documentation for our React `Slider` component](https://canonical.github.io/react-components/?path=/docs/slider--default-story#slider)
+[See the documentation for our React `Slider` component](https://canonical.github.io/react-components/?path=/docs/components-slider--docs)

--- a/templates/docs/patterns/strip/index.md
+++ b/templates/docs/patterns/strip/index.md
@@ -108,4 +108,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use strip in React by installing our react-component library and importing `Strip` component.
 
-[See the documentation for our React `Strip` component](https://canonical.github.io/react-components/?path=/docs/strip--light-strip#strip)
+[See the documentation for our React `Strip` component](https://canonical.github.io/react-components/?path=/docs/components-strip--docs)

--- a/templates/docs/patterns/tabs/index.md
+++ b/templates/docs/patterns/tabs/index.md
@@ -60,4 +60,4 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use tabs in React by installing our react-component library and importing `Tab` component.
 
-[See the documentation for our React `Tab` component](https://canonical.github.io/react-components/?path=/docs/tabs--default-story#tabs)
+[See the documentation for our React `Tab` component](https://canonical.github.io/react-components/?path=/docs/components-tabs--docs)

--- a/templates/docs/patterns/tooltips/index.md
+++ b/templates/docs/patterns/tooltips/index.md
@@ -65,7 +65,7 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 You can use tooltips in React by installing our react-component library and importing `Tooltip` component.
 
-[See the documentation for our React `Tooltip` component](https://canonical.github.io/react-components/?path=/docs/tooltip--default-story)
+[See the documentation for our React `Tooltip` component](https://canonical.github.io/react-components/?path=/docs/components-tooltip--docs)
 
 ## Related
 


### PR DESCRIPTION
## Done

Fix all links to the react components storybook by a new pattern.

Fixes #5374 
Fixes [WD-15774](https://warthogs.atlassian.net/browse/WD-15774)

## QA
- Check new links

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

[WD-15774]: https://warthogs.atlassian.net/browse/WD-15774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ