### PR TITLE
Full width image Hero - Remove margin bottom from H1 only if the subtitle_text is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.19.1",
+  "version": "4.19.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.19.0",
+  "version": "4.19.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/templates/_macros/vf_hero.jinja
+++ b/templates/_macros/vf_hero.jinja
@@ -73,8 +73,10 @@
 
   {%- macro _hero_title_block() -%}
     {%- if has_full_width_image -%}
+      {%- if has_subtitle -%}
       {#- On full-width-image, the h1 and h2 are in separate columns, so there must be no margin-bottom to keep h1 close to h2 on smaller screens  -#}
-      {% set title_class = "u-no-margin--bottom" %}
+        {% set title_class = "u-no-margin--bottom" %}
+      {%- endif -%}
     {%- endif -%}
 
     {#- Only add a class attribute if needed -#}


### PR DESCRIPTION
## Done

- Removed margin from H1 only when the subtitle_text is not provided.

## QA

- View the old [hero-50-50-full-width-image](https://vanillaframework.io/docs/examples/patterns/hero/hero-50-50-full-width-image-without-subtitle_text) in your web browser.
   - Make sure you are previewing in a smaller screen size.
- Notice the missing space between H1 and description paragraph.
- Now, open the [hero-50-50-full-width-image](https://vanilla-framework-5443.demos.haus/docs/examples/patterns/hero/hero-50-50-full-width-image-without-subtitle_text) in your web browser.
   - Make sure you are previewing in a smaller screen size.
- Verify the presence of spacing between H1 and the description paragraph.


## Screenshots

Before:
![image](https://github.com/user-attachments/assets/a1a1dda7-18c7-4aab-ba29-9e914ad01db8)

After:
![image](https://github.com/user-attachments/assets/711df7ed-78e6-4a4c-bfd2-5e12c5817422)

