### PR TITLE
docs(layout settings): Update layout settings docs to reflect new grid variable

### DIFF
--- a/templates/docs/settings/layout-settings.md
+++ b/templates/docs/settings/layout-settings.md
@@ -9,10 +9,10 @@ placed within the grid structure will then adapt to fill the space available to 
 
 | Setting                                                                   | Default value |
 | ------------------------------------------------------------------------- | ------------- |
-| `$grid-gutter-width`                                                      | `20px`        |
+| `$grid-gutter-width`                                                      | `2rem`        |
 | `$grid-8-columns` (new [8 column grid](/docs/patterns/grid))              | `8`           |
 | `$grid-columns` (deprecated [12 column grid](/docs/patterns/grid-legacy)) | `12`          |
-| `$grid-max-width`                                                         | `1030px`      |
+| `$grid-max-width`                                                         | `80rem`       |
 
 ## Import
 

--- a/templates/docs/settings/layout-settings.md
+++ b/templates/docs/settings/layout-settings.md
@@ -4,13 +4,15 @@ context:
   title: Layout | Settings
 ---
 
-These settings are used specifically to configure the grid which will determine your overall site layout. Patterns placed within the grid structure will then adapt to fill the space available to them.
+These settings are used specifically to configure the grid which will determine your overall site layout. Patterns
+placed within the grid structure will then adapt to fill the space available to them.
 
-| Setting              | Default value |
-| -------------------- | ------------- |
-| `$grid-gutter-width` | `20px`        |
-| `$grid-columns`      | `12`          |
-| `$grid-max-width`    | `1030px`      |
+| Setting                                                                   | Default value |
+| ------------------------------------------------------------------------- | ------------- |
+| `$grid-gutter-width`                                                      | `20px`        |
+| `$grid-8-columns` (new [8 column grid](/docs/patterns/grid))              | `8`           |
+| `$grid-columns` (deprecated [12 column grid](/docs/patterns/grid-legacy)) | `12`          |
+| `$grid-max-width`                                                         | `1030px`      |
 
 ## Import
 
@@ -20,4 +22,5 @@ To import just this utility into your project, copy the snippet below and includ
 @import 'utilities_layout';
 ```
 
-For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.
+For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides
+and importing instructions.


### PR DESCRIPTION
## Done

Updates the layout settings documentation per the new 8 column grid

Fixes #5481, [WD-19930](https://warthogs.atlassian.net/browse/WD-19930) 

## QA

- Review [Layout settings docs](https://vanilla-framework-5483.demos.haus/docs/settings/layout-settings)

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![image](https://github.com/user-attachments/assets/0c0e0e7e-4d10-4b0d-9d08-98897693d870)


[WD-19930]: https://warthogs.atlassian.net/browse/WD-19930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ