### PR TITLE
Added aria-label to Range example

### DIFF
--- a/templates/docs/examples/base/forms/range.html
+++ b/templates/docs/examples/base/forms/range.html
@@ -4,8 +4,8 @@
 {% block standalone_css %}base{% endblock %}
 
 {% block content %}
-<input type="range" min="0" max="100" value="50" step="1" />
-<input type="range" min="0" max="100" value="50" step="1" disabled />
+<input type="range" min="0" max="100" value="50" step="1" aria-label="Enabled Range example"/>
+<input type="range" min="0" max="100" value="50" step="1" disabled aria-label="Disabled Range Example" />
 
 <script>
 var isWebkit =


### PR DESCRIPTION
## Done

Added an aria-label to the inputs in Range example for accessibility purposes. 

Fixes #5416 

## QA

- Check /docs/examples/base/forms/range

Not sure if I should update the package.json version

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

Before
![image](https://github.com/user-attachments/assets/97584062-4e39-4483-bca2-12eec6594b71)

After
![image](https://github.com/user-attachments/assets/61f0d270-97cf-4008-91f1-49d84d58b341)

