### PR TITLE
Fix slider margin

### DIFF
--- a/scss/_base_forms-range.scss
+++ b/scss/_base_forms-range.scss
@@ -15,7 +15,7 @@
     // stylelint-enable property-no-vendor-prefix
     background-color: $color-transparent;
     border-radius: $track-radius;
-    margin: $sp-small 0;
+    margin: ($sp-small - $track-height * 0.5) 0;
     padding: 0;
     width: 100%;
 

--- a/scss/_base_forms-range.scss
+++ b/scss/_base_forms-range.scss
@@ -15,8 +15,10 @@
     // stylelint-enable property-no-vendor-prefix
     background-color: $color-transparent;
     border-radius: $track-radius;
+    height: $track-height;
     margin: ($spv--small - $track-height * 0.5) 0;
     padding: 0;
+    vertical-align: bottom;
     width: 100%;
 
     // Chrome

--- a/scss/_base_forms-range.scss
+++ b/scss/_base_forms-range.scss
@@ -15,7 +15,7 @@
     // stylelint-enable property-no-vendor-prefix
     background-color: $color-transparent;
     border-radius: $track-radius;
-    margin: ($sp-small - $track-height * 0.5) 0;
+    margin: ($spv--small - $track-height * 0.5) 0;
     padding: 0;
     width: 100%;
 


### PR DESCRIPTION
## Done
Based on the comment of @lyubomir-popov, it seems we need to reduce the top and bottom margins by half the height of the track. 
I'm not sure if the calculations needed to be enclosed in parentheses, but I did so for better code readability.

Fixes #5391

## QA
- Please review the [updated component Slider(Range input)](https://vanilla-framework-5392.demos.haus/docs/examples/base/forms/range)

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).