### PR TITLE
wip: feat(Tiered List): add media (images/videos) to the Tiered List pattern

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1,5 +1,9 @@
 - version: 4.25.0
   features:
+    - component: Tiered list
+      url: /docs/patterns/tiered-list
+      status: Updated
+      notes: We've added support for <a href="/docs/patterns/tiered-list#with-media-new">embedding images or videos</a> to the tiered list pattern.
     - component: CTA Block
       url: /docs/patterns/cta-block
       status: Updated

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask-base==2.5.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.search==2.1.1
-canonicalwebteam.image-template==1.5.0
+canonicalwebteam.image-template==1.6.0
 mistune==0.8.4
 pyyaml==6.0.2

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -3,31 +3,90 @@
 #   desktop vs. 50/50 split between title/description
 # is_list_full_width_on_tablet: whether list title/description each have their
 #   own row on tablet vs. 50/50 split between title/description
-# is_image_full_width: whether the image is full width
+# is_media_full_width: whether the media is full width
+# media_placement: where the image is placed relative to the description. Options are "after_description" or "before_description".
 # Slots
 # title: top-level title element
 # description: top-level description element
-# image: top-level image element
+# video: top-level video element. Mutually exclusive with image, and takes priority over the image.
+# image: top-level image element. Mutually exclusive with video. Is not rendered if the video is provided.
 # list_item_title_[1-25]: title element of each child list item
 # list_item_description_[1-25]: description element of each child list item
 # cta: CTA block element
 {% macro vf_tiered_list(
   is_description_full_width_on_desktop=true,
   is_list_full_width_on_tablet=true,
-  is_image_full_width=false) -%}
+  is_media_full_width=false,
+  media_placement="after_description"
+  ) -%}
   {%- set title_content = caller('title') -%}
   {%- set description_content = caller('description') -%}
   {%- set has_description = description_content|trim|length > 0 -%}
-  {%- set image = caller('image') -%}
-  {%- set has_image = image|trim|length > 0 -%}
+  {%- set image_content = caller('image') -%}
+  {%- set has_image = image_content|trim|length > 0 -%}
   {%- set cta_content = caller('cta') -%}
   {%- set has_cta = cta_content|trim|length > 0 -%}
+  {%- set video_content = caller('video') -%}
+  {%- set has_video = video_content|trim|length > 0 -%}
+  {%- set has_media = has_image or has_video -%}
 
-  <div class="u-fixed-width">
+  {% if media_placement not in ["before_description", "after_description"] %}
+    {% set media_placement = "after_description" %}
+  {% endif %}
+
+  {% set image_aspect_ratio = "16-9" %}
+  {% if is_media_full_width and not is_video %}
+    {% set image_aspect_ratio = "cinematic" %}
+  {% endif %}
+
+  {% macro _wrapped_media() %}
+    {%- if has_media -%}
+      {%- if has_video -%}
+        <div class="p-section--shallow">
+          {#- u-embedded-media applies 16:9 aspect ratio via padding. -#}
+          <div class="u-embedded-media">
+            {#- Assume u-embedded-media__element on the content -#}
+            {{- video_content -}}
+          </div>
+        </div>
+      {%- elif has_image -%}
+        <div class="p-section--shallow">
+          <div class="p-image-container--{{ image_aspect_ratio }} is-cover">
+            {#- Assume p-image-container__image on the content -#}
+            {{- image_content -}}
+          </div>
+        </div>
+      {%- endif -%}
+    {%- endif -%}
+  {% endmacro %}
+
+  {% macro _full_width_media_row() %}
+    {%- if has_media and is_media_full_width -%}
+      <div class="row">
+        <div class="col">
+          {{- _wrapped_media() -}}
+        </div>
+      </div>
+    {%- endif -%}
+  {% endmacro %}
+
+  {%- if title_content|trim|length == 0 -%}
+    {%- set title_content = "<h2>Tiered List</h2>" -%}
+  {%- endif -%}
+
+  {%- if description_content|trim|length == 0 -%}
+    {%- set description_content = "<p>This is a tiered list.</p>" -%}
+  {%- endif -%}
+
+  {%- if cta_content|trim|length == 0 -%}
+    {%- set cta_content = "<p>No CTA provided.</p>" -%}
+  {%- endif -%}
+
+  <div class="p-section u-fixed-width">
     <hr class="p-rule">
 
-    {% if has_description == true -%}
-      {%- if is_description_full_width_on_desktop == true -%}
+    {% if has_description -%}
+      {%- if is_description_full_width_on_desktop -%}
         <div class="u-fixed-width">
           <div class="p-section--shallow">
             {{ title_content }}
@@ -36,10 +95,18 @@
 
         <div class="row">
           <div class="col-6 col-start-large-7">
+            {#- Non-full-width media before description -#}
+            {% if has_media and media_placement == "before_description" and not is_media_full_width %}
+              {{- _wrapped_media() -}}
+            {% endif %}
             {{ description_content }}
+            {#- Non-full-width media after description -#}
+            {% if has_media and media_placement == "after_description" and not is_media_full_width %}
+              {{- _wrapped_media() -}}
+            {% endif %}
           </div>
         </div>
-      {%- else -%}
+      {%- else -%} {#- (50/50 desktop layout) -#}
         <div class="row">
           <div class="col-6">
             <div class="p-section--shallow">
@@ -48,33 +115,38 @@
           </div>
 
           <div class="col-6">
+            {#- Non-full-width media before description -#}
+            {%- if has_media and media_placement == "before_description" and not is_media_full_width -%}
+              {{- _wrapped_media() -}}
+            {%- endif -%}
             {{ description_content }}
+            {#- Non-full-width media after description -#}
+            {%- if has_media and media_placement == "after_description" and not is_media_full_width -%}
+              {{- _wrapped_media() -}}
+            {%- endif -%}
           </div>
         </div>
       {%- endif -%}
-    {%- else -%}
-      <div class="u-fixed-width">
-        <div class="p-section--shallow">
-          {{ title_content }}
+    {%- else -%} {#- No description (has_description is false) -#}
+      <div class="row">
+        {#- No description; the non-full-width media goes directly adjacent to the title -#}
+        <div class="{% if not has_media or is_media_full_width %}col{% else %}col-6{% endif %}">
+          <div class="p-section--shallow">
+            {{ title_content }}
+          </div>
         </div>
+        {% if has_media and not is_media_full_width %}
+          <div class="col-6 col-start-large-7">
+            {{- _wrapped_media() -}}
+          </div>
+        {% endif %}
       </div>
     {%- endif %}
 
-    {% if has_image -%}
-      <div class="row">
-        {%- if is_image_full_width -%}
-          <div class="p-section--shallow">
-            {{ image }}
-          </div>
-        {%- else -%}
-          <div class="col-start-large-7">
-            <div class="p-section--shallow">
-              {{ image }}
-            </div>
-          </div>
-        {%- endif -%}
-      </div>
-    {%- endif -%}
+    {#- Always render full-width media in its own row, after the main title/description/no-description blocks -#}
+    {% if has_media and is_media_full_width %}
+      {{- _full_width_media_row() -}}
+    {% endif %}
 
     {#-
       When there is a CTA, we use shallow spacing to space the list away from the CTA.
@@ -132,11 +204,12 @@
     {%- endif -%}
 
     {% if has_cta == true -%}
-      <div class="p-cta-block">
-        <div class="row">
-          <div class="col-6 col-start-large-7">
+      <div class="row">
+        <hr class="p-rule--muted"/>
+        <div class="col-6 col-start-large-7">
+          <p>
             {{ cta_content }}
-          </div>
+          </p>
         </div>
       </div>
     {%- endif %}

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -3,22 +3,27 @@
 #   desktop vs. 50/50 split between title/description
 # is_list_full_width_on_tablet: whether list title/description each have their
 #   own row on tablet vs. 50/50 split between title/description
+# is_image_full_width: whether the image is full width
 # Slots
 # title: top-level title element
 # description: top-level description element
+# image: top-level image element
 # list_item_title_[1-25]: title element of each child list item
 # list_item_description_[1-25]: description element of each child list item
 # cta: CTA block element
 {% macro vf_tiered_list(
   is_description_full_width_on_desktop=true,
-  is_list_full_width_on_tablet=true) -%}
+  is_list_full_width_on_tablet=true,
+  is_image_full_width=false) -%}
   {%- set title_content = caller('title') -%}
   {%- set description_content = caller('description') -%}
   {%- set has_description = description_content|trim|length > 0 -%}
+  {%- set image = caller('image') -%}
+  {%- set has_image = image|trim|length > 0 -%}
   {%- set cta_content = caller('cta') -%}
   {%- set has_cta = cta_content|trim|length > 0 -%}
 
-  <div class="p-section u-fixed-width">
+  <div class="u-fixed-width">
     <hr class="p-rule">
 
     {% if has_description == true -%}
@@ -54,6 +59,22 @@
         </div>
       </div>
     {%- endif %}
+
+    {% if has_image -%}
+      <div class="row">
+        {%- if is_image_full_width -%}
+        <div class="p-section--shallow">
+          {{ image }}
+        </div>
+        {%- else -%}
+          <div class="col-start-large-5 col-9">
+            <div class="p-section--shallow">
+              {{ image }}
+            </div>
+          </div>
+        {%- endif -%}
+      </div>
+    {%- endif -%}
 
     {#-
       When there is a CTA, we use shallow spacing to space the list away from the CTA.
@@ -111,14 +132,35 @@
     {%- endif -%}
 
     {% if has_cta == true -%}
-      <div class="row">
-        <hr class="p-rule--muted"/>
-        <div class="col-6 col-start-large-7">
-          <p>
+      <div class="p-cta-block"> {# This div adds the shallow spacing around the CTA #}
+        <div class="row">
+          <div class="col-6 col-start-large-7">
             {{ cta_content }}
-          </p>
+          </div>
         </div>
       </div>
     {%- endif %}
   </div>
 {%- endmacro %}
+
+    {%- if image -%}
+      <div class="row">
+        {%- if is_image_full_width -%}
+        <div class="p-section--shallow">
+          {{ image }}
+        </div>
+        {%- else -%}
+          <div class="col-start-large-5 col-9">
+            <div class="p-section--shallow">
+              {{ image }}
+            </div>
+          </div>
+        {%- endif -%}
+      </div>
+    {%- endif -%}
+
+    {#-
+      When there is a CTA, we use shallow spacing to space the list away from the CTA.
+      When there is no CTA, shallow spacing would combine with the pattern-level p-section padding, which introduces too much space.
+    -#}
+    {%- if has_cta -%}

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -67,7 +67,7 @@
           {{ image }}
         </div>
         {%- else -%}
-          <div class="col-start-large-5 col-9">
+          <div class="col-start-large-7">
             <div class="p-section--shallow">
               {{ image }}
             </div>

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -63,13 +63,17 @@
     {% if has_image -%}
       <div class="row">
         {%- if is_image_full_width -%}
-        <div class="p-section--shallow">
-          {{ image }}
-        </div>
+          <div class="p-section--shallow">
+            <div class="p-image-container--cinematic">
+              {{ image }}
+            </div>
+          </div>
         {%- else -%}
           <div class="col-start-large-7">
             <div class="p-section--shallow">
-              {{ image }}
+              <div class="p-image-container--cinematic">
+                {{ image }}
+              </div>
             </div>
           </div>
         {%- endif -%}

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -5,11 +5,11 @@
 #   own row on tablet vs. 50/50 split between title/description
 # is_media_full_width: whether the media is full width
 # media_placement: where the image is placed relative to the description. Options are "after_description" or "before_description".
+# img_attrs: attributes for the image element, e.g. src, alt, class
+# video_attrs: attributes for the video element, e.g. src, class
 # Slots
 # title: top-level title element
 # description: top-level description element
-# video: top-level video element. Mutually exclusive with image, and takes priority over the image.
-# image: top-level image element. Mutually exclusive with video. Is not rendered if the video is provided.
 # list_item_title_[1-25]: title element of each child list item
 # list_item_description_[1-25]: description element of each child list item
 # cta: CTA block element
@@ -17,17 +17,17 @@
   is_description_full_width_on_desktop=true,
   is_list_full_width_on_tablet=true,
   is_media_full_width=false,
-  media_placement="after_description"
+  media_placement="after_description",
+  img_attrs={},
+  video_attrs={}
   ) -%}
   {%- set title_content = caller('title') -%}
   {%- set description_content = caller('description') -%}
   {%- set has_description = description_content|trim|length > 0 -%}
-  {%- set image_content = caller('image') -%}
-  {%- set has_image = image_content|trim|length > 0 -%}
   {%- set cta_content = caller('cta') -%}
   {%- set has_cta = cta_content|trim|length > 0 -%}
-  {%- set video_content = caller('video') -%}
-  {%- set has_video = video_content|trim|length > 0 -%}
+  {%- set has_image = img_attrs['src']|trim|length > 0 -%}
+  {%- set has_video = video_attrs['src']|trim|length > 0 -%}
   {%- set has_media = has_image or has_video -%}
 
   {% if media_placement not in ["before_description", "after_description"] %}
@@ -45,15 +45,27 @@
         <div class="p-section--shallow">
           {#- u-embedded-media applies 16:9 aspect ratio via padding. -#}
           <div class="u-embedded-media">
-            {#- Assume u-embedded-media__element on the content -#}
-            {{- video_content -}}
+            <iframe class="u-embedded-media__element {{ video_attrs['class'] }}"
+            {% for attr, value in video_attrs.items() %}
+              {% if attr != "class" %}
+                {{- attr }}="{{ value }}"
+              {% endif %}
+            {% endfor %}
+            ></iframe>
           </div>
         </div>
       {%- elif has_image -%}
         <div class="p-section--shallow">
           <div class="p-image-container--{{ image_aspect_ratio }} is-cover">
-            {#- Assume p-image-container__image on the content -#}
-            {{- image_content -}}
+            <img
+              {#- Forward classes from the img_attrs. This is optional, on a per-pattern basis. #}
+              class="p-image-container__image {{ img_attrs['class'] }}"
+            {% for attr, value in img_attrs.items() %}
+              {% if attr != "class" %}
+                {{- attr }}="{{ value }}"
+              {% endif %}
+            {% endfor %}
+            >
           </div>
         </div>
       {%- endif -%}

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -64,16 +64,12 @@
       <div class="row">
         {%- if is_image_full_width -%}
           <div class="p-section--shallow">
-            <div class="p-image-container--cinematic">
-              {{ image }}
-            </div>
+            {{ image }}
           </div>
         {%- else -%}
           <div class="col-start-large-7">
             <div class="p-section--shallow">
-              <div class="p-image-container--cinematic">
-                {{ image }}
-              </div>
+              {{ image }}
             </div>
           </div>
         {%- endif -%}
@@ -136,7 +132,7 @@
     {%- endif -%}
 
     {% if has_cta == true -%}
-      <div class="p-cta-block"> {# This div adds the shallow spacing around the CTA #}
+      <div class="p-cta-block">
         <div class="row">
           <div class="col-6 col-start-large-7">
             {{ cta_content }}
@@ -146,25 +142,3 @@
     {%- endif %}
   </div>
 {%- endmacro %}
-
-    {%- if image -%}
-      <div class="row">
-        {%- if is_image_full_width -%}
-        <div class="p-section--shallow">
-          {{ image }}
-        </div>
-        {%- else -%}
-          <div class="col-start-large-5 col-9">
-            <div class="p-section--shallow">
-              {{ image }}
-            </div>
-          </div>
-        {%- endif -%}
-      </div>
-    {%- endif -%}
-
-    {#-
-      When there is a CTA, we use shallow spacing to space the list away from the CTA.
-      When there is no CTA, shallow spacing would combine with the pattern-level p-section padding, which introduces too much space.
-    -#}
-    {%- if has_cta -%}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-default-width-image-before-description.html
@@ -1,14 +1,18 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 with default width image{% endblock %}
+{% block title %}Tiered list / 50/50 on desktop with description CTA{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 
 {% block content %}
-{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, is_image_full_width=false) -%}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, media_placement="before_description") -%}
   {%- if slot == 'title' -%}
     <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
   {%- endif -%}
 
   {%- if slot == 'description' -%}
@@ -16,18 +20,11 @@
     compute, storage and other resources that can be accessed over the network
     and that are reserved exclusively for them - either in their own data centre
     or via a 3rd party.</p>
-  {%- endif -%}
 
-  {%- if slot == "image" -%}
-    {{ image(url="https://assets.ubuntu.com/v1/3f63a18c-data-center.png",
-            alt="",
-            width="2464",
-            height="1028",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-image-container__image"}
-            ) | safe
-    }}
+    <!-- Optional CTA block -->
+    <div class="p-cta-block">
+      <a href="#">Link to blog post &rsaquo;</a>
+    </div>
   {%- endif -%}
 
   {%- if slot == 'list_item_title_1' -%}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-default-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 on desktop with description CTA{% endblock %}
+{% block title %}Tiered list / 50/50 on desktop with description CTA / With default width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-default-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 on desktop with description CTA{% endblock %}
+{% block title %}Tiered list / 50/50 on desktop with description CTA / With default width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-default-width-image.html
@@ -1,0 +1,93 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on desktop with description CTA{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+
+    <!-- Optional CTA block -->
+    <div class="p-cta-block">
+      <a href="#">Link to blog post &rsaquo;</a>
+    </div>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-full-width-image-before-description.html
@@ -1,0 +1,96 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on desktop with description CTA{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, is_media_full_width=true, media_placement="before_description") -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+
+    <!-- Optional CTA block -->
+    <div class="p-cta-block">
+      <a href="#">Link to blog post &rsaquo;</a>
+    </div>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-full-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 on desktop with description CTA{% endblock %}
+{% block title %}Tiered list / 50/50 on desktop with description CTA / With full width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-full-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 on desktop with description CTA{% endblock %}
+{% block title %}Tiered list / 50/50 on desktop with description CTA / With full width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-full-width-image.html
@@ -1,0 +1,96 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on desktop with description CTA{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, is_media_full_width=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+
+    <!-- Optional CTA block -->
+    <div class="p-cta-block">
+      <a href="#">Link to blog post &rsaquo;</a>
+    </div>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-default-width-image-before-description.html
@@ -1,0 +1,88 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 with default width image{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, media_placement="before_description") -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-default-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 with default width image{% endblock %}
+{% block title %}Tiered list / 50/50 with default width image / With default width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-default-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 with default width image{% endblock %}
+{% block title %}Tiered list / 50/50 with default width image / With default width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-default-width-image.html
@@ -1,0 +1,88 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 with default width image{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-full-width-image-before-description.html
@@ -1,0 +1,90 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 with default width image{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, is_media_full_width=true, media_placement="before_description") -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-full-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 with default width image{% endblock %}
+{% block title %}Tiered list / 50/50 with default width image / With full width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-full-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 with default width image{% endblock %}
+{% block title %}Tiered list / 50/50 with default width image / With full width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-full-width-image.html
@@ -6,15 +6,17 @@
 {% block standalone_css %}patterns_all{% endblock %}
 
 {% block content %}
-{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, is_media_full_width=true) -%}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, is_media_full_width=true, img_attrs=image(
+url="https://assets.ubuntu.com/v1/3f63a18c-data-center.png",
+alt="",
+width="2464",
+height="1028",
+hi_def=True,
+loading="auto|lazy",
+output_mode="attrs"
+)) -%}
   {%- if slot == 'title' -%}
     <h2>H2 - up to two lines; ideally one.</h2>
-  {%- endif -%}
-
-  {%- if slot == "image" -%}
-      <img class="p-image-container__image"
-           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
-           width="2464" height="1028" alt="">
   {%- endif -%}
 
   {%- if slot == 'description' -%}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-full-width-image.html
@@ -1,0 +1,90 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 with default width image{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, is_media_full_width=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-default-width-image-before-description.html
@@ -1,0 +1,88 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on tablet with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=false, media_placement="before_description") -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-default-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 on tablet with description{% endblock %}
+{% block title %}Tiered list / 50/50 on tablet with description / With default width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-default-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 on tablet with description{% endblock %}
+{% block title %}Tiered list / 50/50 on tablet with description / With default width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-default-width-image.html
@@ -1,0 +1,88 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on tablet with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=false) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-full-width-image-before-description.html
@@ -1,0 +1,90 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on tablet with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=false, is_media_full_width=true, media_placement="before_description") -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-full-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 on tablet with description{% endblock %}
+{% block title %}Tiered list / 50/50 on tablet with description / With full width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-full-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 on tablet with description{% endblock %}
+{% block title %}Tiered list / 50/50 on tablet with description / With full width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-full-width-image.html
@@ -1,0 +1,90 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on tablet with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=false, is_media_full_width=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-default-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 on tablet without description{% endblock %}
+{% block title %}Tiered list / 50/50 on tablet without description / With default width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-default-width-image-before-description.html
@@ -1,0 +1,81 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on tablet without description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=false, media_placement="before_description") -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-default-width-image.html
@@ -1,0 +1,81 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on tablet without description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=false) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-default-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 on tablet without description{% endblock %}
+{% block title %}Tiered list / 50/50 on tablet without description / With default width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-full-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 on tablet without description{% endblock %}
+{% block title %}Tiered list / 50/50 on tablet without description / With full width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-full-width-image-before-description.html
@@ -1,0 +1,83 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on tablet without description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=false, is_media_full_width=true, media_placement="before_description") -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-full-width-image.html
@@ -1,0 +1,83 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on tablet without description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=false, is_media_full_width=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-full-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 on tablet without description{% endblock %}
+{% block title %}Tiered list / 50/50 on tablet without description / With full width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description-with-default-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 with description{% endblock %}
+{% block title %}Tiered list / 50/50 with description / With default width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description-with-default-width-image-before-description.html
@@ -1,14 +1,18 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 with full width image{% endblock %}
+{% block title %}Tiered list / 50/50 with description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 
 {% block content %}
-{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, is_image_full_width=true) -%}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=false, media_placement="before_description") -%}
   {%- if slot == 'title' -%}
     <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
   {%- endif -%}
 
   {%- if slot == 'description' -%}
@@ -16,18 +20,6 @@
     compute, storage and other resources that can be accessed over the network
     and that are reserved exclusively for them - either in their own data centre
     or via a 3rd party.</p>
-  {%- endif -%}
-
-  {%- if slot == "image" -%}
-    {{ image(url="https://assets.ubuntu.com/v1/3f63a18c-data-center.png",
-            alt="",
-            width="2464",
-            height="1028",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-image-container__image"}
-            ) | safe
-    }}
   {%- endif -%}
 
   {%- if slot == 'list_item_title_1' -%}

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description-with-default-width-image.html
@@ -1,0 +1,88 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=false) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description-with-default-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 with description{% endblock %}
+{% block title %}Tiered list / 50/50 with description / With default width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description-with-full-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 with description{% endblock %}
+{% block title %}Tiered list / 50/50 with description / With full width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description-with-full-width-image-before-description.html
@@ -1,0 +1,90 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=false, is_media_full_width=true, media_placement="before_description") -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description-with-full-width-image.html
@@ -1,0 +1,90 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=false, is_media_full_width=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description-with-full-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 with description{% endblock %}
+{% block title %}Tiered list / 50/50 with description / With full width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-default-width-image-before-description.html
@@ -1,0 +1,83 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 with description / Without CTA{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=false, media_placement="before_description") -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-default-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 with description / Without CTA{% endblock %}
+{% block title %}Tiered list / 50/50 with description / Without CTA / With default width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-default-width-image.html
@@ -1,0 +1,83 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 with description / Without CTA{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=false) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-default-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 with description / Without CTA{% endblock %}
+{% block title %}Tiered list / 50/50 with description / Without CTA / With default width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-full-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 with description / Without CTA{% endblock %}
+{% block title %}Tiered list / 50/50 with description / Without CTA / With full width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-full-width-image-before-description.html
@@ -1,0 +1,85 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 with description / Without CTA{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=false, is_media_full_width=true, media_placement="before_description") -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-full-width-image.html
@@ -1,0 +1,85 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 with description / Without CTA{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=false, is_media_full_width=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-full-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 with description / Without CTA{% endblock %}
+{% block title %}Tiered list / 50/50 with description / Without CTA / With full width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/combined.html
+++ b/templates/docs/examples/patterns/tiered-list/combined.html
@@ -15,7 +15,44 @@
 <section>{% include 'docs/examples/patterns/tiered-list/full-width-without-description.html' %}</section>
 <section>{% include 'docs/examples/patterns/tiered-list/full-width-with-description.html' %}</section>
 <section>{% include 'docs/examples/patterns/tiered-list/full-width-with-description-without-cta.html' %}</section>
-<section>{% include 'docs/examples/patterns/tiered-list/with-default-width-image.html' %}</section>
-<section>{% include 'docs/examples/patterns/tiered-list/with-full-width-image.html' %}</section>
+
+{# All new and renamed files from git status (using their NEW names) #}
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-default-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-default-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-full-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-description-cta-with-full-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-default-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-default-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-full-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-description-with-full-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-default-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-default-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-full-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-full-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-default-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-default-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-full-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-tablet-without-description-with-full-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-with-description-with-default-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-with-description-with-default-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-with-description-with-full-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-with-description-with-full-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-default-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-default-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-full-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-with-description-without-cta-with-full-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/full-width-with-description-with-default-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/full-width-with-description-with-default-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/full-width-with-description-with-full-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/full-width-with-description-with-full-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-default-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-default-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-full-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-full-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/full-width-without-description-with-default-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/full-width-without-description-with-default-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/full-width-without-description-with-full-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/full-width-without-description-with-full-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/video.html' %}</section>
 {% endwith %}
 {% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/combined.html
+++ b/templates/docs/examples/patterns/tiered-list/combined.html
@@ -15,5 +15,7 @@
 <section>{% include 'docs/examples/patterns/tiered-list/full-width-without-description.html' %}</section>
 <section>{% include 'docs/examples/patterns/tiered-list/full-width-with-description.html' %}</section>
 <section>{% include 'docs/examples/patterns/tiered-list/full-width-with-description-without-cta.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/with-default-width-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/with-full-width-image.html' %}</section>
 {% endwith %}
 {% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description-with-default-width-image-before-description.html
@@ -1,0 +1,88 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / Full-width with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=true, media_placement="before_description") -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description-with-default-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / Full-width with description{% endblock %}
+{% block title %}Tiered list / Full-width with description / With default width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description-with-default-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / Full-width with description{% endblock %}
+{% block title %}Tiered list / Full-width with description / With default width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description-with-default-width-image.html
@@ -1,0 +1,88 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / Full-width with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description-with-full-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / Full-width with description{% endblock %}
+{% block title %}Tiered list / Full-width with description / With full width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description-with-full-width-image-before-description.html
@@ -1,0 +1,90 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / Full-width with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=true, is_media_full_width=true, media_placement="before_description") -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description-with-full-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / Full-width with description{% endblock %}
+{% block title %}Tiered list / Full-width with description / With full width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description-with-full-width-image.html
@@ -1,0 +1,90 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / Full-width with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=true, is_media_full_width=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-default-width-image-before-description.html
@@ -1,0 +1,83 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / Full-width with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-default-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / Full-width with description{% endblock %}
+{% block title %}Tiered list / Full-width with description / With default width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-default-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / Full-width with description{% endblock %}
+{% block title %}Tiered list / Full-width with description / With default width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-default-width-image.html
@@ -1,0 +1,83 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / Full-width with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-full-width-image-before-description.html
@@ -1,0 +1,85 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / Full-width with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=true, is_media_full_width=true, media_placement="before_description") -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-full-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / Full-width with description{% endblock %}
+{% block title %}Tiered list / Full-width with description / With full width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-full-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / Full-width with description{% endblock %}
+{% block title %}Tiered list / Full-width with description / With full width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-with-description-without-cta-with-full-width-image.html
@@ -1,0 +1,85 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / Full-width with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=true, is_media_full_width=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/full-width-without-description-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-without-description-with-default-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / Full-width without description{% endblock %}
+{% block title %}Tiered list / Full-width without description / With default width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/full-width-without-description-with-default-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-without-description-with-default-width-image-before-description.html
@@ -1,0 +1,81 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / Full-width without description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=true, media_placement="before_description") -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/full-width-without-description-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-without-description-with-default-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / Full-width without description{% endblock %}
+{% block title %}Tiered list / Full-width without description / With default width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/full-width-without-description-with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-without-description-with-default-width-image.html
@@ -1,0 +1,81 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / Full-width without description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/98b645b4-assessment.png" width="800" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/full-width-without-description-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-without-description-with-full-width-image-before-description.html
@@ -1,0 +1,83 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / Full-width without description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=true, is_media_full_width=true, media_placement="before_description") -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/full-width-without-description-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-without-description-with-full-width-image-before-description.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / Full-width without description{% endblock %}
+{% block title %}Tiered list / Full-width without description / With full width image before description{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/full-width-without-description-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-without-description-with-full-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / Full-width without description{% endblock %}
+{% block title %}Tiered list / Full-width without description / With full width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/full-width-without-description-with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/full-width-without-description-with-full-width-image.html
@@ -1,0 +1,83 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / Full-width without description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=true, is_media_full_width=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+      <img class="p-image-container__image"
+           src="https://assets.ubuntu.com/v1/3f63a18c-data-center.png"
+           width="2464" height="1028" alt="">
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/video.html
+++ b/templates/docs/examples/patterns/tiered-list/video.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / Full-width with description{% endblock %}
+{% block title %}Tiered list / With video{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 

--- a/templates/docs/examples/patterns/tiered-list/video.html
+++ b/templates/docs/examples/patterns/tiered-list/video.html
@@ -1,0 +1,88 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / Full-width with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == 'video' -%}
+    <iframe title="Title of the media object" class="u-embedded-media__element" src="https://www.youtube.com/embed/PZdJiH0bUxY?si=zepeZVY1SXWr-KJo" allowfullscreen=""></iframe>
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/video.html
+++ b/templates/docs/examples/patterns/tiered-list/video.html
@@ -6,7 +6,7 @@
 {% block standalone_css %}patterns_all{% endblock %}
 
 {% block content %}
-{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=true) -%}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=true, video_attrs={"src": "https://www.youtube.com/embed/TShKZLeZzWE", "allowfullscreen": ""}) -%}
   {%- if slot == 'title' -%}
     <h2>H2 - up to two lines; ideally one.</h2>
   {%- endif -%}

--- a/templates/docs/examples/patterns/tiered-list/with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/with-default-width-image.html
@@ -1,0 +1,98 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on desktop with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, is_image_full_width=false) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+  <div class="p-image-container--3-2 is-cover">
+    {{ image(url="https://assets.ubuntu.com/v1/3f63a18c-data-center.png",
+            alt="",
+            width="2464",
+            height="1028",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-image-container__image"}
+            ) | safe
+    }}
+  </div>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/with-default-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 on desktop with description{% endblock %}
+{% block title %}Tiered list / 50/50 with default width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 
@@ -19,7 +19,7 @@
   {%- endif -%}
 
   {%- if slot == "image" -%}
-  <div class="p-image-container--3-2 is-cover">
+  <div class="p-image-container">
     {{ image(url="https://assets.ubuntu.com/v1/3f63a18c-data-center.png",
             alt="",
             width="2464",

--- a/templates/docs/examples/patterns/tiered-list/with-default-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/with-default-width-image.html
@@ -19,7 +19,6 @@
   {%- endif -%}
 
   {%- if slot == "image" -%}
-  <div class="p-image-container">
     {{ image(url="https://assets.ubuntu.com/v1/3f63a18c-data-center.png",
             alt="",
             width="2464",
@@ -29,7 +28,6 @@
             attrs={"class": "p-image-container__image"}
             ) | safe
     }}
-  </div>
   {%- endif -%}
 
   {%- if slot == 'list_item_title_1' -%}

--- a/templates/docs/examples/patterns/tiered-list/with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/with-full-width-image.html
@@ -1,7 +1,7 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 on desktop with description{% endblock %}
+{% block title %}Tiered list / 50/50 with full width image{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 
@@ -19,7 +19,7 @@
   {%- endif -%}
 
   {%- if slot == "image" -%}
-  <div class="p-image-container--3-2 is-cover">
+  <div class="p-image-container--cinematic is-cover">
     {{ image(url="https://assets.ubuntu.com/v1/3f63a18c-data-center.png",
             alt="",
             width="2464",

--- a/templates/docs/examples/patterns/tiered-list/with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/with-full-width-image.html
@@ -19,7 +19,6 @@
   {%- endif -%}
 
   {%- if slot == "image" -%}
-  <div class="p-image-container--cinematic is-cover">
     {{ image(url="https://assets.ubuntu.com/v1/3f63a18c-data-center.png",
             alt="",
             width="2464",
@@ -29,7 +28,6 @@
             attrs={"class": "p-image-container__image"}
             ) | safe
     }}
-  </div>
   {%- endif -%}
 
   {%- if slot == 'list_item_title_1' -%}

--- a/templates/docs/examples/patterns/tiered-list/with-full-width-image.html
+++ b/templates/docs/examples/patterns/tiered-list/with-full-width-image.html
@@ -1,0 +1,98 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on desktop with description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, is_image_full_width=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == "image" -%}
+  <div class="p-image-container--3-2 is-cover">
+    {{ image(url="https://assets.ubuntu.com/v1/3f63a18c-data-center.png",
+            alt="",
+            width="2464",
+            height="1028",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-image-container__image"}
+            ) | safe
+    }}
+  </div>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/patterns/tiered-list/index.md
+++ b/templates/docs/patterns/tiered-list/index.md
@@ -20,6 +20,8 @@ from a variety of tiered list layouts:
 - [50/50 with description](#5050-with-description)
 - [Full-width without description](#full-width-without-description)
 - [Full-width with description](#full-width-with-description)
+- [Default-width image](#full-width-with-description)
+- [Full-width image](#full-width-with-description)
 
 The tiered list pattern is composed of the following elements:
 
@@ -27,6 +29,7 @@ The tiered list pattern is composed of the following elements:
 | --------------------- | ----------------------------------------------------------------------------------- |
 | Title (**required**)  | <code>h2</code> title text                                                          |
 | Description           | <code>p</code> description text with optional [CTA block](/docs/patterns/cta-block) |
+| Image (optional)      | Image to show under description                                                     |
 | List item title       | Title text/content                                                                  |
 | List item description | Description text/content with optional [CTA block](/docs/patterns/cta-block)        |
 | Call to action block  | [CTA block](/docs/patterns/cta-block) beneath the list                              |
@@ -86,6 +89,26 @@ child list are presented full-width on desktop and tablet screen sizes
 respectively.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/full-width-with-description/" class="js-example" data-lang="jinja">
+View example of the tiered list pattern
+</a></div>
+
+## With default width image
+
+This variant contains a top-level description, and its title, description, and
+child list are presented full-width on desktop and tablet screen sizes
+respectively. Additionally, it also contains an image with a default width under the title and description.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/with-default-width-image/" class="js-example" data-lang="jinja">
+View example of the tiered list pattern
+</a></div>
+
+## With full width image
+
+This variant contains a top-level description, and its title, description, and
+child list are presented full-width on desktop and tablet screen sizes
+respectively. Additionally, it also contains an image with full width under the title and description.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/with-full-width-image/" class="js-example" data-lang="jinja">
 View example of the tiered list pattern
 </a></div>
 
@@ -153,6 +176,23 @@ The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. 
         </td>
         <td>
           Whether the list element should be full-width on tablet
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>is_image_full_width</code>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>
+          Whether the image should be full-width
         </td>
       </tr>
     </tbody>

--- a/templates/docs/patterns/tiered-list/index.md
+++ b/templates/docs/patterns/tiered-list/index.md
@@ -20,7 +20,6 @@ from a variety of tiered list layouts:
 - [50/50 with description](#5050-with-description)
 - [Full-width without description](#full-width-without-description)
 - [Full-width with description](#full-width-with-description)
-- [Default-width image](#full-width-with-description)
 - [With media](#with-media-new)
 
 The tiered list pattern is composed of the following elements:

--- a/templates/docs/patterns/tiered-list/index.md
+++ b/templates/docs/patterns/tiered-list/index.md
@@ -96,7 +96,7 @@ View example of the tiered list pattern
 
 This variant contains a top-level description, and its title, description, and
 child list are presented full-width on desktop and tablet screen sizes
-respectively. Additionally, it also contains an image with a default width under the title and description.
+respectively. Additionally, this variant features a default width image positioned beneath the title and description.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/with-default-width-image/" class="js-example" data-lang="jinja">
 View example of the tiered list pattern
@@ -106,7 +106,7 @@ View example of the tiered list pattern
 
 This variant contains a top-level description, and its title, description, and
 child list are presented full-width on desktop and tablet screen sizes
-respectively. Additionally, it also contains an image with full width under the title and description.
+respectively. Additionally, this variant features a full width image positioned beneath the title and description.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/with-full-width-image/" class="js-example" data-lang="jinja">
 View example of the tiered list pattern

--- a/templates/docs/patterns/tiered-list/index.md
+++ b/templates/docs/patterns/tiered-list/index.md
@@ -21,7 +21,7 @@ from a variety of tiered list layouts:
 - [Full-width without description](#full-width-without-description)
 - [Full-width with description](#full-width-with-description)
 - [Default-width image](#full-width-with-description)
-- [Full-width image](#full-width-with-description)
+- [With media](#with-media-new)
 
 The tiered list pattern is composed of the following elements:
 
@@ -29,7 +29,7 @@ The tiered list pattern is composed of the following elements:
 | --------------------- | ----------------------------------------------------------------------------------- |
 | Title (**required**)  | <code>h2</code> title text                                                          |
 | Description           | <code>p</code> description text with optional [CTA block](/docs/patterns/cta-block) |
-| Image (optional)      | Image to show under description                                                     |
+| Media (optional)      | Image or video to show near description                                             |
 | List item title       | Title text/content                                                                  |
 | List item description | Description text/content with optional [CTA block](/docs/patterns/cta-block)        |
 | Call to action block  | [CTA block](/docs/patterns/cta-block) beneath the list                              |
@@ -92,23 +92,82 @@ respectively.
 View example of the tiered list pattern
 </a></div>
 
-## With default width image
+## With media {{ status('new') }}
+
+You can embed an [image](#image) or a [video](#video) near the description.
+
+### Image
+
+You can embed a [default width](#default-width-image) or [full width](#full-width-image) image near the description.
+The image may be positioned before or after the description, depending on the variant you choose.
+The aspect ratio of the image depends on the variant you choose, and it will be wrapped in an [image container](/docs/patterns/images#image-container-with-aspect-ratio) to ensure it maintains the correct aspect ratio.
+
+**Always apply the `p-image-container__image` class to your image** to ensure the image is styled correctly.
+
+#### Default width image
 
 This variant contains a top-level description, and its title, description, and
 child list are presented full-width on desktop and tablet screen sizes
 respectively. Additionally, this variant features a default width image positioned beneath the title and description.
 
-<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/with-default-width-image/" class="js-example" data-lang="jinja">
+When using the default width image, the image will use half of the page width on large screens.
+We recommend following these guidelines when using the default width image:
+
+- Use an image with a width sufficient to fill the page width on all screens.
+- Use an image with an aspect ratio of approximately 16:9 to avoid using too much vertical space.
+  - The Jinja macro will wrap your image in
+    a [16:9 image container](/docs/patterns/images#image-container-with-aspect-ratio) and make your
+    image [fill its contents](/docs/patterns/images#cover-image). Use an image with approximately a 16:9 aspect ratio,
+    otherwise some of your image contents may be cropped at some screen sizes.
+
+The following example demonstrates a good usage of the default width image variant:
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-default-width-image" class="js-example" data-lang="jinja">
 View example of the tiered list pattern
 </a></div>
 
-## With full width image
+#### Full width image
 
 This variant contains a top-level description, and its title, description, and
 child list are presented full-width on desktop and tablet screen sizes
 respectively. Additionally, this variant features a full width image positioned beneath the title and description.
 
-<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/with-full-width-image/" class="js-example" data-lang="jinja">
+When using the full width image, the image will use the full width of the page on all screens.
+We recommend following these guidelines when using the full width image:
+
+- Use an image with a width sufficient to fill the page width on all screens.
+- Use an image with an aspect ratio of approximately 2.4:1 to avoid using too much vertical space.
+  - The Jinja macro will wrap your image in
+    a [2.4:1 ("cinematic") image container](/docs/patterns/images#image-container-with-aspect-ratio) and make your
+    image [fill its contents](/docs/patterns/images#cover-image). Use an image with approximately a 2.4:1 aspect
+    ratio, otherwise some of your image contents may be cropped at some screen sizes.
+
+The following example demonstrates a good usage of the full width image variant:
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-full-width-image" class="js-example" data-lang="jinja">
+View example of the tiered list pattern
+</a></div>
+
+### Variable media placement
+
+By default, the media is displayed after the description, but you can choose whether it should be displayed before or after the description.
+To do this, set the `media_placement` parameter in the Jinja macro to either `before_description` or `after_description`.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/50-50-tablet-with-description-with-default-width-image-before-description" class="js-example" data-lang="jinja">
+View example of the tiered list pattern
+</a></div>
+
+### Video
+
+You may also use this variant to embed a video. Videos are positioned exactly the same as images, but they always have a
+16:9 aspect ratio.
+
+When embedding a video with the Jinja macro, follow the following guidelines:
+
+- Use the `video` slot instead of the `image` slot.
+- Apply the `u-embedded-media__element` class, which is provided by the [embedded media utility](/docs/utilities/embedded-media).
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/video/" class="js-example" data-lang="jinja">
 View example of the tiered list pattern
 </a></div>
 
@@ -180,7 +239,7 @@ The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. 
       </tr>
       <tr>
         <td>
-          <code>is_image_full_width</code>
+          <code>is_media_full_width</code>
         </td>
         <td>
           No
@@ -192,7 +251,10 @@ The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. 
           <code>false</code>
         </td>
         <td>
-          Whether the image should be full-width
+          Whether the media should be full-width and displayed in its own row.<br/>
+          If the media is a full-width image, a <a href="/docs/patterns/images#image-container-with-aspect-ratio">cinematic (2.4:1 aspect ratio) image container</a> will wrap your image.<br/>
+          If the media is a default-width image, a <a href="/docs/patterns/images#image-container-with-aspect-ratio">16:9 image container</a> will wrap your image.<br/>
+          If you use the <code>video</code> slot, this parameter will affect the positioning of the video, but will not change its aspect ratio. Videos are always 16:9.
         </td>
       </tr>
     </tbody>
@@ -220,6 +282,32 @@ The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. 
         </td>
         <td>
           Title sentence displayed at the top of the pattern
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>image</code>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          Image to display near the description.<br/>
+          Must have the class <code><a href="/docs/patterns/images">p-image-container__image</a></code>.<br/>
+          If the <code>video</code> slot is used, this slot will be ignored.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>video</code>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          Video to display near the description.<br/>
+          Must have the class <code><a href="/docs/utilities/embedded-media">u-embedded-media__element</a></code>.<br/>
+          Takes precedence over the <code>image</code> slot, so if both are used, the <code>video</code> will be displayed instead of the <code>image</code>.
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
## Done

- Added support for rendering images and videos inside the tiered list pattern.
- First example of variable content ordering in one of our patterns: the media can be displayed before or after the description.

Fixes #5549 
Fixes [WD-22925](https://warthogs.atlassian.net/browse/WD-22925)

## QA

- Navigate to the [combined Tiered list examples](https://vanilla-framework-5503.demos.haus/docs/examples/patterns/tiered-list/combined?theme=light) and verify they appear as expected. The new examples are at the end of the list of examples, and all include "image" or "video" in their titles.
  - Things to pay attention to:
    - Full-width description examples with default width images cause the media to be displayed beneath/after the description, in the same row as the description. 
    - Full width media examples always render the media in a separate row, after the title and description. Media should never precede the title, even if `media_placement="before_description"` is used.
    - Media uses the proper aspect ratios for requested media size. Full-width = 2.4:1, default-width = 16:9. 
    - Videos are always rendered with 16:9 aspect ratio.
    - The rest of the pattern (list & cta) has not been changed at all.
    - **Be sure to check at small, medium, and large breakpoints.**
- Review the [tiered list with media docs](https://vanilla-framework-5503.demos.haus/docs/patterns/tiered-list)
- Review [4.25.0 release notes](https://vanilla-framework-5503.demos.haus/docs/whats-new)

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![Screenshot from 2025-06-09 18-12-36](https://github.com/user-attachments/assets/bf129784-24fd-4959-9071-e1d0a6e26d11)
![Screenshot from 2025-06-09 18-13-03](https://github.com/user-attachments/assets/8f655260-fc8a-48ae-99d6-cdc9f2dc1c35)
![Screenshot from 2025-06-09 18-12-42](https://github.com/user-attachments/assets/82f38b91-7b84-46cd-a6b6-704ce422c517)
![image](https://github.com/user-attachments/assets/31839d33-91ed-49e3-82b6-5061cdba2681)



[WD-22925]: https://warthogs.atlassian.net/browse/WD-22925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ