### PR TITLE
fix: Update link to accessibility report tool

### DIFF
--- a/templates/accessibility.html
+++ b/templates/accessibility.html
@@ -25,7 +25,7 @@
         <p>We use the following tools to continually audit the framework:</p>
       </div>
       <div class="col-6">
-        <p class="p-heading--5 u-no-margin--bottom"><a href="https://www.w3.org/WAI/eval/report-tool/#!/evaluation/audit">Accessibility report tool</a></p>
+        <p class="p-heading--5 u-no-margin--bottom"><a href="https://www.w3.org/WAI/eval/report-tool/evaluation/audit-sample">Accessibility report tool</a></p>
         <p>A checklist that can be filtered by A / AA / AAA level, with a short description and links to the related "Understanding" and "How to Meet" articles that accompany each criterion.</p>
         <p class="p-heading--5 u-no-margin--bottom"><a href="https://www.w3.org/WAI/ARIA/apg/">WAI-ARIA Authoring Practices Guide</a></p>
         <p>

--- a/templates/accessibility.html
+++ b/templates/accessibility.html
@@ -26,7 +26,7 @@
       </div>
       <div class="col-6">
         <p class="p-heading--5 u-no-margin--bottom"><a href="https://www.w3.org/WAI/eval/report-tool/evaluation/audit-sample">Accessibility report tool</a></p>
-        <p>A checklist that can be filtered by A / AA / AAA level, with a short description and links to the related "Understanding" and "How to Meet" articles that accompany each criterion.</p>
+        <p>A checklist that can be filtered by A / AA level, with a short description and links to the related "Understanding" and "How to Meet" articles that accompany each criterion.</p>
         <p class="p-heading--5 u-no-margin--bottom"><a href="https://www.w3.org/WAI/ARIA/apg/">WAI-ARIA Authoring Practices Guide</a></p>
         <p>
           <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> A guide for understanding how to use <cite><a href="https://www.w3.org/TR/wai-aria-1.1/"><abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> 1.1</a></cite> to create an accessible Rich Internet Application. It provides guidance on the appropriate application of <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr>, describes recommended <abbr title="Accessible Rich Internet Applications">WAI-ARIA</abbr> usage patterns, and explains concepts behind them.</p>


### PR DESCRIPTION
## Description

The [accessibility page in Vanilla's documentation](https://vanillaframework.io/accessibility) links to WAI's report tool however, the link appears to be broken. 

Currently the link navigates to the [Overview Page](https://www.w3.org/WAI/eval/report-tool) (instead of the [Audit Page](https://www.w3.org/WAI/eval/report-tool/evaluation/audit-sample)) of the report tool and the broken link also throws an error in browser console. 
![Screenshot from 2024-12-06 10-59-18](https://github.com/user-attachments/assets/2063cb6c-4618-44ae-a270-0564c2c266e4)

The W3C report tool [changed their route links](https://github.com/Dinika/wai-wcag-em-report-tool/commit/329a637c69c726fab9d7f6dfec40509fa9c1913f#diff-79cbc9000cd82c2fb5785502b45377ec6948531a359e0be13f5369a2adb52184L77). This PR update the link to navigate to their new audit page.

![Screenshot from 2024-12-06 11-14-57](https://github.com/user-attachments/assets/6cd55591-3b3a-4350-80a1-c15979d24f09)

## QA

- Open [accessibility page](https://vanilla-framework-5428.demos.haus/accessibility)
- Verify the "Accessibility report tool" link's description is accurate and the link navigates to the WAI's report tool

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
