### PR TITLE
Move tiered list padding from CTA to the entire pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.23.0",
+  "version": "4.23.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -18,7 +18,7 @@
   {%- set cta_content = caller('cta') -%}
   {%- set has_cta = cta_content|trim|length > 0 -%}
 
-  <div class="u-fixed-width">
+  <div class="p-section u-fixed-width">
     <hr class="p-rule">
 
     {% if has_description == true -%}
@@ -103,11 +103,11 @@
     </div>
 
     {% if has_cta == true -%}
-      <div class="p-cta-block">
-        <div class="row">
-          <div class="col-6 col-start-large-7">
+      <div class="row">
+        <div class="col-6 col-start-large-7">
+          <p>
             {{ cta_content }}
-          </div>
+          </p>
         </div>
       </div>
     {%- endif %}


### PR DESCRIPTION
## Done

Moves the bottom padding from the tiered list pattern from the CTA block to the pattern as a whole. 

Fixes #5497
Fixes [WD-21392](https://warthogs.atlassian.net/browse/WD-21392)

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).