### PR TITLE
chore: contribution guidelines/issue creation updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/propose-changes-to-existing-component.md
+++ b/.github/ISSUE_TEMPLATE/propose-changes-to-existing-component.md
@@ -2,7 +2,7 @@
 name: Propose changes to existing component
 about: This template allows users to propose an amendment to an existing component
   or pattern
-title: ''
+title: '[Component amendment]: <Component name>'
 labels: 'WG: Proposal'
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/propose-new-component.md
+++ b/.github/ISSUE_TEMPLATE/propose-new-component.md
@@ -1,7 +1,7 @@
 ---
 name: Propose new component
 about: This template allows users to propose a new pattern or component
-title: ''
+title: '[New component]: <Component name>'
 labels: 'WG: Proposal'
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/report-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-a-bug.md
@@ -1,7 +1,7 @@
 ---
 name: Report a bug
 about: Create a bug report to help us improve Vanilla framework or our site
-title: ''
+title: '[Bug]: <Short description of the bug>'
 labels: "Bug \U0001F41B"
 assignees: ''
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ As developers and maintainers of the Vanilla project, we follow a [Code of Condu
 
 We use the [GitHub issues](https://github.com/canonical/vanilla-framework/issues) to track all our bugs and feature requests.
 
-When [submitting a new issue](https://github.com/canonical/vanilla-framework/issues/new), please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.
+When [submitting a new issue](https://github.com/canonical/vanilla-framework/issues/new/choose), please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.
 
 Please provide as much information possible detailing what you're currently experiencing and what you'd expect to experience.
 


### PR DESCRIPTION
## Done

- Updates link in the contribution documentation to go to the [issue template chooser](https://github.com/canonical/vanilla-framework/issues/new/choose), instead of an [empty new issue](https://github.com/canonical/vanilla-framework/issues/new/).
- Auto-suggests a title for new issues created by the issue templates

Fixes [thread](https://chat.canonical.com/canonical/pl/34ytx7p7pfgomr7uoxexogu8cy) by @EnzoYD

## QA

- See that the link in the contribution guidelines for this PR links to the issue template chooser.
- I'm not aware of a way to QA the issue names.

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
