### PR TITLE
Fix using the image container with lazyloaded images

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.18.1",
+  "version": "4.18.2",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -84,8 +84,8 @@ $aspect-ratios: (
     justify-content: center;
     text-align: center;
 
-    // If there is a child element that is not the image, don't let it affect the layout
-    & > *:not(.p-image-container__image) {
+    // If there is a child lazyloaded image, don't let it affect the layout
+    & > .lazyloaded {
       display: contents;
     }
 


### PR DESCRIPTION
## Done

Specifically targets `.lazyloaded` images for `display: contents` to avoid applying contents display to `.lazyload`

## QA

- Check out https://github.com/canonical/canonical.com/pull/1409
- Set `vanilla-framework` version to `jmuzina/vanilla-framework#5402-image-aspect-ratio-lazyloaded-fix`
- Set `sass` version to `1.79.0`
- Open [what is Spark page](http://0.0.0.0:8002/data/spark/what-is-spark)
- Verify the lazily loaded "how do companies use spark" images load and have the correct aspect ratio

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).