### PR TITLE
chore: add matrix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/vanilla-framework.svg)](http://badge.fury.io/js/vanilla-framework)
 [![Downloads](http://img.shields.io/npm/dm/vanilla-framework.svg)](https://www.npmjs.com/package/vanilla-framework)
+[![Chat in #vanilla:ubuntu.com on Matrix](https://img.shields.io/badge/chat-%23vanilla:ubuntu.com-blue.svg)](https://matrix.to/#/#vanilla:ubuntu.com)
 [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io)
 
 Vanilla Framework is an extensible CSS framework, built using [Sass](http://sass-lang.com/) and is designed to be used either directly or by using themes to extend or supplement its patterns.

--- a/templates/index.html
+++ b/templates/index.html
@@ -286,6 +286,9 @@
       <h2>Get involved</h2>
       <ul class="p-list--divided">
         <li class="p-list__item">
+          <a href="https://matrix.to/#/#vanilla:ubuntu.com" class="p-link--soft">Matrix&nbsp;&rsaquo;</a>
+        </li>
+        <li class="p-list__item">
           <a href="https://twitter.com/vanillaframewrk" class="p-link--soft">Twitter&nbsp;&rsaquo;</a>
         </li>
         <li class="p-list__item">


### PR DESCRIPTION
## Done

Adds links to our new [Matrix room](https://matrix.to/#/#vanilla:ubuntu.com) as requested [here](https://github.com/canonical/vanilla-framework/issues/5363#issuecomment-2934313705)

## QA

- Open [demo homepage](https://vanilla-framework-5536.demos.haus/). Verify the link to Matrix takes you to the #vanilla:ubuntu.com room.
- Open the [Readme in preview mode](https://github.com/canonical/vanilla-framework/blob/d9d58bdfa3e5de424397ea0734f03105510184f6/README.md). Verify the Matrix badge link renders properly and takes you to the #vanilla:ubuntu.com room.

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
