### PR TITLE
fix: removed the extra spacing between the chips in search and filter from vanilla example

### DIFF
--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -196,6 +196,7 @@
 
       &[aria-expanded='false'] {
         max-height: 5rem; // 2 rows of chips
+        font-size: 0;
       }
     }
 

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -196,7 +196,6 @@
 
       &[aria-expanded='false'] {
         max-height: 5rem; // 2 rows of chips
-        font-size: 0;
       }
     }
 

--- a/templates/docs/examples/patterns/search-and-filter/chip-overflow.html
+++ b/templates/docs/examples/patterns/search-and-filter/chip-overflow.html
@@ -57,67 +57,35 @@
     <div class="p-filter-panel-section">
       <h5 class="p-filter-panel-section__heading">Cloud</h5>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <button class="p-chip">
-          <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Azure</span>
-        </button>
-      </div>
+        <button class="p-chip"><span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Azure</span></button>
+      </div>      
     </div>
 
     <div class="p-filter-panel-section">
       <h5 class="p-filter-panel-section__heading">Region</h5>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east1</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north2</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south3</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north4</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east5</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south6</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east7</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east8</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east9</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east10</span>
-        </button>
-      </div>
+        <button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east1</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north2</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south3</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north4</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east5</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south6</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east7</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east8</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east9</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east10</span></button>
+      </div>      
     </div>
 
     <div class="p-filter-panel-section">
       <h5 class="p-filter-panel-section__heading">Owner</h5>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <button class="p-chip">
-          <span class="p-chip__lead">OWNER</span><span class="p-chip__value">foo</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">OWNER</span><span class="p-chip__value">bar</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">OWNER</span><span class="p-chip__value">baz</span>
-        </button>
-      </div>
+        <button class="p-chip"><span class="p-chip__lead">OWNER</span><span class="p-chip__value">foo</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">OWNER</span><span class="p-chip__value">bar</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">OWNER</span><span class="p-chip__value">baz</span></button>
+      </div>      
     </div>
   </div>
 </div>

--- a/templates/docs/examples/patterns/search-and-filter/default.html
+++ b/templates/docs/examples/patterns/search-and-filter/default.html
@@ -16,67 +16,35 @@
     <div class="p-filter-panel-section">
       <h5 class="p-filter-panel-section__heading">Cloud</h5>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <button class="p-chip">
-          <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Azure</span>
-        </button>
-      </div>
+        <button class="p-chip"><span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Azure</span></button>
+      </div>      
     </div>
 
     <div class="p-filter-panel-section">
       <h5 class="p-filter-panel-section__heading">Region</h5>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east1</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north2</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south3</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north4</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east5</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south6</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east7</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east8</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east9</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east10</span>
-        </button>
-      </div>
+        <button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east1</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north2</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south3</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north4</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east5</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south6</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east7</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east8</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east9</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east10</span></button>
+      </div>      
     </div>
 
     <div class="p-filter-panel-section">
       <h5 class="p-filter-panel-section__heading">Owner</h5>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <button class="p-chip">
-          <span class="p-chip__lead">OWNER</span><span class="p-chip__value">foo</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">OWNER</span><span class="p-chip__value">bar</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">OWNER</span><span class="p-chip__value">baz</span>
-        </button>
-      </div>
+        <button class="p-chip"><span class="p-chip__lead">OWNER</span><span class="p-chip__value">foo</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">OWNER</span><span class="p-chip__value">bar</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">OWNER</span><span class="p-chip__value">baz</span></button>
+      </div>      
     </div>
   </div>
 </div>

--- a/templates/docs/examples/patterns/search-and-filter/expanded.html
+++ b/templates/docs/examples/patterns/search-and-filter/expanded.html
@@ -16,67 +16,35 @@
     <div class="p-filter-panel-section">
       <h5 class="p-filter-panel-section__heading">Cloud</h5>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <button class="p-chip">
-          <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Azure</span>
-        </button>
+        <button class="p-chip"><span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Azure</span></button>
       </div>
-    </div>
+   </div>   
 
     <div class="p-filter-panel-section">
       <h5 class="p-filter-panel-section__heading">Region</h5>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east1</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north2</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south3</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north4</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east5</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south6</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east7</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east8</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east9</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east10</span>
-        </button>
-      </div>
+        <button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east1</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north2</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south3</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north4</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east5</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south6</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east7</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east8</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east9</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east10</span></button>
+      </div>      
     </div>
 
     <div class="p-filter-panel-section">
       <h5 class="p-filter-panel-section__heading">Owner</h5>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <button class="p-chip">
-          <span class="p-chip__lead">OWNER</span><span class="p-chip__value">foo</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">OWNER</span><span class="p-chip__value">bar</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">OWNER</span><span class="p-chip__value">baz</span>
-        </button>
-      </div>
+        <button class="p-chip"><span class="p-chip__lead">OWNER</span><span class="p-chip__value">foo</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">OWNER</span><span class="p-chip__value">bar</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">OWNER</span><span class="p-chip__value">baz</span></button>
+      </div>      
     </div>
   </div>
 </div>

--- a/templates/docs/examples/patterns/search-and-filter/with-chips.html
+++ b/templates/docs/examples/patterns/search-and-filter/with-chips.html
@@ -24,67 +24,35 @@
     <div class="p-filter-panel-section">
       <h5 class="p-filter-panel-section__heading">Cloud</h5>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <button class="p-chip">
-          <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Azure</span>
-        </button>
-      </div>
+        <button class="p-chip"><span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">CLOUD</span><span class="p-chip__value">AWS</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Azure</span></button>
+      </div>      
     </div>
 
     <div class="p-filter-panel-section">
       <h5 class="p-filter-panel-section__heading">Region</h5>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east1</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north2</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south3</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north4</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east5</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south6</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east7</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east8</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east9</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east10</span>
-        </button>
-      </div>
+        <button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east1</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north2</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south3</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-north4</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east5</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-south6</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east7</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east8</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east9</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">us-east10</span></button>
+      </div>      
     </div>
 
     <div class="p-filter-panel-section">
       <h5 class="p-filter-panel-section__heading">Owner</h5>
       <div class="p-filter-panel-section__chips" aria-expanded="false">
-        <button class="p-chip">
-          <span class="p-chip__lead">OWNER</span><span class="p-chip__value">foo</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">OWNER</span><span class="p-chip__value">bar</span>
-        </button>
-        <button class="p-chip">
-          <span class="p-chip__lead">OWNER</span><span class="p-chip__value">baz</span>
-        </button>
-      </div>
+        <button class="p-chip"><span class="p-chip__lead">OWNER</span><span class="p-chip__value">foo</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">OWNER</span><span class="p-chip__value">bar</span></button><!--
+        --><button class="p-chip"><span class="p-chip__lead">OWNER</span><span class="p-chip__value">baz</span></button>
+      </div>      
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

Removed extra spacing between search & filter chips that are only present in the Vanilla examples by setting the font-size to 0 as suggested by @lyubomir-popov in the issue conversation.

Fixes #5227

## QA

- Open [search & filter examples](https://vanilla-framework-5414.demos.haus/docs/examples/patterns/search-and-filter/combined) and verify they look correct
- Open [search & filter docs](https://vanilla-framework-5414.demos.haus/docs/patterns/search-and-filter) and verify the markup in the example code snippets is easy to read

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

## Screenshot
![Screenshot 2024-11-28 at 2 55 02 AM](https://github.com/user-attachments/assets/20ebcc84-5309-4be8-980a-fa2583095dd3)

