### PR TITLE
Increase contrast of switch track and thumb

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.21.1",
+  "version": "4.21.2",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -38,7 +38,9 @@ $knob-size: $sp-unit * 2;
   .p-switch__slider {
     background: $colors--theme--background-neutral-default;
     border-radius: $knob-size;
-    box-shadow: inset 0 2px 5px 0 color.scale($color-x-dark, $alpha: -80%);
+    box-shadow:
+      inset 0 0 0 $input-border-thickness $colors--theme--border-high-contrast,
+      inset 0 2px 5px 0 color.scale($color-x-dark, $alpha: -80%);
     display: inline-block;
     height: $knob-size;
     margin: 0;
@@ -50,7 +52,7 @@ $knob-size: $sp-unit * 2;
       @include vf-transition($duration: slow);
 
       background: $colors--theme--background-default;
-      border: $input-border-thickness solid $colors--theme--background-neutral-default;
+      border: $input-border-thickness solid $colors--theme--border-high-contrast;
       border-radius: 50%;
       content: '';
       height: $knob-size;


### PR DESCRIPTION
## Done

Increases color contrast of the switch track and thumb by applying high contrast border color per @lyubomir-popov 's instructions and visual [here](https://github.com/canonical/vanilla-framework/issues/5470#issuecomment-2650423066)

Fixes #5470 , [WD-19209](https://warthogs.atlassian.net/browse/WD-19209)

## QA

- Open switch component
- Verify it looks as expected in all color themes

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![image](https://github.com/user-attachments/assets/433f16d6-2fd9-422a-babb-0025a21ee1bc)
![image](https://github.com/user-attachments/assets/e691dd96-8a40-4e4f-a694-5a1b3d46754a)

