### PR TITLE
Ft: add content guidelines page

### DIFF
--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -1,3 +1,4 @@
+---
 - heading: Welcome
   subheadings:
     - title: Get started

--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -1,3 +1,4 @@
+---
 - heading: Welcome
   subheadings:
     - title: Get started
@@ -6,6 +7,8 @@
       url: /docs/building-vanilla
     - title: Customising Vanilla
       url: /docs/customising-vanilla
+    - title: Content Guidelines
+      url: /docs/content-guidelines
     - title: What's new in {version}
       url: /docs/whats-new
     - title: Migrating to v4

--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -1,4 +1,3 @@
----
 - heading: Welcome
   subheadings:
     - title: Get started

--- a/templates/docs/content-guidelines.md
+++ b/templates/docs/content-guidelines.md
@@ -68,7 +68,7 @@ On Canonical websites (‘Sites’), we have three CTA patterns: primary (green 
 
 <a href="#" class="p-button--positive">Positive</a>
 <a href="#" class="p-button">Secondary</a>
-<a href="#">Tertiary;&rsaquo;</a>
+<a href="#">Tertiary &rsaquo;</a>
 
 For buttons:
 

--- a/templates/docs/content-guidelines.md
+++ b/templates/docs/content-guidelines.md
@@ -36,6 +36,8 @@ For complex images like graphs or diagrams, consider putting a longer descriptio
 - Always write alt text when the image adds meaning.
 - Use an empty alt attribute (`alt=""`) if the image doesn’t add meaning. For example, the currency icons below are decorative and do not add meaning. [Learn more about decorative images](https://www.w3.org/WAI/tutorials/images/decorative/).
 
+<img src="https://assets.ubuntu.com/v1/f6d73074-alt-text-entreprise-savings.png" alt="" width="560">
+
 ### How to write alt text for images
 
 - Be concise, ideally less than 125 characters.

--- a/templates/docs/content-guidelines.md
+++ b/templates/docs/content-guidelines.md
@@ -69,6 +69,7 @@ On Canonical websites (‘Sites’), we have three CTA patterns: primary (green 
 <a href="#" class="p-button--positive">Positive</a>
 <a href="#" class="p-button">Secondary</a>
 <a href="#">Tertiary;&rsaquo;</a>
+
 For buttons:
 
 - Start with a verb when the button connects to an action.

--- a/templates/docs/content-guidelines.md
+++ b/templates/docs/content-guidelines.md
@@ -101,8 +101,6 @@ You can also use this cheat sheet:
 
 To support international and US audiences, shorten dates with dashes. For example, 10-SEPT-23.
 
-To save space, you can use all numerals separated by a forward slash using the UK convention of [day]/[month]/[year].
-
 Use numerals for relative dates. For example, ‘2 hours ago’ or ‘Updated 5 days ago’.
 
 ## Numbers

--- a/templates/docs/content-guidelines.md
+++ b/templates/docs/content-guidelines.md
@@ -45,6 +45,7 @@ For complex images like graphs or diagrams, consider putting a longer descriptio
 **Instructions for certain types of images:**
 
 - **Card images:** Images inside cards or with links can be tricky. The screen reader will include the card title and link text, so alt text just needs to fill in any gaps. For example below, the card and link text tell the user a Dell XPS 13 Plus is a featured device, the missing information is it’s a laptop.
+
 <img src="https://assets.ubuntu.com/v1/1db0cd77-card-image-featured-device.png" alt="" width="250">
 
 - **Charts and diagrams:** If the chart is already explained in the text, use an empty alt attribute (`alt=""`). For example:

--- a/templates/docs/content-guidelines.md
+++ b/templates/docs/content-guidelines.md
@@ -93,10 +93,6 @@ Error messages can be more frustrating than other notifications. Support the use
 
 Consider thinking about the specific user and the moment they get this error. Do they have a very technical background and want lots of details? Is there a job to be done and they just need to know how to get there?
 
-You can also use this cheat sheet:
-
-<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/7d840944-error-message-cheat-sheet.png" alt="A decision tree explains how to decide on the vocabulary relative to an error."></div>
-
 ## Dates and times
 
 To support international and US audiences, shorten dates with dashes. For example, 10-SEPT-23.

--- a/templates/docs/content-guidelines.md
+++ b/templates/docs/content-guidelines.md
@@ -54,11 +54,9 @@ For complex images like graphs or diagrams, consider putting a longer descriptio
 
 <img src="https://assets.ubuntu.com/v1/0dd0ff70-empty-alt-attribute.png" alt="A screenshot of a page that describes the LTS support cycle of Ubuntu. A table summarizing the information is provided afterwards, with an empty alt-text." width="600">
 
-- **Graphs:** Describe the key trend or insight depicted in the graph so users understand the main data point. For example:
+- **Graphs:** Describe the key trend or insight depicted in the graph so users understand the main data point.
 
 - **Logos:** Just use the brand name (for example, ‘Microsoft Azure,’ not ‘Microsoft Azure logo’). Use empty state if the company name is used in the title or a link label.
-
-- **Icons and isometric images:** [Add examples for when you do need alt text and when you don’t].
 
 ---
 

--- a/templates/docs/content-guidelines.md
+++ b/templates/docs/content-guidelines.md
@@ -1,70 +1,190 @@
 ---
 wrapper_template: '_layouts/docs.html'
 context:
-  title: Content Guidelines | test
+  title: Content Guidelines
+  description: Content guidelines for the Canonical design system
 ---
 
-Here you will find information on customising Vanilla to suit your project.
+Open source software connects and uplifts, and our content does the same. With a diverse and global community of users, our language should be clear, consistent, and accessible.
 
-## Overriding default settings
+Follow this overall guidance for all UX copy:
 
-To override the default settings you must do so _before_ you include Vanilla in your main Sass file. It is good practice to include custom styles in a separate settings file. A list of configurable settings can be found in the [Related settings section](#related-settings).
+- Put the most important information first
+- Use short words and short sentences
+- Use sentence case
+- Avoid "please" and "thank you" – in UI copy, they can vary by culture
+- Use inclusive language – avoid gendered pronouns and ableist words such as "see" or "view"
 
-```
-// Override default Vanilla settings in your main Sass file
-$breakpoint-navigation-threshold: 900px;
-$color-accent: #7cf0ee;
-$font-base-family: 'Merriweather';
-$grid-max-width: 1440px;
+## Abbreviations
 
-// ...or include it from a separate settings file in the same folder
-@import 'settings';
+Do not use e.g. or i.e. Instead, use ‘for example’ or ‘meaning’.
 
-// Import Vanilla framework
-@import 'vanilla-framework';
+## Alt text for images
 
-// Include all of Vanilla Framework
-@include vanilla;
-```
+Alt text is a short description that replaces an image for users who don’t see the image. They may rely on screen readers or other assistive technologies. This is also good for SEO.
 
-## Importing individual components
+### How screen readers work
 
-Your project may not warrant including all of Vanilla, in which case you can include components modularly. We recommend including `vf-base` as many components depend on the base styling. As a bare minimum, you need to include `vf-b-placeholders`, as many patterns extend these placeholders and will generate errors if they are missing. Below is an example of how to include Vanilla components on an as-needed basis:
+Screen readers follow the HTML reading order to read and interpret content for users.
 
-```
-// Import Vanilla framework
-@import 'vanilla-framework';
+When an image conveys important information, alt text is how users who don’t see the images consume that information. When a screen reader gets to an image, it will read the alt text to describe the content or purpose. Screen readers ignore images with empty alt attributes.
 
-// Include base Vanilla styles
-@include vf-base;
+For complex images like graphs or diagrams, consider putting a longer description somewhere else on the page. For example, in a nearby paragraph or through ARIA attributes.
 
-// Include the components you want
-@include vf-p-buttons;
-@include vf-p-forms;
-@include vf-p-links;
-```
+### When to write alt text
 
-## Related settings
+- Always write alt text when the image adds meaning.
+- Use an empty alt attribute (`alt=""`) if the image doesn’t add meaning. For example, the currency icons below are decorative and do not add meaning. [Learn more about decorative images](https://www.w3.org/WAI/tutorials/images/decorative/).
 
-<div class="row">
-  <div class="col-3">
-  <ul class="p-list--divided">
-  <li class="p-list__item"><a href="/docs/settings/animation-settings">Animation</a></li>
-  <li class="p-list__item"><a href="/docs/settings/assets-settings">Assets</a></li>
-  <li class="p-list__item"><a href="/docs/settings/breakpoint-settings">Breakpoint</a></li>
-  </ul>
-  </div>
-  <div class="col-3">
-  <ul class="p-list--divided">
-  <li class="p-list__item"><a href="/docs/settings/color-settings">Color</a></li>
-  <li class="p-list__item"><a href="/docs/settings/font-settings">Font</a></li>
-  <li class="p-list__item"><a href="/docs/settings/layout-settings">Layout</a></li>
-  </ul>
-  </div>
-  <div class="col-3">
-  <ul class="p-list--divided">
-  <li class="p-list__item"><a href="/docs/settings/placeholder-settings">Placeholder</a></li>
-  <li class="p-list__item"><a href="/docs/settings/spacing-settings">Spacing</a></li>
-  </ul>
-  </div>
-</div>
+### How to write alt text for images
+
+- Be concise, ideally less than 125 characters.
+- Describe the image accurately.
+- Add information the image conveys that is not in titles, link text, or paragraphs.
+
+**Instructions for certain types of images:**
+
+- **Card images:** Images inside cards or with links can be tricky. The screen reader will include the card title and link text, so alt text just needs to fill in any gaps. For example below, the card and link text tell the user a Dell XPS 13 Plus is a featured device, the missing information is it’s a laptop.
+<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/1db0cd77-card-image-featured-device.png" alt=""></div>
+
+- **Charts and diagrams:** If the chart is already explained in the text, use an empty alt attribute (`alt=""`). For example:
+
+<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/0dd0ff70-empty-alt-attribute.png" alt="A screenshot of a page that describes the LTS support cycle of Ubuntu. A table summarizing the information is provided afterwards, with an empty alt-text."></div>
+
+- **Graphs:** Describe the key trend or insight depicted in the graph so users understand the main data point. For example:
+
+- **Logos:** Just use the brand name (for example, ‘Microsoft Azure,’ not ‘Microsoft Azure logo’). Use empty state if the company name is used in the title or a link label.
+
+- **Icons and isometric images:** [Add examples for when you do need alt text and when you don’t].
+
+---
+
+## Buttons and other CTAs
+
+On Canonical websites (‘Sites’), we have three CTA patterns: primary (green buttons), secondary (white buttons), and tertiary (linked text with a chevron).
+
+For buttons:
+
+- Start with a verb when the button connects to an action.
+- Match language between the CTA and the title.
+- Try to use three words or fewer.
+
+Terry Podemjersky, a content designer at Google, notes that buttons that are more than two words long aren’t clicked as much.
+
+For links followed by a chevron:
+
+- Be specific, not generic (for example avoid, ‘learn more’ ‘click here’).
+- Use chevrons at the end of a CTA when the information is alone. Do not use chevrons when it’s a list of links with context.
+
+**Examples from Sites:**
+
+<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/57b9c63d-buttons-ctas-primary-secondary.png" alt="Example showing a Hero with Primary and Secondary buttons"></div>
+
+<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/e38f7945-buttons-ctas-tertiary.png" alt="Example showing tertiary buttons"></div>
+
+## Error messages
+
+Error messages can be more frustrating than other notifications. Support the user when something goes wrong.
+
+- Don’t blame the user (Use ‘incorrect password,’ not, ‘you entered your password incorrectly.’)
+- Explain what went wrong.
+- Use verb-first, short instructions on how to fix the issue or get help.
+- Try to match the title action to the CTA action.
+
+Consider thinking about the specific user and the moment they get this error. Do they have a very technical background and want lots of details? Is there a job to be done and they just need to know how to get there?
+
+You can also use this cheat sheet:
+
+<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/7d840944-error-message-cheat-sheet.png" alt="A decision tree explains how to decide on the vocabulary relative to an error."></div>
+
+## Dates and times
+
+To support international and US audiences, shorten dates with dashes. For example, 10-SEPT-23.
+
+To save space, you can use all numerals separated by a forward slash using the UK convention of [day]/[month]/[year].
+
+Use numerals for relative dates. For example, ‘2 hours ago’ or ‘Updated 5 days ago’.
+
+## Numbers
+
+Use numerals in the UI when it can help highlight an action and compare two amounts. Use the UK convention for commas and decimals in numbers. For example, £10.00 rather than £10,00.
+
+- **Example from Landscape:**
+
+<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/135209d1-numbers-numberals-example-landscape.png" alt="An example of a dialaog in Landscape where the use of numbers is shown"></div>
+
+- Note: this guidance differs from the Copy Style Guide to spell out numerals less than 10. Follow the Copy Style Guide for copy that is not part of the UI.
+
+## Videos
+
+When you embed a video in a web page, you don’t need a ‘watch’ CTA as well. Use a clear header to explain to the user what they will get from clicking on the video. For example, what they will learn.
+
+## Writing notifications
+
+There are three basic concepts for UX copy that we use: attributes and objects, and actions.
+
+- **Attributes:** The components that make up a piece of content. For example, a title, description.
+- **Objects:** Usually nouns, the things users interact with.
+- **Actions:** Often verbs, things users can do with objects.
+
+<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/cde94563-lxd-context.png" alt="A capture of a form of the LXD UI, including the app side navigation. The context relevant for an error message is outlined on the screenshot."></div>
+
+We should be specific about objects and actions and not have duplicate terms. Our messages typically include three attributes:
+
+- **Title**
+- **Description**
+- **CTA**
+
+**Example from Anbox:**
+
+<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/e53e5133-reset-dialog.png" alt="Example of a reset dialog in Anbox with contextualized title, description and CTA."></div>
+
+You may need to consult with your product manager or engineers to clarify the objects and actions in different circumstances. Follow the guidance below to write messages that support users.
+
+### Title
+
+- Use a verb phrase to describe the action that will affect a certain object. In the example above, the action is to ‘reset’ and the object is ‘default values’.
+- Do not use punctuation in the title.
+
+### Description
+
+- Add details about the action, try not to add more objects.
+- Use punctuation in the description.
+
+**Research says to:**
+
+- Aim for 3-6 words per line, no more than 3 lines per message.
+- Avoid asterisks (users don’t really trust them).
+
+### CTAs
+
+- Match the text of the primary CTA button to the action in the title.
+- Note: our current convention is to make ‘Cancel’ the secondary CTA button. It performs the same action as an ‘X’ icon in the top right corner.
+
+## Notification library
+
+The following is a library of messages you can use or edit to your specific needs.
+
+**Error: Unspecified systems error**  
+Use this kind of message when we don’t know what caused the error. Adjust the message to match the action the system can’t complete and the options the user has to fix the issue.
+
+**Installation failed**  
+We're sorry, but we're not sure what went wrong. You can try restarting your computer and start the installation process again. You can also report the issue.
+
+**Error: No connection**  
+Connect to the internet  
+We can't load [insert specifics of what we cannot load] without an internet connection. Check your connection and reload.
+
+**Example from App Store:**  
+We can't load content in the App Center without an internet connection. Check your connection and reload.
+
+**Error: 404 for Vanilla**  
+404 Page not found  
+We can’t find the page you’re looking for. File a bug if you think this might be an error.
+
+<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/98071afb-page-not-found.png" alt="Example of a 404 page from Vanilla"></div>
+
+**Confirmation: Contact form submission**  
+‘Thank you for contacting us. A member of our team will be in touch shortly.’
+
+> Note: Follow the guidance as described for consistency and accessibility across all content.

--- a/templates/docs/content-guidelines.md
+++ b/templates/docs/content-guidelines.md
@@ -66,6 +66,9 @@ For complex images like graphs or diagrams, consider putting a longer descriptio
 
 On Canonical websites (‘Sites’), we have three CTA patterns: primary (green buttons), secondary (white buttons), and tertiary (linked text with a chevron).
 
+<a href="#" class="p-button--positive">Positive</a>
+<a href="#" class="p-button">Secondary</a>
+<a href="#">Tertiary;&rsaquo;</a>
 For buttons:
 
 - Start with a verb when the button connects to an action.

--- a/templates/docs/content-guidelines.md
+++ b/templates/docs/content-guidelines.md
@@ -45,11 +45,11 @@ For complex images like graphs or diagrams, consider putting a longer descriptio
 **Instructions for certain types of images:**
 
 - **Card images:** Images inside cards or with links can be tricky. The screen reader will include the card title and link text, so alt text just needs to fill in any gaps. For example below, the card and link text tell the user a Dell XPS 13 Plus is a featured device, the missing information is it’s a laptop.
-<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/1db0cd77-card-image-featured-device.png" alt="" width="250"></div>
+<img src="https://assets.ubuntu.com/v1/1db0cd77-card-image-featured-device.png" alt="" width="250">
 
 - **Charts and diagrams:** If the chart is already explained in the text, use an empty alt attribute (`alt=""`). For example:
 
-<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/0dd0ff70-empty-alt-attribute.png" alt="A screenshot of a page that describes the LTS support cycle of Ubuntu. A table summarizing the information is provided afterwards, with an empty alt-text." width="600"></div>
+<img src="https://assets.ubuntu.com/v1/0dd0ff70-empty-alt-attribute.png" alt="A screenshot of a page that describes the LTS support cycle of Ubuntu. A table summarizing the information is provided afterwards, with an empty alt-text." width="600">
 
 - **Graphs:** Describe the key trend or insight depicted in the graph so users understand the main data point. For example:
 
@@ -138,7 +138,7 @@ We should be specific about objects and actions and not have duplicate terms. Ou
 
 **Example from Anbox:**
 
-<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/e53e5133-reset-dialog.png" alt="Example of a reset dialog in Anbox with contextualized title, description and CTA." width="500"></div>
+<img src="https://assets.ubuntu.com/v1/e53e5133-reset-dialog.png" alt="Example of a reset dialog in Anbox with contextualized title, description and CTA." width="500">
 
 You may need to consult with your product manager or engineers to clarify the objects and actions in different circumstances. Follow the guidance below to write messages that support users.
 
@@ -192,7 +192,7 @@ We can't load content in the App Center without an internet connection. Check yo
 404 Page not found  
 We can’t find the page you’re looking for. File a bug if you think this might be an error.
 
-<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/98071afb-page-not-found.png" alt="Example of a 404 page from Vanilla" width="600"></div>
+<img src="https://assets.ubuntu.com/v1/98071afb-page-not-found.png" alt="Example of a 404 page from Vanilla" width="600">
 
 **Confirmation: Contact form submission**  
 ‘Thank you for contacting us. A member of our team will be in touch shortly.’

--- a/templates/docs/content-guidelines.md
+++ b/templates/docs/content-guidelines.md
@@ -45,11 +45,11 @@ For complex images like graphs or diagrams, consider putting a longer descriptio
 **Instructions for certain types of images:**
 
 - **Card images:** Images inside cards or with links can be tricky. The screen reader will include the card title and link text, so alt text just needs to fill in any gaps. For example below, the card and link text tell the user a Dell XPS 13 Plus is a featured device, the missing information is it’s a laptop.
-<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/1db0cd77-card-image-featured-device.png" alt=""></div>
+<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/1db0cd77-card-image-featured-device.png" alt="" width="250"></div>
 
 - **Charts and diagrams:** If the chart is already explained in the text, use an empty alt attribute (`alt=""`). For example:
 
-<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/0dd0ff70-empty-alt-attribute.png" alt="A screenshot of a page that describes the LTS support cycle of Ubuntu. A table summarizing the information is provided afterwards, with an empty alt-text."></div>
+<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/0dd0ff70-empty-alt-attribute.png" alt="A screenshot of a page that describes the LTS support cycle of Ubuntu. A table summarizing the information is provided afterwards, with an empty alt-text." width="600"></div>
 
 - **Graphs:** Describe the key trend or insight depicted in the graph so users understand the main data point. For example:
 
@@ -105,9 +105,16 @@ Use numerals in the UI when it can help highlight an action and compare two amou
 
 - **Example from Landscape:**
 
-<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/135209d1-numbers-numberals-example-landscape.png" alt="An example of a dialaog in Landscape where the use of numbers is shown"></div>
+<img src="https://assets.ubuntu.com/v1/135209d1-numbers-numberals-example-landscape.png" alt="An example of a dialaog in Landscape where the use of numbers is shown" width="400">
 
-- Note: this guidance differs from the Copy Style Guide to spell out numerals less than 10. Follow the Copy Style Guide for copy that is not part of the UI.
+<div class="p-notification--information">
+  <p class="p-notification__content">
+    <span class="p-notification__title">Note:</span>
+    <span class="p-notification__message">
+This guidance differs from the Copy Style Guide to spell out numerals less than 10. Follow the Copy Style Guide for copy that is not part of the UI.
+    </span>
+  </p>
+</div>
 
 ## Videos
 
@@ -131,7 +138,7 @@ We should be specific about objects and actions and not have duplicate terms. Ou
 
 **Example from Anbox:**
 
-<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/e53e5133-reset-dialog.png" alt="Example of a reset dialog in Anbox with contextualized title, description and CTA."></div>
+<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/e53e5133-reset-dialog.png" alt="Example of a reset dialog in Anbox with contextualized title, description and CTA." width="500"></div>
 
 You may need to consult with your product manager or engineers to clarify the objects and actions in different circumstances. Follow the guidance below to write messages that support users.
 
@@ -152,8 +159,17 @@ You may need to consult with your product manager or engineers to clarify the ob
 
 ### CTAs
 
-- Match the text of the primary CTA button to the action in the title.
-- Note: our current convention is to make ‘Cancel’ the secondary CTA button. It performs the same action as an ‘X’ icon in the top right corner.
+Match the text of the primary CTA button to the action in the title.
+
+<div class="p-notification--information">
+  <p class="p-notification__content">
+    <span class="p-notification__title">Note:</span>
+    <span class="p-notification__message">
+        Our current convention is to make ‘Cancel’ the secondary CTA button. It performs the same action as an ‘X’ icon in the top right corner.
+    </span>
+
+  </p>
+</div>
 
 ## Notification library
 
@@ -176,9 +192,17 @@ We can't load content in the App Center without an internet connection. Check yo
 404 Page not found  
 We can’t find the page you’re looking for. File a bug if you think this might be an error.
 
-<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/98071afb-page-not-found.png" alt="Example of a 404 page from Vanilla"></div>
+<div class="u-fixed-width"><img src="https://assets.ubuntu.com/v1/98071afb-page-not-found.png" alt="Example of a 404 page from Vanilla" width="600"></div>
 
 **Confirmation: Contact form submission**  
 ‘Thank you for contacting us. A member of our team will be in touch shortly.’
 
-> Note: Follow the guidance as described for consistency and accessibility across all content.
+<div class="p-notification--information">
+  <p class="p-notification__content">
+    <span class="p-notification__title">Note:</span>
+    <span class="p-notification__message">
+Follow the guidance as described for consistency and accessibility across all content.
+    </span>
+
+  </p>
+</div>

--- a/templates/docs/content-guidelines.md
+++ b/templates/docs/content-guidelines.md
@@ -1,0 +1,70 @@
+---
+wrapper_template: '_layouts/docs.html'
+context:
+  title: Content Guidelines | test
+---
+
+Here you will find information on customising Vanilla to suit your project.
+
+## Overriding default settings
+
+To override the default settings you must do so _before_ you include Vanilla in your main Sass file. It is good practice to include custom styles in a separate settings file. A list of configurable settings can be found in the [Related settings section](#related-settings).
+
+```
+// Override default Vanilla settings in your main Sass file
+$breakpoint-navigation-threshold: 900px;
+$color-accent: #7cf0ee;
+$font-base-family: 'Merriweather';
+$grid-max-width: 1440px;
+
+// ...or include it from a separate settings file in the same folder
+@import 'settings';
+
+// Import Vanilla framework
+@import 'vanilla-framework';
+
+// Include all of Vanilla Framework
+@include vanilla;
+```
+
+## Importing individual components
+
+Your project may not warrant including all of Vanilla, in which case you can include components modularly. We recommend including `vf-base` as many components depend on the base styling. As a bare minimum, you need to include `vf-b-placeholders`, as many patterns extend these placeholders and will generate errors if they are missing. Below is an example of how to include Vanilla components on an as-needed basis:
+
+```
+// Import Vanilla framework
+@import 'vanilla-framework';
+
+// Include base Vanilla styles
+@include vf-base;
+
+// Include the components you want
+@include vf-p-buttons;
+@include vf-p-forms;
+@include vf-p-links;
+```
+
+## Related settings
+
+<div class="row">
+  <div class="col-3">
+  <ul class="p-list--divided">
+  <li class="p-list__item"><a href="/docs/settings/animation-settings">Animation</a></li>
+  <li class="p-list__item"><a href="/docs/settings/assets-settings">Assets</a></li>
+  <li class="p-list__item"><a href="/docs/settings/breakpoint-settings">Breakpoint</a></li>
+  </ul>
+  </div>
+  <div class="col-3">
+  <ul class="p-list--divided">
+  <li class="p-list__item"><a href="/docs/settings/color-settings">Color</a></li>
+  <li class="p-list__item"><a href="/docs/settings/font-settings">Font</a></li>
+  <li class="p-list__item"><a href="/docs/settings/layout-settings">Layout</a></li>
+  </ul>
+  </div>
+  <div class="col-3">
+  <ul class="p-list--divided">
+  <li class="p-list__item"><a href="/docs/settings/placeholder-settings">Placeholder</a></li>
+  <li class="p-list__item"><a href="/docs/settings/spacing-settings">Spacing</a></li>
+  </ul>
+  </div>
+</div>

--- a/templates/docs/customising-vanilla.md
+++ b/templates/docs/customising-vanilla.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/docs.html'
 context:
-  title: Customising Vanilla | test
+  title: Customising Vanilla
 ---
 
 Here you will find information on customising Vanilla to suit your project.


### PR DESCRIPTION
## Done

- Added Content Guidelines page from [copydoc](https://docs.google.com/document/d/12nLPp3ktElJCNl_i3q5fGOjWMPhPXXFsIJGH-AuxduQ/edit?tab=t.0)

This is a draft. A few things are missing. Would love to hear your thoughts @bartaz @jmuzina on those : 
- Display the images in reasonable sizes
- Figure out a better way to display notessuch as in "contact form submission"

## QA

- Run vanilla-framework (`dotrun`)
- Go to Docs/Content Guidelines
- Review documentation

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)

## Screenshots

[if relevant, include a screenshot or screen capture]
