### PR TITLE
Add logo section negative margin right

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.24.0",
+  "version": "4.24.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_logo-section.scss
+++ b/scss/_patterns_logo-section.scss
@@ -46,6 +46,7 @@
       // compensate for the negative margin on the logos
       padding-bottom: $logo-section-offset-small;
       padding-top: $logo-section-offset-small;
+      margin-right: #{-1 * $logo-section-item-gap};
 
       @media (min-width: $breakpoint-small) {
         padding-bottom: $logo-section-offset;


### PR DESCRIPTION
## Done

[List of work items including drive-bys]

Fixes #5522 
Fixes [WD-22109](https://warthogs.atlassian.net/browse/WD-22109)

## QA

- Open logo section examples and verify the spacing is correct
- Review 4.24.1 release notes

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1095" alt="Screenshot 2025-06-04 at 09 28 35" src="https://github.com/user-attachments/assets/b02d553e-ebc0-4178-8ad3-5c35019df616" />
