### PR TITLE
Fix wrapping items in right side of navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.20.2",
+  "version": "4.20.3",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -231,6 +231,10 @@ $navigation-height: calc(map-get($line-heights, default-text) + 2 * $spv--large)
       // shift navigation items by the size of grid margin to align with grid
       .p-navigation__items:first-child {
         margin-left: calc(-1 * $sph--large);
+      }
+
+      // if there is only one navigation items list, extend it to the full width (taking into account margin shift)
+      .p-navigation__items:first-child:not(:has(+ .p-navigation__items)) {
         width: calc(100% + $sph--large);
       }
 

--- a/templates/docs/examples/patterns/navigation/search.html
+++ b/templates/docs/examples/patterns/navigation/search.html
@@ -46,6 +46,9 @@
             <span class="p-navigation__search-label">Search</span>
           </button>
         </li>
+        <li class="p-navigation__item">
+          <a class="p-navigation__link" href="#">Sign in</a>
+        </li>
       </ul>
       <div class="p-navigation__search">
         <form class="p-search-box">

--- a/templates/docs/examples/patterns/navigation/sliding-search.html
+++ b/templates/docs/examples/patterns/navigation/sliding-search.html
@@ -113,9 +113,6 @@
             <span class="p-navigation__search-label">Search</span>
           </button>
         </li>
-        <li class="p-navigation__item">
-          <a class="p-navigation__link" href="#">Sign in</a>
-        </li>
       </ul>
       <div class="p-navigation__search">
         <form class="p-search-box">

--- a/templates/docs/examples/patterns/navigation/sliding-search.html
+++ b/templates/docs/examples/patterns/navigation/sliding-search.html
@@ -113,6 +113,9 @@
             <span class="p-navigation__search-label">Search</span>
           </button>
         </li>
+        <li class="p-navigation__item">
+          <a class="p-navigation__link" href="#">Sign in</a>
+        </li>
       </ul>
       <div class="p-navigation__search">
         <form class="p-search-box">


### PR DESCRIPTION
## Done

Fixes issue found when debugging WD-18308.
When right part of top navigation contains more than one item, they get wrapped.

This seems to be caused by width set on `p-navigation__items` (needed for when it's the only part of navigation).

This PR moves the width setting to specifically the situation when it's needed (when it's the first and the only element with `p-navigation__items` class).

## QA

TBA (when demo is ready)…

- Open [demo](https://vanilla-framework-5461.demos.haus/docs/examples/patterns/navigation/search?theme=dark)
- Make sure that "search" and "sign in" items don't wrap
- Review [all navigation examples](https://vanilla-framework-5461.demos.haus/docs/examples/patterns/navigation/combined?theme=light) to make sure there are no regressions

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

Before

<img width="1405" alt="image" src="https://github.com/user-attachments/assets/6e73c74a-10e0-450c-b039-309fecc685ef" />



After

<img width="1405" alt="image" src="https://github.com/user-attachments/assets/fd1f65ca-3456-4bc8-ae45-b0d4a3afb65b" />


