### PR TITLE
Add CSS range syntax to breakpoints settings page

### DIFF
--- a/templates/docs/settings/breakpoint-settings.md
+++ b/templates/docs/settings/breakpoint-settings.md
@@ -20,7 +20,7 @@ Vanilla uses three main breakpoints for screen sizes, below you can see the sett
 ## Target small screens
 
 ```css
-@media screen and (max-width: $breakpoint-small - 1) {
+@media screen and (width < $breakpoint-small) {
   // css
 }
 ```
@@ -28,7 +28,7 @@ Vanilla uses three main breakpoints for screen sizes, below you can see the sett
 ## Target medium size screens
 
 ```css
-@media screen and (min-width: $breakpoint-small) and (max-width: $breakpoint-large - 1) {
+@media screen and ($breakpoint-small <= width < $breakpoint-large) {
   // css
 }
 ```
@@ -36,7 +36,7 @@ Vanilla uses three main breakpoints for screen sizes, below you can see the sett
 ## Target large screens
 
 ```css
-@media screen and (min-width: $breakpoint-large) {
+@media screen and ($breakpoint-large <= width) {
   //css
 }
 ```
@@ -44,7 +44,7 @@ Vanilla uses three main breakpoints for screen sizes, below you can see the sett
 ## Target extra large screens
 
 ```css
-@media screen and (min-width: $breakpoint-x-large) {
+@media screen and ($breakpoint-x-large <= width) {
   //css
 }
 ```


### PR DESCRIPTION
## Done
Updated breakpoints settings page to use new CSS range syntax, based on conversation in #5287

Fixes #5394

## QA
- Open `breakpoint-settings` page

### Check if PR is ready for release
If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

## Screenshot
![Screenshot 2024-10-22 at 10 12 33](https://github.com/user-attachments/assets/2cb4e006-17b4-4fb9-bb6b-f1969f2d3b8f)