### PR TITLE
feat: Create modifier class to 'no-full-stop' be applied to 'p-stepped-list' and it's variants

### DIFF
--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -426,6 +426,13 @@ $list-step-bullet-margin: $sph--x-large;
 
     margin-bottom: 0; // spacing has been moved onto __item; this ensures that the heading / paragraph spacing matches that of regular headings / paragraphs
     margin-left: 0;
+
+    &.no-full-stop {
+      .p-stepped-list__title::before {
+        content: counter(p-stepped-list-counter);
+        text-align: left;
+      }
+    }
   }
 
   .p-stepped-list__item {
@@ -543,6 +550,13 @@ $list-step-bullet-margin: $sph--x-large;
           right: 0;
           top: 0;
         }
+      }
+    }
+
+    &.no-full-stop {
+      .p-stepped-list__title::before {
+        content: counter(p-stepped-list-counter);
+        text-align: left;
       }
     }
   }

--- a/templates/docs/examples/patterns/lists/lists-stepped-no-full-stop.html
+++ b/templates/docs/examples/patterns/lists/lists-stepped-no-full-stop.html
@@ -1,0 +1,36 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Lists / Stepped{% endblock %}
+
+{% block standalone_css %}patterns_lists{% endblock %}
+
+{% block content %}
+<ol class="p-stepped-list no-full-stop">
+  <li class="p-stepped-list__item">
+    <h2 class="p-stepped-list__title">
+      Log in to JAAS
+    </h2>
+    <p class="p-stepped-list__content">Ensure you have an Ubuntu SSO account before contacting JAAS. Log in to JAAS now.</p>
+  </li>
+
+  <li class="p-stepped-list__item">
+    <h2 class="p-stepped-list__title">
+      Configure a model
+    </h2>
+    <p class="p-stepped-list__content">Applications are contained within models and are installed via charms. Configure your model by pressing the "Start a new model" button.</p>
+  </li>
+
+  <li class="p-stepped-list__item">
+    <h2 class="p-stepped-list__title">
+      Credentials and SSH keys
+    </h2>
+    <p class="p-stepped-list__content">After having selected a cloud, a form will appear for submitting your credentials to JAAS. The below resources are available if you need help with gathering credentials.</p>
+  </li>
+
+  <li class="p-stepped-list__item">
+    <h2 class="p-stepped-list__title">
+      Design and&nbsp;<strong>build</strong>
+    </h2>
+    <p class="p-stepped-list__content">Together, we design your Kubernetes cluster based on your hardware, scale, roadmap, applications and monitoring system. We'll guide you through the hardware specification process to maximise the efficiency of your CAPEX, and we'll tailor the architecture of your cloud to meet your application, security, regulatory and integration requirements.</p>
+  </li>
+</ol>
+{% endblock %}

--- a/templates/docs/patterns/lists/index.md
+++ b/templates/docs/patterns/lists/index.md
@@ -133,6 +133,14 @@ When the steps don't have headings use `<p>` paragraph as `.p-stepped-list__titl
 View example of the stepped list without headings
 </a></div>
 
+## Vertical stepped no full stop
+
+The a vatient on the stepped list without the full stop and the counter left aligned
+
+<div class="embedded-example"><a href="/docs/examples/patterns/lists/lists-stepped-no-full-stop/" class="js-example">
+View example of the stepped list pattern with no full stop
+</a></div>
+
 ## Horizontal stepped
 
 The stepped list should be used for step-by-step instructions.


### PR DESCRIPTION
## Done

- Create modifier class to 'no-full-stop' be applied to 'p-stepped-list' and it's variants. This removes the full stop and aligns the counter to the left

Fixes https://github.com/canonical/ubuntu.com/pull/14702/files/214ab12ae0503642d147ea6e9f1cfda172c84352#r1940227885 

Fixes #5477 

## QA

- Open [demo](https://vanilla-framework-5465.demos.haus/docs/patterns/lists#vertical-stepped-no-full-stop)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
