### PR TITLE
Changed fixScroll to scroll correctly on ids with labels

### DIFF
--- a/templates/static/js/example.js
+++ b/templates/static/js/example.js
@@ -479,10 +479,22 @@
   }
 
   function fixScroll() {
-    const titleId = window.location.hash;
+    let titleId = window.location.hash;
     if (titleId) {
-      const title = document.querySelector(titleId);
-      title.scrollIntoView();
+      titleId = titleId.substring(1); // Removes the #
+      let title = document.getElementById(titleId);
+      // If there is no element with that id, maybe it is because there is a status tag attatched to it
+      if (title == null) {
+        const matchingIdElems = Array.from(document.querySelectorAll(`[id^="${titleId}-"]`));
+        // Get the ones that have the tag content added to the id.
+        const elemWithStatus = matchingIdElems.filter((elem) => {
+          const labeledChilds = Array.from(elem.querySelectorAll(`[class^="p-status-label--"],[class*=" p-status-label--"]`));
+          const labelsOnId = labeledChilds.map((childElem) => '-' + childElem.innerText.replace(' ', '-').toLowerCase());
+          return elem.id === titleId + labelsOnId.join('');
+        });
+        title = elemWithStatus[0];
+      }
+      title?.scrollIntoView();
     }
   }
 


### PR DESCRIPTION
## Done

Fixscroll now also checks if the requested hash can be identified by comparing: the id of the headers that start with the hash, and the hash plus the labels inside those headers.  

E.g., if the requested hash is `#hello`, and the header `hello` has a tag `new`, fixScroll will search first for `#hello` and then for `#hello-new`.  

Fixes #5393 

## QA

- Go to `http://.../docs/patterns/hero#5050-with-no-image`
- Check that the redirection occurs correctly.
- Check that once the page has been loaded and the same link is used without refreshing the site, the user is not redirected, contrary to #5531.

### Check if PR is ready for release

PR does not contain Vanilla SCSS or macro code changes.