### PR TITLE
Changed UI kit references to Figma community

### DIFF
--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -207,5 +207,5 @@
       url: /docs/examples
     - title: Release notes for {version}
       url: https://github.com/canonical/vanilla-framework/releases/latest
-    - title: Download Sketch UI Kit
-      url: https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch
+    - title: UI kit on Figma community
+      url: https://www.figma.com/community/file/1435297834108003391/vanilla-core-component-library

--- a/templates/index.html
+++ b/templates/index.html
@@ -169,7 +169,7 @@
           <h3 class="p-heading-icon__title">Vanilla UI kit</h3>
         </div>
         <p>Get our UI kit to start designing with Vanilla components.</p>
-        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla Design UI Kit', 'eventValue' : undefined });" class="p-button" href="https://www.figma.com/community/file/1435297834108003391/vanilla-core-component-library">Download the Figma UI kit</a></p>
+        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla Design UI Kit', 'eventValue' : undefined });" class="p-button" href="https://www.figma.com/community/file/1435297834108003391/vanilla-core-component-library">Get the Figma UI kit</a></p>
       </div>
     </div>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -165,12 +165,11 @@
     <div class="p-card--highlighted col-4 col-medium-3">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9a5b9c51-sketch-icon.svg" alt="Sketch library:" />
-          <h3 class="p-heading-icon__title">Vanilla Design</h3>
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/c42ba977-figma-logo-o.svg" alt="Figma library:" />
+          <h3 class="p-heading-icon__title">Vanilla UI kit</h3>
         </div>
-        <p>Get our Sketch library of common design components.</p>
-        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla Design UI Kit', 'eventValue' : undefined });" class="p-button" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download the Sketch UI Kit</a></p>
-        <small><i class="p-icon--warning"></i> The Sketch UI Kit is no longer maintained. Current version is compatible with Vanilla v2.25.</small>
+        <p>Get our UI kit to start designing with Vanilla components.</p>
+        <p style="margin-bottom: 0px;"><a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla Design UI Kit', 'eventValue' : undefined });" class="p-button" href="https://www.figma.com/community/file/1435297834108003391/vanilla-core-component-library">Download the Figma UI kit</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done
- Changed UI kit reference on home page from sketch to Figma
- Changed UI kit reference in the side navigation of the docs from Sketch to Figma

## QA

- Open Demo
- Look at UI kit card on home page
- Verify it looks good and links work
- Look at Resources group in side nav
- Verify it looks good and links work

## Screenshots
### Before:
![Screenshot 2024-11-05 at 09 59 43](https://github.com/user-attachments/assets/bfeed3d4-3a82-4dc5-bfda-18a8ce57ffaf)

![Screenshot 2024-11-05 at 10 00 36](https://github.com/user-attachments/assets/c58622a8-3421-4827-a1d5-91f0d0da399b)


### After:
![Screenshot 2024-11-05 at 10 00 18](https://github.com/user-attachments/assets/9c4b1544-827d-487c-a79c-d9a6d695707b)

![Screenshot 2024-11-05 at 10 00 48](https://github.com/user-attachments/assets/848a7235-058d-460a-b9a5-c016d2a21a57)
