### PR TITLE
Nested dropdowns no longer dismiss overlay

### DIFF
--- a/templates/docs/examples/patterns/navigation/_script-sliding.js
+++ b/templates/docs/examples/patterns/navigation/_script-sliding.js
@@ -173,7 +173,9 @@ const initNavigationSliding = () => {
           navigation.classList.add('has-menu-open');
         } else {
           collapseDropdown(toggle, target, true);
-          navigation.classList.remove('has-menu-open');
+          if (!isNested) {
+            navigation.classList.remove('has-menu-open');
+          }
         }
       }
     });


### PR DESCRIPTION
## Done

For the non-mobile version of the component: closing a nested drop-down doesn't dismiss the overlay anymore. Now it is only dismissed when closing the root drop-down.

Fixes #5288

## QA

- Open any of the "sliding" patterns, for example /docs/examples/patterns/navigation/sliding-dark.
- Open "LXCFS" menu, then "Nested Layer". 
- Close "Nested Layer" and compare the behavior with closing "LXCFS" directly. 

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

## Screenshots

This is the pattern I'm talking about:

![image](https://github.com/user-attachments/assets/7de546a1-78cb-4c10-afe5-8e536bd7fd79)

