### PR TITLE
Add links to react storybook for existing components

### DIFF
--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -252,8 +252,20 @@ For more information see [Customising Vanilla](/docs/customising-vanilla/) in yo
 
 ## React
 
-You can use forms in React by installing our react-component library and importing `Form` and `Input` component.
+You can use forms in React by installing our react-component library and importing `Form`, `Input`, `PasswordToggle`, `Textarea`, `CheckboxInput`, `RadioInput`, `Select` and `MultiSelect` components.
 
 [See the documentation for our React `Form` component](https://canonical.github.io/react-components/?path=/docs/components-form--docs)
 
 [See the documentation for our React `Input` component](https://canonical.github.io/react-components/?path=/docs/components-input--docs)
+
+[See the documentation for our React `PasswordToggle` component](https://canonical.github.io/react-components/?path=/docs/components-passwordtoggle--docs)
+
+[See the documentation for our React `Textarea` component](https://canonical.github.io/react-components/?path=/docs/components-textarea--docs)
+
+[See the documentation for our React `CheckboxInput` component](https://canonical.github.io/react-components/?path=/docs/components-checkboxinput--docs)
+
+[See the documentation for our React `RadioInput` component](https://canonical.github.io/react-components/?path=/docs/components-radioinput--docs)
+
+[See the documentation for our React `Select` component](https://canonical.github.io/react-components/?path=/docs/components-select--docs)
+
+[See the documentation for our React `MultiSelect` component](https://canonical.github.io/react-components/?path=/docs/components-multiselect--docs)

--- a/templates/docs/patterns/badge/index.md
+++ b/templates/docs/patterns/badge/index.md
@@ -60,3 +60,9 @@ To import just this component into your project, copy the snippet below and incl
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
+
+## React
+
+You can use badge in React by installing our react-component library and importing `Badge` component.
+
+[See the documentation for our React `Badge` component](https://canonical.github.io/react-components/?path=/docs/components-badge--docs)

--- a/templates/docs/patterns/navigation/index.md
+++ b/templates/docs/patterns/navigation/index.md
@@ -258,3 +258,9 @@ To import side navigation, copy snippet below:
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
+
+## React
+
+You can use navigation in React by installing our react-component library and importing `Navigation` component.
+
+[See the documentation for our React `Navigation` component](https://canonical.github.io/react-components/?path=/docs/components-navigation--docs)

--- a/templates/docs/patterns/status-labels/index.md
+++ b/templates/docs/patterns/status-labels/index.md
@@ -30,3 +30,9 @@ To import just this component into your project, copy the snippet below and incl
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
+
+## React
+
+You can use status labels in React by installing our react-component library and importing `StatusLabel` component.
+
+[See the documentation for our React `StatusLabel` component](https://canonical.github.io/react-components/?path=/docs/components-statuslabel--docs)

--- a/templates/docs/patterns/switch/index.md
+++ b/templates/docs/patterns/switch/index.md
@@ -24,3 +24,9 @@ To import just this component into your project, copy the snippet below and incl
 ```
 
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
+
+## React
+
+You can use switch in React by installing our react-component library and importing `Switch` component.
+
+[See the documentation for our React `Switch` component](https://canonical.github.io/react-components/?path=/docs/components-switch--docs)


### PR DESCRIPTION
## Done

I have identified several missing links to the React Storybook documentation for certain existing components, and I have added them accordingly.

## QA
Check new links for:
- Base elements/Forms (I've added a few more)
- Components/Badge
- Components/Navigation
- Components/Status labels
- Components/Switch

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).