### PR TITLE
fix(tabs): Bottom border of `.p-tabs__list` spans full width on all screen sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.20.1",
+  "version": "4.20.2",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -9,7 +9,7 @@
 
     &__list {
       // inset box shadow used to draw the border inside the list's box
-      box-shadow: inset 0 -#{$input-border-thickness} 0 0 $colors--theme--border-default;
+      box-shadow: inset 0 -1px 0 0 $colors--theme--border-default;
       display: flex;
       margin: 0 auto $spv--x-large;
       overflow-x: auto;

--- a/scss/_patterns_tabs.scss
+++ b/scss/_patterns_tabs.scss
@@ -8,8 +8,8 @@
     position: relative;
 
     &__list {
-      @extend %vf-pseudo-border--bottom;
-
+      // inset box shadow used to draw the border inside the list's box
+      box-shadow: inset 0 -#{$input-border-thickness} 0 0 $colors--theme--border-default;
       display: flex;
       margin: 0 auto $spv--x-large;
       overflow-x: auto;
@@ -17,9 +17,6 @@
       position: relative;
       white-space: nowrap;
       width: 100%;
-      &::after {
-        background-color: $colors--theme--border-default;
-      }
     }
 
     &__item {


### PR DESCRIPTION
## Done

Adjusts the border of the `p-tabs__list` so that it spans full width on all screen sizes.
Previously, a pseudoelement `.p-tabs__list::after` was used as a pseudo-border, but this pseudo-border spanned the width of `.p-tabs__list`, which is a horizontally scrolling flex container. So, the border spans the constrained width of the container, not the width of the list itself.

This alters the border to use an inset box shadow, basing the border sizing off of the box model of `p-tabs__list` instead. This correctly forces the bottom border to span the full width of the tabs list on all screen sizes. 

Fixes #5446 
Fixes [WD-18333](https://warthogs.atlassian.net/browse/WD-18333)

## QA

- Open tab variants and verify the bottom border of the tabs list spans the full width of the body on all screen sizes, especially when the screen is small enough to cause the tabs list to scroll horizontally. Make sure you scroll to the right as well.
  - [Tabbed content](https://vanilla-framework-5457.demos.haus/docs/examples/patterns/tabs/content?theme=light)
  - [Navigation](https://vanilla-framework-5457.demos.haus/docs/examples/patterns/tabs/navigation?theme=light)
  - [Badges/tabs](https://vanilla-framework-5457.demos.haus/docs/examples/patterns/badge/tabs?theme=light)
  - The tabs on docs pages (i.e. component implementation/accessibility/design guidelines tabs) - [badge](https://vanilla-framework-5457.demos.haus/docs/patterns/badge) for example

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

### Tabbed content
#### Before
![image](https://github.com/user-attachments/assets/35132b81-a806-4dcd-8cf2-eef6a54b6925)

#### After
![image](https://github.com/user-attachments/assets/a2e4fb54-9fc6-4a8e-860f-58491711405a)

### Docs
#### Before
![image](https://github.com/user-attachments/assets/00a8c55f-68ec-4eae-be53-44c74171e973)

#### After
![image](https://github.com/user-attachments/assets/72662729-a541-4a2b-9ed0-c2b69643950a)



[WD-18333]: https://warthogs.atlassian.net/browse/WD-18333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ