### PR TITLE
Fix input padding alignment

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -25,6 +25,7 @@
     border: 0 solid transparent;
     border-bottom: $input-border-thickness solid $colors--theme--border-high-contrast;
     border-radius: 0;
+    border-top: $input-border-thickness solid transparent;
     color: $colors--theme--text-default;
     font-family: unquote($font-base-family);
     font-size: 1rem;

--- a/scss/_patterns_search-box.scss
+++ b/scss/_patterns_search-box.scss
@@ -34,12 +34,7 @@
       @extend %transparent-button;
     }
 
-    // Theme set on body element
     .p-search-box__input {
-      background-color: $colors--theme--background-inputs;
-      border-color: $colors--theme--border-high-contrast;
-
-      color: $colors--theme--text-default;
       flex: 1 1 100%;
       margin-bottom: 0;
       padding-right: calc(2 * (2 * $spv-nudge + map-get($line-heights, default-text)));

--- a/scss/_settings_placeholders.scss
+++ b/scss/_settings_placeholders.scss
@@ -3,8 +3,6 @@
 @import 'settings_colors';
 
 // Global placeholder settings
-$input-border-thickness: 1.5px;
-$input-vertical-padding: calc($spv-nudge - $input-border-thickness);
 $bar-thickness: 0.1875rem !default; // 3px at 16px fontsize, expressed in rems so it scales with text if the root font-size changes at a breakpoint
 $border-radius: 0; // deprecated, will be removed in future version of Vanilla
 $border: $input-border-thickness solid $colors--theme--border-default !default;

--- a/scss/_settings_placeholders.scss
+++ b/scss/_settings_placeholders.scss
@@ -4,6 +4,7 @@
 
 // Global placeholder settings
 $input-border-thickness: 1.5px;
+$input-vertical-padding: calc($spv-nudge - $input-border-thickness);
 $bar-thickness: 0.1875rem !default; // 3px at 16px fontsize, expressed in rems so it scales with text if the root font-size changes at a breakpoint
 $border-radius: 0; // deprecated, will be removed in future version of Vanilla
 $border: $input-border-thickness solid $colors--theme--border-default !default;

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -117,8 +117,11 @@ $sp-after: (
 // commonly occuring calculations available as variables
 $spv-nudge: map-get($nudges, p) !default; // top: nudge; bottom: unit - nudge; result: height = exact multiple of base unit
 $spv-nudge-compensation: $sp-unit - $spv-nudge !default;
+
+// form input spacing variables
 $input-margin-bottom: $sp-unit * 4 - $spv-nudge * 2;
-$input-vertical-padding: calc($spv-nudge - 1px);
+$input-border-thickness: 1.5px;
+$input-vertical-padding: calc($spv-nudge - $input-border-thickness);
 
 // tick element variables
 $form-tick-box-size: 1rem;


### PR DESCRIPTION
## Done

Reimplementation of #4954

Makes sure that input border width is correctly applied to top and bottom padding of inputs.

Drive-by: remove theming from search box (as it can inherit it from base inputs).

## QA

- Open [demo](https://vanilla-framework-5389.demos.haus/docs/examples/base/forms/labels?theme=light)
- Check form examples: https://vanilla-framework-5389.demos.haus/docs/examples/base/forms/combined?theme=light
- Check buttons: https://vanilla-framework-5389.demos.haus/docs/examples/patterns/buttons/combined?theme=light


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
