### PR TITLE
fix(hero): 50/50 with no image is laid out in split columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.20.0",
+  "version": "4.20.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.20.1
+  features:
+    - component: Hero
+      url: /docs/patterns/hero#5050-with-no-image-new
+      status: Updated
+      notes: We've added support for 50/50 hero sections with no image.
 - version: 4.20.0
   features:
     - component: List

--- a/templates/_macros/vf_hero.jinja
+++ b/templates/_macros/vf_hero.jinja
@@ -32,6 +32,8 @@
     {% set layout = 'fallback' %}
   {% endif %}
 
+  {% set is_50_50_no_image = (layout == "50-50" and not has_image) %}
+
   {% if layout == '50-50-full-width-image' and has_image %}
     {% set layout = '50-50' %}
     {% set has_full_width_image = true %}
@@ -72,9 +74,9 @@
   {% endif %}
 
   {%- macro _hero_title_block() -%}
-    {%- if has_full_width_image -%}
+    {%- if has_full_width_image or is_50_50_no_image -%}
       {%- if has_subtitle -%}
-      {#- On full-width-image, the h1 and h2 are in separate columns, so there must be no margin-bottom to keep h1 close to h2 on smaller screens  -#}
+      {#- On full-width-image and 50/50 with no image, the h1 and h2 are in separate columns, so there must be no margin-bottom to keep h1 close to h2 on smaller screens  -#}
         {% set title_class = "u-no-margin--bottom" %}
       {%- endif -%}
     {%- endif -%}
@@ -139,7 +141,7 @@
             {{ image_content }}
           </div>
         {% endif -%}
-      {% elif has_full_width_image and not has_signpost_image %}
+      {% elif (has_full_width_image and not has_signpost_image) or is_50_50_no_image %}
         <div class="{{ col_classes[0] }}">
           {{ _hero_title_block() }}
         </div>

--- a/templates/docs/examples/patterns/hero/combined.html
+++ b/templates/docs/examples/patterns/hero/combined.html
@@ -23,5 +23,6 @@
 <section>{% include 'docs/examples/patterns/hero/hero-50-50-split-on-medium.html' %}</section>
 <section>{% include 'docs/examples/patterns/hero/hero-75-25.html' %}</section>
 <section>{% include 'docs/examples/patterns/hero/hero-fallback.html' %}</section>
+<section>{% include 'docs/examples/patterns/hero/hero-50-50-no-image.html' %}</section>
 {% endwith %}
 {% endblock %}

--- a/templates/docs/examples/patterns/hero/hero-50-50-no-image.html
+++ b/templates/docs/examples/patterns/hero/hero-50-50-no-image.html
@@ -1,0 +1,27 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+
+{% block title %}Hero / 50/50 / Without image{% endblock %}
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% set is_paper = true %}
+{% block content %}
+
+{% call(slot) vf_hero(
+  title_text='H1 - ideally one line, up to two',
+  subtitle_text='H2 placeholder - aim for one line, 2 is acceptable, more - use a paragraph',
+  layout='50/50'
+) -%}
+    {%- if slot == 'description' -%}
+      <p>
+        Generally, the height of the right hand side of a 50/50 split should contain more content than the left
+        hand side.
+      </p>
+    {%- endif -%}
+    {%- if slot == 'cta' -%}
+      <a href="#" class="p-button--positive">Learn more</a>
+      <a href="#">Contact us ›</a>
+    {%- endif -%}
+{% endcall -%}
+
+{% endblock %}

--- a/templates/docs/patterns/hero/index.md
+++ b/templates/docs/patterns/hero/index.md
@@ -113,7 +113,7 @@ This places the title and subtitle in their own row above the rest of the hero c
 View example of the hero pattern in fallback configuration
 </a></div>
 
-## Jinja Macro {{ status("new") }}
+## Jinja Macro
 
 The `vf_hero` Jinja macro can be used to generate a hero pattern. The API for the macro is shown below.
 
@@ -270,7 +270,7 @@ The `vf_hero` Jinja macro can be used to generate a hero pattern. The API for th
   </table>
 </div>
 
-## Import {{ status("updated") }}
+## Import
 
 ### Jinja Macro
 

--- a/templates/docs/patterns/hero/index.md
+++ b/templates/docs/patterns/hero/index.md
@@ -13,6 +13,7 @@ Depending on the size and composition of your content, you can choose from a var
 
 - [50/50](#5050)
 - [50/50 with full-width image](#5050-with-full-width-image)
+- [50/50 with no image](#5050-with-no-image-new)
 - [25/75 Signpost](#2575-signpost)
 - [75/25](#7525)
 - [Fallback](#fallback)
@@ -62,6 +63,14 @@ This will make the image take up the full width of the hero.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/hero/hero-50-50-full-width-image" class="js-example" data-lang="jinja">
 View example of the hero pattern in 50/50 split with a full-width image
+</a></div>
+
+### 50/50 with no image {{ status("new") }}
+
+This layout positions the title in the left half of the hero, and the rest of the text content in the right half.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/hero/hero-50-50-no-image" class="js-example" data-lang="jinja">
+View example of the hero pattern in 50/50 split with no image
 </a></div>
 
 ## 25/75 "signpost"

--- a/templates/docs/patterns/tiered-list/index.md
+++ b/templates/docs/patterns/tiered-list/index.md
@@ -103,7 +103,7 @@ View example of the tiered list pattern
 View example of the tiered list pattern
 </a></div>
 
-## Jinja Macro {{ status("new") }}
+## Jinja Macro
 
 The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. The API for the macro is shown below.
 
@@ -231,7 +231,7 @@ The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. 
   </table>
 </div>
 
-## Import {{ status("updated") }}
+## Import
 
 ### Jinja Macro
 

--- a/templates/docs/utilities/align.md
+++ b/templates/docs/utilities/align.md
@@ -22,7 +22,7 @@ If you only need text to be aligned, you can use the `u-align-text` utilities.
 View example of the text align utility
 </a></div>
 
-## Vertical alignment {{ status("new") }}
+## Vertical alignment
 
 If you need to vertically align inline elements to the middle of their
 container, you can use the `u-vertical-align--middle` utility.


### PR DESCRIPTION
## Done

- Adjusts the hero pattern to split its left and right columns when `layout="50/50"` and no image is provided. 
- Drive-by: removes docs section new/updated status labels for changes that were made several months ago.

No API changes have been made. 

Fixes #5449 
Fixes [WD-18357](https://warthogs.atlassian.net/browse/WD-18357)

## QA

- Open [example](https://vanilla-framework-5450.demos.haus/docs/examples/patterns/hero/hero-50-50-no-image) and verify it appears as expected.
- Review [updated Hero docs](https://vanilla-framework-5450.demos.haus/docs/patterns/hero#5050-with-no-image-new)
- Review [4.20.1 release notes](https://vanilla-framework-5450.demos.haus/docs/whats-new)

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![Screenshot from 2025-01-22 17-44-38](https://github.com/user-attachments/assets/b9208daf-7958-4705-a9e0-7cc2f336b161)
![Screenshot from 2025-01-22 17-44-28](https://github.com/user-attachments/assets/c6b83ba8-d069-4f44-932e-838699eca963)
![Screenshot from 2025-01-22 17-44-14](https://github.com/user-attachments/assets/3c3c6786-9b18-4e6b-9c3b-84b3f5af49f1)



[WD-18357]: https://warthogs.atlassian.net/browse/WD-18357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ