### PR TITLE
CTA is borderless by default; add bordered CTA variant for backwards compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.24.1",
+  "version": "4.25.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.25.0
+  features:
+    - component: CTA Block
+      url: /docs/patterns/cta-block
+      status: Updated
+      notes: We've updated the CTA block to be borderless by default. A new <code>has-border</code> class can be used to add a border back, but this will be deprecated in the next major version.
 - version: 4.24.0
   features:
     - component: Equal heights
@@ -87,7 +93,7 @@
 - version: 4.16.0
   features:
     - component: CTA Block / Borderless
-      url: /docs/patterns/cta-block#borderless
+      url: /docs/patterns/cta-block#borderless-deprecated
       status: New
       notes: We've introduced a new borderless variant of the CTA block component.
     - component: Forms / Fieldset required

--- a/scss/_patterns_cta.scss
+++ b/scss/_patterns_cta.scss
@@ -5,7 +5,9 @@
       .p-cta-block:
         Main element of the CTA block.
       "&.is-borderless":
-        Borderless variant, to be used to hide top border and padding.
+        Deprecated modifier class that removed top border and padding before v4.25.0. This is now the default behavior, so this class is no longer needed.
+      "&.has-border":
+        Deprecated modifier class that adds a top border and padding.
 */
 
 @import 'settings';
@@ -13,15 +15,20 @@
 @mixin vf-p-cta-block {
   .p-cta-block {
     align-items: baseline;
-    border-top: 1px solid $colors--theme--border-low-contrast;
     display: flex;
     flex-wrap: wrap;
     padding-bottom: $spv--x-large;
-    padding-top: $spv--small;
 
+    &,
+      /** deprecated, borderless is now default behavior */
     &.is-borderless {
       border: none;
       padding-top: 0;
+    }
+
+    &.has-border {
+      border-top: 1px solid $colors--theme--border-low-contrast;
+      padding-top: $spv--small;
     }
   }
 }

--- a/templates/docs/examples/patterns/cta-block/bordered.html
+++ b/templates/docs/examples/patterns/cta-block/bordered.html
@@ -1,0 +1,12 @@
+{% extends "_layouts/examples.html" %}
+
+{% block title %}CTA Block / Bordered{% endblock %}
+
+{% block standalone_css %}patterns_cta{% endblock %}
+
+{% block content %}
+<div class="p-cta-block has-border">
+  <a href="#" class="p-button--positive">Learn more</a>
+  <a href="#">Contact us ›</a>
+</div>
+{% endblock %}

--- a/templates/docs/examples/patterns/cta-block/combined.html
+++ b/templates/docs/examples/patterns/cta-block/combined.html
@@ -7,5 +7,6 @@
 {% with is_combined = true %}
 <section>{% include 'docs/examples/patterns/cta-block/default.html' %}</section>
 <section>{% include 'docs/examples/patterns/cta-block/borderless.html' %}</section>
+<section>{% include 'docs/examples/patterns/cta-block/bordered.html' %}</section>
 {% endwith %}
 {% endblock %}

--- a/templates/docs/patterns/cta-block/index.md
+++ b/templates/docs/patterns/cta-block/index.md
@@ -11,9 +11,22 @@ A CTA (call to action) block is a pattern that is used to encourage users to tak
 View example of the CTA block pattern
 </a></div>
 
-## Borderless
+## Bordered {{ status("deprecated") }}
 
-The CTA block can be used without a border. This is useful when the CTA block is stacked beneath related content.
+In Vanilla v4.25.0, the borderless variant of the CTA block pattern was made the default variant.
+The bordered variant is now deprecated and will be removed in the next major version.
+
+In case you need to use the bordered variant in the meantime, you can include the top border and
+padding by using the `.has-border` class. Note that this class will be removed in the next major version.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/cta-block/bordered" class="js-example">
+View example of the CTA block pattern with a border
+</a></div>
+
+## Borderless {{ status("deprecated") }}
+
+In Vanilla v4.25.0, the borderless variant of the CTA block pattern was made the default variant.
+The `.is-borderless` class will be removed in the next major version, as it has no effect anymore.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/cta-block/borderless" class="js-example">
 View example of the CTA block pattern with no border


### PR DESCRIPTION
- Makes borderless the default variant of the CTA block
- Introduces a bordered variant of the CTA block for compatibility with older designs
- Deprecates the borderless modifier class as it is now default behavior. 

## Done

Fixes #5541 
Fixes [WD-22685](https://warthogs.atlassian.net/browse/WD-22685)

## QA

- Open [CTA block examples](https://vanilla-framework-5543.demos.haus/docs/examples/patterns/cta-block/combined?theme=light) and verify the default and borderless variants have no border and the bordered variant has a top border and padding.
- Review [CTA block docs](https://vanilla-framework-5543.demos.haus/docs/patterns/cta-block)
- Review [4.25.0 release notes](https://vanilla-framework-5543.demos.haus/docs/whats-new)

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![image](https://github.com/user-attachments/assets/e0fe2ed8-8d6b-4852-a15d-62c15043f6de)


[WD-22685]: https://warthogs.atlassian.net/browse/WD-22685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ