### PR TITLE
fix(Image container): Fix `p-image-container__image` with explicit dimensions on Safari not following set aspect ratio

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.23.2",
+  "version": "4.23.3",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -94,13 +94,13 @@ $aspect-ratios: (
     }
 
     .p-image-container__image {
-      // prevent the image from stretching the container
+      // height and width prevent the image from stretching the container
       // forces the image to respect container aspect ratio, even if its explicit dimensions are in conflict with the aspect ratio
       height: 100%;
-      width: 100%;
       // when the aspect ratio is set, and object-fit ensures the aspect ratio
       // of the image content is maintained
       object-fit: contain;
+      width: 100%;
     }
 
     &.is-cover {

--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -94,18 +94,18 @@ $aspect-ratios: (
     }
 
     .p-image-container__image {
-      // max height prevents the image from stretching the container
+      // prevent the image from stretching the container
+      // forces the image to respect container aspect ratio, even if its explicit dimensions are in conflict with the aspect ratio
+      height: 100%;
+      width: 100%;
       // when the aspect ratio is set, and object-fit ensures the aspect ratio
       // of the image content is maintained
-      max-height: 100%;
       object-fit: contain;
     }
 
     &.is-cover {
       .p-image-container__image {
-        height: 100%;
         object-fit: cover;
-        width: 100%;
       }
     }
   }


### PR DESCRIPTION
## Done

Fixes a bug where `img.p-image-container__image` with explicit dimensions disrespected the aspect ratio of their `p-image-container` parent.

Fixes [WD-21797](https://warthogs.atlassian.net/browse/WD-21797)
Fixes #5508 

## QA



### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1483" alt="Screenshot 2025-05-07 at 16 46 03" src="https://github.com/user-attachments/assets/a0cab20e-cbf5-4947-aabf-00f0eccd7b26" />



[WD-21797]: https://warthogs.atlassian.net/browse/WD-21797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ