### PR TITLE
Remove mailing list, freenode links, remove devdep badge (no longer w…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,11 @@
 
 [![npm version](https://badge.fury.io/js/vanilla-framework.svg)](http://badge.fury.io/js/vanilla-framework)
 [![Downloads](http://img.shields.io/npm/dm/vanilla-framework.svg)](https://www.npmjs.com/package/vanilla-framework)
-[![devDependency Status](https://david-dm.org/canonical/vanilla-framework/dev-status.svg)](https://david-dm.org/canonical/vanilla-framework#info=devDependencies)
-[![Chat in #vanilla-framework on Freenode](https://img.shields.io/badge/chat-%23vanilla--framework-blue.svg)](http://webchat.freenode.net/?channels=vanilla-framework)
 [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io)
 
 Vanilla Framework is an extensible CSS framework, built using [Sass](http://sass-lang.com/) and is designed to be used either directly or by using themes to extend or supplement its patterns.
 
 [Documentation](https://vanillaframework.io/docs) |
-[Join the mailing list](http://canonical.us3.list-manage2.com/subscribe?u=56dac47c206ba0f58ec25f314&id=36f7d8394e)
 
 ## Table of contents
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -277,12 +277,12 @@
 
 <div class="p-strip">
   <div class="row">
-    <div class="col-3">
+    <div class="col-6">
       <h2>Contribute</h2>
       <p><a class="github-button" href="https://github.com/canonical/vanilla-framework" data-size="large" data-show-count="true" aria-label="Follow @vanilla-framework on GitHub">Follow @vanilla-framework</a></p>
       <p><a class="github-button" href="https://github.com/canonical/vanilla-framework/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork vanilla-framework/vanilla-framework on GitHub">Fork</a></p>
     </div>
-    <div class="col-3">
+    <div class="col-6">
       <h2>Get involved</h2>
       <ul class="p-list--divided">
         <li class="p-list__item">
@@ -292,18 +292,6 @@
           <a href="https://github.com/canonical/vanilla-framework" class="p-link--soft">GitHub&nbsp;&rsaquo;</a>
         </li>
       </ul>
-    </div>
-    <div class="col-6">
-      <h2>Subscribe to Vanilla updates</h2>
-      <form action="//canonical.us3.list-manage.com/subscribe/post?u=56dac47c206ba0f58ec25f314&amp;id=36f7d8394e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="p-form">
-        <div class="p-form__group">
-          <label for="mce-EMAIL">Email address</label>
-          <input type="email" value="" name="EMAIL" placeholder="vanilla@example.com" id="mce-EMAIL" aria-label="Email address" autocomplete="email" required />
-          <input class="u-off-screen" aria-hidden="true" type="hidden" name="b_56dac47c206ba0f58ec25f314_36f7d8394e" tabindex="-1" value="" />
-          <p class="p-form-help-text">Know about new releases, features, blog posts, calls&#8209;for&#8209;help&nbsp;and more.</p>
-        </div>
-        <button name="subscribe" type="submit" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Subscribe', 'eventLabel' : 'Subcribe to Vanilla updates', 'eventValue' : undefined });" class="p-button--positive">Subscribe</button>
-      </form>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Removes mailchimp links (it is no longer maintained & the subscribe link is dead)
- Removes freenode chat link (dead link) - perhaps soon we could set up a channel in the [Ubuntu Matrix](https://ubuntu.com/community/communications/matrix)
- Removed the david-dm dependency badge - it seems to [no longer work](https://github.com/alanshaw/david/issues/182), we should find an alternative. 

Fixes #5363 
Fixes [WD-15548](https://warthogs.atlassian.net/browse/WD-15548)

## QA

1. Open demo.
2. Scroll down to where the mailing list subscribe used to be. Verify it is no longer there, and the "get involved" and "contribute" sections now take 50% width each on large.

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
