### PR TITLE
Fix typo in breakpoint class name used in documentation

### DIFF
--- a/templates/docs/layouts/fluid-breakout.md
+++ b/templates/docs/layouts/fluid-breakout.md
@@ -10,7 +10,7 @@ In some cases, there might be a good reason to break out of the constraints of a
 
 ### Wrapper
 
-The `.l-fluid-breakout` serves as a wrapper, and allows for an aside and a main area. On screens smaller than `$breakpoint--large`, it acts as a single column. On larger screens it switches to a 3 column layout - a central area and two aside areas on either side.
+The `.l-fluid-breakout` serves as a wrapper, and allows for an aside and a main area. On screens smaller than `$breakpoint-large`, it acts as a single column. On larger screens it switches to a 3 column layout - a central area and two aside areas on either side.
 
 The wrapper aims to align as much as possible with the 12 column grid. On smaller screens, that is limited to ensuring the padding of both layouts match. Once the window width becomes large enough, the left edges of the regular 12 column grid and the central column of the fluid breakout layout also align. For this to be possible, two conditions need to be met:
 
@@ -27,7 +27,7 @@ View example of the fluid breakout layout with a left aside and a toolbar
 
 ### Aside
 
-The aside is optional. When present, the order of the aside can be changed from before to after the main area by re-arranging the markup. Depending on the screen width, that would place it above / below (on screens smaller than `$breakpoint--large`) or to the left / right on larger screens.
+The aside is optional. When present, the order of the aside can be changed from before to after the main area by re-arranging the markup. Depending on the screen width, that would place it above / below (on screens smaller than `$breakpoint-large`) or to the left / right on larger screens.
 
 An aside to the left, main area to the right:
 

--- a/templates/docs/layouts/full-width.md
+++ b/templates/docs/layouts/full-width.md
@@ -17,7 +17,7 @@ context:
 
 The `.l-full-width` serves as a wrapper for full-width layout and allows for a start (left), main (central) and end (right) areas. Usually, the `l-full-width` class name would be placed on a strip component `p-strip` or an individual element. Additionally, a separate `l-full-width__sidebar` element can be added as a container for side navigation placed on top of the start (left) area of the layout.
 
-On screens smaller than `$breakpoint--large` the sidebar is hidden off-screen and the whole width of the page is occupied by the main content area. On larger screens, the sidebar is visible on the left side of the window.
+On screens smaller than `$breakpoint-large` the sidebar is hidden off-screen and the whole width of the page is occupied by the main content area. On larger screens, the sidebar is visible on the left side of the window.
 
 ### Main area
 


### PR DESCRIPTION
## Done

The utility class for breakpoint `$breakpoint-large` is referenced in the [fluid-breakout](https://vanillaframework.io/docs/layouts/fluid-breakout) documentation with an extra dash (`-`). This PR simply corrects the small typo.


Please note - I can't seem to be able to add any label to this PR. I wanted to add `Documentation 📝`. 


### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
