### PR TITLE
chore: align side padding of input with buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.24.0",
+  "version": "4.24.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -33,8 +33,8 @@
     line-height: map-get($line-heights, default-text);
     margin-bottom: $input-margin-bottom;
     min-width: 8em;
-    padding-left: $sph--small;
-    padding-right: $sph--small;
+    padding-left: $sph--large;
+    padding-right: $sph--large;
     vertical-align: baseline;
     width: 100%;
 


### PR DESCRIPTION
## Done

Updates the side padding of the input elements to match the side padding of the button component.

Fixes #5487 
Fixes [WD-20049](https://warthogs.atlassian.net/browse/WD-20049)

## QA

- Open [forms examples](https://vanilla-framework-5539.demos.haus/docs/examples/base/forms/combined?theme=light) and verify that input elements' side padding matches button side padding.
- Review [Percy build](https://percy.io/bb49709b/web/vanilla-framework/builds/40802709/changed/2192019248?browser=chrome&browser_ids=64&group_snapshots_by=similar_diff&subcategories=unreviewed%2Cchanges_requested&viewLayout=overlay&viewMode=new&width=1280&widths=375%2C1280) for full visual diff as there may be many changes.

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="827" alt="Screenshot 2025-06-04 at 09 52 18" src="https://github.com/user-attachments/assets/c71dc7c0-6389-4c34-a24b-9670790d53df" />

<img width="325" alt="Screenshot 2025-06-04 at 09 59 56" src="https://github.com/user-attachments/assets/c21373cd-8c56-45b8-a858-9fcb56a4f7db" />




[WD-20049]: https://warthogs.atlassian.net/browse/WD-20049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ