### PR TITLE
Conditionally render the shallow padded block for subtitle_text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.18.4",
+  "version": "4.18.5",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/templates/_macros/vf_hero.jinja
+++ b/templates/_macros/vf_hero.jinja
@@ -142,9 +142,11 @@
           {{ _hero_title_block() }}
         </div>
         <div class="{{ col_classes[1] }}">
-          <div class="p-section--shallow">
-            {{- _hero_subtitle_block() -}}
-          </div>
+          {% if has_subtitle %}
+            <div class="p-section--shallow">
+              {{- _hero_subtitle_block() -}}
+            </div>
+          {% endif %}
           {{- _hero_description_block() -}}
           {{- _hero_cta_block() -}}
         </div>

--- a/templates/docs/examples/patterns/hero/combined.html
+++ b/templates/docs/examples/patterns/hero/combined.html
@@ -19,6 +19,7 @@
 <section>{% include 'docs/examples/patterns/hero/hero-signpost-full-width-image.html' %}</section>
 <section>{% include 'docs/examples/patterns/hero/hero-50-50.html' %}</section>
 <section>{% include 'docs/examples/patterns/hero/hero-50-50-full-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/hero/hero-50-50-full-width-image-without-subtitle_text.html' %}</section>
 <section>{% include 'docs/examples/patterns/hero/hero-50-50-split-on-medium.html' %}</section>
 <section>{% include 'docs/examples/patterns/hero/hero-75-25.html' %}</section>
 <section>{% include 'docs/examples/patterns/hero/hero-fallback.html' %}</section>

--- a/templates/docs/examples/patterns/hero/hero-50-50-full-width-image-without-subtitle_text.html
+++ b/templates/docs/examples/patterns/hero/hero-50-50-full-width-image-without-subtitle_text.html
@@ -1,0 +1,31 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+
+{% block title %}Hero / 50/50 / Full width image{% endblock %}
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% set is_paper = true %}
+{% block content %}
+
+{% call(slot) vf_hero(
+  title_text='H1 - ideally one line, up to two',
+  layout='50/50-full-width-image'
+) -%}
+  {%- if slot == 'description' -%}
+    <p>
+      Generally, the height of the right hand side of a 50/50 split should contain more content than the left
+      hand side.
+    </p>
+  {%- endif -%}
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button--positive">Learn more</a>
+    <a href="#">Contact us ›</a>
+  {%- endif -%}
+  {%- if slot == 'image' -%}
+    <div class="p-image-container--cinematic is-cover">
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/a299c914-GettyImages-DataCenter.jpeg" alt="">
+    </div>
+  {% endif -%}
+{% endcall -%}
+
+{% endblock %}

--- a/templates/docs/examples/patterns/hero/hero-50-50-full-width-image-without-subtitle_text.html
+++ b/templates/docs/examples/patterns/hero/hero-50-50-full-width-image-without-subtitle_text.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_hero.jinja" import vf_hero %}
 
-{% block title %}Hero / 50/50 / Full width image{% endblock %}
+{% block title %}Hero / 50/50 / Without subtitle{% endblock %}
 {% block standalone_css %}patterns_all{% endblock %}
 
 {% set is_paper = true %}


### PR DESCRIPTION
## Done

- Conditional rendering of shallow padded block for the hero pattern `hero-50-50-full-width-image`.

## QA
- Check out this branch
- Open the file `docs/examples/patterns/hero/hero-50-50-full-width-image`
- Remove the `subtitle_text` parameter from macro call.
-  View the site locally at http://localhost:8101/docs/examples/patterns/hero/hero-50-50-full-width-image
- Note that the left heading and right description are now aligned and there's no shallow padded empty block above description.

## Screenshots
Before, without providing subtitle_text
![image](https://github.com/user-attachments/assets/b4649b49-338f-4d89-8f4d-3cccc80cc354)


After, without providing subtitle_text
![image](https://github.com/user-attachments/assets/554e3940-4e10-48fc-86b1-5c99827a663f)
