### PR TITLE
Adjust search and filter component height to align with standard inputs

### DIFF
--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -18,15 +18,15 @@
 
   // When the search and filter is not expanded, but is overflowing with chips, we need to
   // specify a height that matches that of a standard input element. This height is a combination
-  // of an input's line-height, its vertical padding, and a nudge.
-  $input-height: calc(map-get($line-heights, default-text) + $input-vertical-padding + $spv-nudge - $input-border-thickness);
+  // of an input's line-height, its vertical padding, and the (top transparent) border.
+  $input-height: calc(map-get($line-heights, default-text) + $input-vertical-padding + $input-vertical-padding + $input-border-thickness);
 
   .p-search-and-filter {
     border-bottom: $input-border-thickness solid $colors--theme--border-high-contrast;
     position: relative;
 
     .p-search-and-filter__search-container {
-      align-items: center;
+      align-items: flex-start;
       background-color: $colors--theme--background-inputs;
       display: flex;
       flex-wrap: wrap;
@@ -123,7 +123,7 @@
     }
 
     .p-search-and-filter__input {
-      border: 0;
+      border-bottom: 0; // only remove bottom border (replaced by component border), as the top transparent border is still needed for correct alignment
       box-shadow: none;
       flex-grow: 1;
       margin-bottom: 0;

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -47,7 +47,7 @@
       }
 
       .p-chip {
-        margin-bottom: $spv--x-small;
+        margin-bottom: 0;
         margin-top: $spv--x-small;
       }
 


### PR DESCRIPTION
## Done

Adjust search and filter component height calculations and its internal input styling to better align with standard inputs.

Fixes #4984
Supersedes #5019

## QA

- Open [demo](https://vanilla-framework-5399.demos.haus/docs/examples/patterns/search-and-filter/default?theme=light)
- Review search & filter examples, make sure that in all cases and stated the root element `p-search-and-filter` has height of 36px (same as standard input)
  - https://vanilla-framework-5399.demos.haus/docs/examples/patterns/search-and-filter/default?theme=light
  - https://vanilla-framework-5399.demos.haus/docs/examples/patterns/search-and-filter/expanded?theme=light
  - https://vanilla-framework-5399.demos.haus/docs/examples/patterns/search-and-filter/with-chips?theme=light
  - https://vanilla-framework-5399.demos.haus/docs/examples/patterns/search-and-filter/with-search-prompt?theme=light
  - https://vanilla-framework-5399.demos.haus/docs/examples/patterns/search-and-filter/chip-overflow?theme=light

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1270" alt="image" src="https://github.com/user-attachments/assets/d4a387bb-4557-4300-a507-03235ff20ccf">
