### PR TITLE
fix(vf_tiered-list.jinja): Update to have top hr on all screen sizes

### DIFF
--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -19,7 +19,7 @@
   {%- set has_cta = cta_content|trim|length > 0 -%}
 
   <div class="u-fixed-width">
-    <hr class="u-hide--small">
+    <hr class="p-rule">
 
     {% if has_description == true -%}
       {%- if is_description_full_width_on_desktop == true -%}


### PR DESCRIPTION
## Done

- Removes `u-hide--small` class from top `<hr>` in vf_tiered-list jinja template

## QA

- Open [demo](https://vanilla-framework-5444.demos.haus/docs/examples/patterns/tiered-list/combined?theme=light)
- Check the top hr in the pattern is retained on all screen sizes

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
<img width="380" alt="Screenshot 2025-01-16 at 12 49 11" src="https://github.com/user-attachments/assets/c99f0466-2fb9-4044-af34-f1f447dcb972" />


