### PR TITLE
docs: Update tiered list jinja template docs to use semantic structure

### DIFF
--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta.html
@@ -24,7 +24,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_1' -%}
-    <h5>Rich portfolio of products</h5>
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_1' -%}
@@ -34,7 +34,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_2' -%}
-    <h5>Sales enablement</h5>
+    <h3 class="p-heading--5">Sales enablement</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_2' -%}
@@ -44,7 +44,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_3' -%}
-    <h5>Access to Canonical partner portal</h5>
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_3' -%}
@@ -53,7 +53,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_4' -%}
-    <h5>Training and certification</h5>
+    <h3 class="p-heading--5">Training and certification</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_4' -%}
@@ -63,7 +63,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_5' -%}
-    <h5>Technical enablement</h5>
+    <h3 class="p-heading--5">Technical enablement</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_5' -%}
@@ -73,7 +73,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_6' -%}
-    <h5>Go to market with Canonical</h5>
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_6' -%}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description.html
@@ -19,7 +19,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_1' -%}
-    <h5>Rich portfolio of products</h5>
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_1' -%}
@@ -29,7 +29,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_2' -%}
-    <h5>Sales enablement</h5>
+    <h3 class="p-heading--5">Sales enablement</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_2' -%}
@@ -39,7 +39,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_3' -%}
-    <h5>Access to Canonical partner portal</h5>
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_3' -%}
@@ -48,7 +48,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_4' -%}
-    <h5>Training and certification</h5>
+    <h3 class="p-heading--5">Training and certification</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_4' -%}
@@ -58,7 +58,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_5' -%}
-    <h5>Technical enablement</h5>
+    <h3 class="p-heading--5">Technical enablement</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_5' -%}
@@ -68,7 +68,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_6' -%}
-    <h5>Go to market with Canonical</h5>
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_6' -%}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-list-item-cta.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-list-item-cta.html
@@ -19,7 +19,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_1' -%}
-    <h5>Rich portfolio of products</h5>
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_1' -%}
@@ -34,7 +34,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_2' -%}
-    <h5>Sales enablement</h5>
+    <h3 class="p-heading--5">Sales enablement</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_2' -%}
@@ -44,7 +44,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_3' -%}
-    <h5>Access to Canonical partner portal</h5>
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_3' -%}
@@ -53,7 +53,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_4' -%}
-    <h5>Training and certification</h5>
+    <h3 class="p-heading--5">Training and certification</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_4' -%}
@@ -63,7 +63,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_5' -%}
-    <h5>Technical enablement</h5>
+    <h3 class="p-heading--5">Technical enablement</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_5' -%}
@@ -73,7 +73,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_6' -%}
-    <h5>Go to market with Canonical</h5>
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_6' -%}

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description.html
@@ -19,7 +19,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_1' -%}
-    <h5>Rich portfolio of products</h5>
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_1' -%}
@@ -29,7 +29,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_2' -%}
-    <h5>Sales enablement</h5>
+    <h3 class="p-heading--5">Sales enablement</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_2' -%}
@@ -39,7 +39,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_3' -%}
-    <h5>Access to Canonical partner portal</h5>
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_3' -%}
@@ -48,7 +48,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_4' -%}
-    <h5>Training and certification</h5>
+    <h3 class="p-heading--5">Training and certification</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_4' -%}
@@ -58,7 +58,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_5' -%}
-    <h5>Technical enablement</h5>
+    <h3 class="p-heading--5">Technical enablement</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_5' -%}
@@ -68,7 +68,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_6' -%}
-    <h5>Go to market with Canonical</h5>
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_6' -%}

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description.html
@@ -12,7 +12,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_1' -%}
-    <h5>Rich portfolio of products</h5>
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_1' -%}
@@ -22,7 +22,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_2' -%}
-    <h5>Sales enablement</h5>
+    <h3 class="p-heading--5">Sales enablement</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_2' -%}
@@ -32,7 +32,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_3' -%}
-    <h5>Access to Canonical partner portal</h5>
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_3' -%}
@@ -41,7 +41,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_4' -%}
-    <h5>Training and certification</h5>
+    <h3 class="p-heading--5">Training and certification</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_4' -%}
@@ -51,7 +51,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_5' -%}
-    <h5>Technical enablement</h5>
+    <h3 class="p-heading--5">Technical enablement</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_5' -%}
@@ -61,7 +61,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_6' -%}
-    <h5>Go to market with Canonical</h5>
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_6' -%}

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description.html
@@ -19,7 +19,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_1' -%}
-    <h5>Rich portfolio of products</h5>
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_1' -%}
@@ -29,7 +29,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_2' -%}
-    <h5>Sales enablement</h5>
+    <h3 class="p-heading--5">Sales enablement</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_2' -%}
@@ -39,7 +39,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_3' -%}
-    <h5>Access to Canonical partner portal</h5>
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_3' -%}
@@ -48,7 +48,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_4' -%}
-    <h5>Training and certification</h5>
+    <h3 class="p-heading--5">Training and certification</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_4' -%}
@@ -58,7 +58,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_5' -%}
-    <h5>Technical enablement</h5>
+    <h3 class="p-heading--5">Technical enablement</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_5' -%}
@@ -68,7 +68,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_6' -%}
-    <h5>Go to market with Canonical</h5>
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_6' -%}

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description.html
@@ -19,7 +19,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_1' -%}
-    <h5>Rich portfolio of products</h5>
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_1' -%}
@@ -29,7 +29,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_2' -%}
-    <h5>Sales enablement</h5>
+    <h3 class="p-heading--5">Sales enablement</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_2' -%}
@@ -39,7 +39,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_3' -%}
-    <h5>Access to Canonical partner portal</h5>
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_3' -%}
@@ -48,7 +48,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_4' -%}
-    <h5>Training and certification</h5>
+    <h3 class="p-heading--5">Training and certification</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_4' -%}
@@ -58,7 +58,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_5' -%}
-    <h5>Technical enablement</h5>
+    <h3 class="p-heading--5">Technical enablement</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_5' -%}
@@ -68,7 +68,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_6' -%}
-    <h5>Go to market with Canonical</h5>
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_6' -%}

--- a/templates/docs/examples/patterns/tiered-list/full-width-without-description.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-without-description.html
@@ -12,7 +12,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_1' -%}
-    <h5>Rich portfolio of products</h5>
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_1' -%}
@@ -22,7 +22,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_2' -%}
-    <h5>Sales enablement</h5>
+    <h3 class="p-heading--5">Sales enablement</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_2' -%}
@@ -32,7 +32,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_3' -%}
-    <h5>Access to Canonical partner portal</h5>
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_3' -%}
@@ -41,7 +41,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_4' -%}
-    <h5>Training and certification</h5>
+    <h3 class="p-heading--5">Training and certification</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_4' -%}
@@ -51,7 +51,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_5' -%}
-    <h5>Technical enablement</h5>
+    <h3 class="p-heading--5">Technical enablement</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_5' -%}
@@ -61,7 +61,7 @@
   {%- endif -%}
 
   {%- if slot == 'list_item_title_6' -%}
-    <h5>Go to market with Canonical</h5>
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
   {%- endif -%}
 
   {%- if slot == 'list_item_description_6' -%}

--- a/templates/docs/patterns/tiered-list/index.md
+++ b/templates/docs/patterns/tiered-list/index.md
@@ -95,11 +95,11 @@ In addition to the CTA block placed below the list, you may also add CTA blocks
 below the top-level description text, as well as below each list item's
 description text.
 
-<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta/" class="js-example" data-lang="jinja">
 View example of the tiered list pattern
 </a></div>
 
-<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/50-50-desktop-with-list-item-cta/" class="js-example">
+<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/50-50-desktop-with-list-item-cta/" class="js-example" data-lang="jinja">
 View example of the tiered list pattern
 </a></div>
 


### PR DESCRIPTION
## Done

- Update `<h5>` to `<h3 class="p-heading--5">` in tiered list jinja template docs
- Add `data-lang="jinja"` to some examples that were missing it

## QA

- Open [demo](https://vanilla-framework-5429.demos.haus/)
- Review updated documentation:
  - Check the headings follow semantic structure ie. not skipping levels, [see reference](https://webaim.org/techniques/headings/)
  - Check all examples display jinja templates

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
