### PR TITLE
Remove padding-bottom in cta-block

### DIFF
--- a/scss/_patterns_cta.scss
+++ b/scss/_patterns_cta.scss
@@ -16,7 +16,6 @@
     border-top: 1px solid $colors--theme--border-low-contrast;
     display: flex;
     flex-wrap: wrap;
-    padding-bottom: $spv--x-large;
     padding-top: $spv--small;
 
     &.is-borderless {


### PR DESCRIPTION
## Done

Remove padding-bottom in cta-block, based on issue #5397

Fixes #5397

## QA

- Open `CTA Block` page

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).