### PR TITLE
Corrected documentation for importing quote macro

### DIFF
--- a/templates/docs/patterns/quote-wrapper/index.md
+++ b/templates/docs/patterns/quote-wrapper/index.md
@@ -285,7 +285,7 @@ Jinja template.
 
 ```jinja
 {% raw -%}
-{% from "_macros/vf_quote-wrapper.jinja" import vf_quote-wrapper %}
+{% from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
 {%- endraw -%}
 ```
 


### PR DESCRIPTION
## Done

- Corrected documentation for importing quote macro
- `vf_quote-wrapper` gave error when imported

## QA

- Open [demo](https://vanilla-framework-5422.demos.haus/docs/patterns/quote-wrapper) and see if the import statement is corrected

### Check if PR is ready for release

If this PR contains Vanilla SCSS code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention:
  - if CSS class names are not changed it can be bugfix release (x.x.**X**)
  - if CSS class names are changed/added/removed it should be minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![image](https://github.com/user-attachments/assets/e17cf501-9ea2-495a-8057-ba28faaff0b7)
