### PR TITLE
fix(code) allow code line selection with triple click

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.23.0",
+  "version": "4.23.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_base_code.scss
+++ b/scss/_base_code.scss
@@ -50,7 +50,6 @@ $code-inline-padding: 0.25rem;
   pre code {
     background: none;
     box-shadow: none;
-    display: inline-block;
     line-height: map-get($line-heights, default-text);
     margin-left: 0;
     margin-right: 0;


### PR DESCRIPTION
## Done

fix(code) allow code line selection with triple click

Fixes #5505

## QA

- Open [/docs](https://vanilla-framework-5506.demos.haus/docs) page and triple click on the box `yarn add vanilla-framework`
- This should select the whole text, while on the [current page](https://vanillaframework.io/docs) it only selects the first letter when browsing with Chrome.

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

