### PR TITLE
Change the JIRA epic where new issues are synchronised

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -28,7 +28,7 @@ settings:
   sync_comments: true
 
   # (Optional) (Default: None) Parent Epic key to link the issue to
-  epic_key: "WD-189"
+  epic_key: "WD-15821"
 
   # (Optional) Dictionary mapping GitHub issue labels to Jira issue types.
   # If label on the issue is not in specified list, this issue will be created as a Bug


### PR DESCRIPTION
## Done

Changes JIRA epic where new issues are synchronised to our new "Incoming" epic (https://warthogs.atlassian.net/browse/WD-15821)

