### PR TITLE
Update layout of the homepage "downloads" section on medium screens

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -148,10 +148,10 @@
 
 <div class="p-strip">
   <div class="row">
-    <div class="col-4 col-medium-2">
+    <div class="col-4">
       <h2>Downloads</h2>
     </div>
-    <div class="p-card--highlighted col-4 col-medium-2">
+    <div class="p-card--highlighted col-4 col-medium-3">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/0276b842-github-icon.svg" alt="GitHub repo:" />
@@ -162,7 +162,7 @@
         <small>See the <a href="https://github.com/canonical/vanilla-framework/releases">release notes</a> for details on the latest&nbsp;updates.</small>
       </div>
     </div>
-    <div class="p-card--highlighted col-4 col-medium-2">
+    <div class="p-card--highlighted col-4 col-medium-3">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9a5b9c51-sketch-icon.svg" alt="Sketch library:" />


### PR DESCRIPTION
## Done
I arranged the cards to display in a 50/50 split under the heading when viewed on a medium screen size.

Fixes #5367

## QA
- Open the [homepage](https://vanilla-framework-5400.demos.haus/) and check the downloads section on different screen sizes.

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
<img width="1525" alt="Screenshot 2024-10-24 at 14 40 53" src="https://github.com/user-attachments/assets/41cea216-ddb4-4717-8e03-dd5f0a7bde05">
<img width="1029" alt="Screenshot 2024-10-24 at 14 41 10" src="https://github.com/user-attachments/assets/51da6c32-cff6-4309-8544-1d3358d4366f">
<img width="577" alt="Screenshot 2024-10-24 at 14 41 32" src="https://github.com/user-attachments/assets/02e89d9f-0b4b-49fd-ba79-b7cd42effe08">

