### PR TITLE
fix: quote wrapper's `title_text` is now a semantic `h2`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.18.3",
+  "version": "4.18.4",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/templates/_macros/vf_quote-wrapper.jinja
+++ b/templates/_macros/vf_quote-wrapper.jinja
@@ -99,7 +99,7 @@
           {%- if has_title %}
             {#- Optional heading text -#}
             <div class="col-3 col-medium-2">
-              <p class="p-muted-heading">{{ title_text }}</p>
+              <h2 class="p-muted-heading">{{ title_text }}</h2>
             </div>
           {%- endif -%}
 


### PR DESCRIPTION
## Done

- Updates the `title_text` of the quote wrapper to an `h2` to improve semantic structure of pages that use it.

Fixes #5426 , [WD-17584](https://warthogs.atlassian.net/browse/WD-17584)

## QA

- Open [combined quote wrapper example](https://vanilla-framework-5427.demos.haus/docs/examples/patterns/quote-wrapper/combined) and verify that the examples that have title bars use an `h2` for for the title text.

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


[WD-17584]: https://warthogs.atlassian.net/browse/WD-17584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ