### PR TITLE
feat(Icons): Icons consume color of their surrounding context

### DIFF
--- a/scss/_base_icon-definitions.scss
+++ b/scss/_base_icon-definitions.scss
@@ -9,7 +9,7 @@
 // - a mixin `vf-icon-NAME-themed` that sets the background-image to the icon URL with the light and dark theme colors
 
 // chevron
-@function vf-icon-chevron-url($color) {
+@function vf-icon-chevron-url($color: $colors--icon-mask) {
   @return url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='#{vf-url-friendly-color($color)}' d='M8.187 11.748l6.187-6.187-1.06-1.061-5.127 5.127L3.061 4.5 2 5.561z'/%3E%3C/svg%3E");
 }
 
@@ -20,7 +20,8 @@
 // Default chevron is the same as down chevron - points down, as in its usage
 // in accordions/dropdowns
 @mixin vf-icon-chevron-themed {
-  @include vf-themed-icon($light-value: vf-icon-chevron-url($colors--light-theme--icon), $dark-value: vf-icon-chevron-url($colors--dark-theme--icon));
+  mask-image: vf-icon-chevron-url();
+  -webkit-mask-image: vf-icon-chevron-url();
 }
 
 @mixin vf-icon-chevron-up-themed {

--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -241,6 +241,11 @@
     vertical-align: calc($vertical-offset + 0.5 * $cap-height - 0.5 * $default-icon-size);
   }
 
+  %themed-icon {
+    @extend %icon;
+    background-color: currentColor;
+  }
+
   %social-icon {
     @extend %vf-hide-text;
     @include vf-icon-size(map-get($icon-sizes, heading-icon--x-small));

--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -150,7 +150,7 @@
   .p-icon--chevron-right,
   .p-icon--chevron-down,
   .p-icon--chevron-left {
-    @extend %icon;
+    @extend %themed-icon;
   }
 }
 

--- a/scss/_settings_colors.scss
+++ b/scss/_settings_colors.scss
@@ -291,6 +291,7 @@ $colors--theme--button-negative-active: var(--vf-color-button-negative-active);
 $colors--theme--button-negative-text: var(--vf-color-button-negative-text);
 
 $colors--theme--accent: var(--vf-color-accent);
+$colors--icon-mask: $color-x-dark;
 
 // Theme colors exposed as CSS custom properties
 @mixin vf-theme-light--colors {

--- a/templates/docs/examples/patterns/icons/combined.html
+++ b/templates/docs/examples/patterns/icons/combined.html
@@ -14,5 +14,6 @@
 <section>{% include 'docs/examples/patterns/icons/icons-links.html' %}</section>
 <section>{% include 'docs/examples/patterns/icons/icons-social.html' %}</section>
 <section>{% include 'docs/examples/patterns/icons/standard.html' %}</section>
+<section>{% include 'docs/examples/patterns/icons/icons-contextual.html' %}</section>
 {% endwith %}
 {% endblock %}

--- a/templates/docs/examples/patterns/icons/icons-contextual.html
+++ b/templates/docs/examples/patterns/icons/icons-contextual.html
@@ -1,0 +1,11 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Icons / Standard{% endblock %}
+
+{% block standalone_css %}patterns_icons{% endblock %}
+
+{% block content %}
+<p><a href="#">Link icon<i class="p-icon--chevron-down"></i></a></p>
+<p>Default icon<i class="p-icon--chevron-down"></i></p>
+<p>Semantic icons <i class="p-icon--success"></i><i class="p-icon--warning"></i><i class="p-icon--information"></i><i class="p-icon--error"></i></p>
+<button class="p-button" disabled>Disabled icon<i class="p-icon--chevron-down"></i></button>
+{% endblock %}


### PR DESCRIPTION
## Done

Updated the icons component so that icons consume the color of their parent context. 

The icon SVG url is now applied as a monochromatic [mask](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-image), instead of having color baked in. Icon color is then set using [currentColor](https://css-tricks.com/currentcolor/).

WIP: Currently this is a proof of concept and only `p-icon--chevron-down` consumes contextual color. 

Fixes #5494 
Fixes [WD-20987](https://warthogs.atlassian.net/browse/WD-20987)

## QA

- Open [contextual icons example](https://vanilla-framework-5537.demos.haus/docs/examples/patterns/icons/icons-contextual?theme=light)
- Review 4.24.x release notes (TBD)
- Review updated icon docs copy per [this comment](https://github.com/canonical/vanilla-framework/issues/5494#issuecomment-2858260361) (TBD)

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="191" alt="Screenshot 2025-06-03 at 16 55 54" src="https://github.com/user-attachments/assets/f9781ef5-b2ab-4f76-9f0f-171797ae3f9b" />



[WD-20987]: https://warthogs.atlassian.net/browse/WD-20987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ