### PR TITLE
variable font size (calc)

### DIFF
--- a/scss/_base_typography.scss
+++ b/scss/_base_typography.scss
@@ -18,17 +18,8 @@
     line-height: map-get($line-heights, default-text);
     text-wrap: pretty;
 
-    @if ($increase-font-size-on-larger-screens) {
-      font-size: map-get($base-font-sizes, base);
+    font-size: map-get($base-font-sizes, base);
 
-      @media (min-width: $breakpoint-x-large) {
-        font-size: map-get($base-font-sizes, large);
-        //the rem value is not affected by the change in font-size; it needs to be multiplied by the ratio new font-size/default font-size
-        line-height: map-get($line-heights, default-text) * $font-size-ratio--largescreen;
-      }
-    } @else {
-      font-size: map-get($base-font-sizes, base);
-    }
   }
 
   // headings

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -8,7 +8,7 @@ $increase-font-size-on-larger-screens: true !default;
 $font-size-ratio--largescreen: 1.125 !default;
 $font-size-largescreen: #{$font-size-ratio--largescreen}rem;
 $base-font-sizes: (
-  base: 1rem,
+  base: calc(0.8rem + 0.2vw),
   large: $font-size-largescreen,
 ) !default;
 $font-weight-display-heading: 100 !default;


### PR DESCRIPTION
Sets the root font size to an expression of rem and vw. Being used for design discussions at the sprint, do not merge.