### PR TITLE
fix(Badge): Truncate badges with long text, make the smallest badge a perfect circle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.25.0",
+  "version": "4.25.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_badge.scss
+++ b/scss/_patterns_badge.scss
@@ -7,6 +7,7 @@
     border-radius: 1rem;
     box-sizing: content-box;
     color: $colors--theme--background-default; // inverse the theme by using the baackground color
+    display: inline-block;
     margin-bottom: 0;
     max-width: 4ch;
     overflow: hidden;

--- a/scss/_patterns_badge.scss
+++ b/scss/_patterns_badge.scss
@@ -10,8 +10,10 @@
     display: inline-block;
     margin-bottom: 0;
     max-width: 4ch;
+    min-width: $sph--small;
     overflow: hidden;
     padding: 0 $spv--x-small;
+    text-align: center;
   }
 
   .p-badge,

--- a/scss/_patterns_badge.scss
+++ b/scss/_patterns_badge.scss
@@ -10,7 +10,10 @@
     display: inline-block;
     margin-bottom: 0;
     max-width: 4ch;
-    min-width: $sph--small;
+    // the minimum content width should be the total desired width (the line-height)
+    // minus the space already taken up by the left and right padding
+    // Makes the shortest badge a perfect circle and keeps it related to line-height (of %x-small-text) and padding (below)
+    min-width: map-get($line-heights, x-small) - (2 * $spv--x-small);
     overflow: hidden;
     padding: 0 $spv--x-small;
     text-align: center;

--- a/scss/_patterns_badge.scss
+++ b/scss/_patterns_badge.scss
@@ -6,7 +6,7 @@
     background-color: $colors--theme--text-default; // inverse the theme by using the text color
     border-radius: 1rem;
     box-sizing: content-box;
-    color: $colors--theme--background-default; // inverse the theme by using the baackground color
+    color: $colors--theme--background-default; // inverse the theme by using the background color
     display: inline-block;
     margin-bottom: 0;
     max-width: 4ch;


### PR DESCRIPTION
## Done

- Set `display: inline-block` on the badge component, to ensure its `max-width` and `line-height` are properly enforced
- Set a minimum width on badges so that badges with the smallest size possible are perfect 16x16 circles
  - Set badge text to center-align (otherwise very short badge text would not be horizontally centered)

Fixes [WD-23540](https://warthogs.atlassian.net/browse/WD-23540)
Fixes #5568 

## QA

- Open [badge](https://vanilla-framework-5569.demos.haus/docs/examples/patterns/badge/default?theme=light)
- Verify that the "9" badge is a perfect 16x16 circle
- Use "Inspect element" to change any badge to have very long text, longer than 4 characters.
- Verify that the badge with the long text does not show more than 4 full characters, and the rest of the characters are cut off (not displayed)

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

![image](https://github.com/user-attachments/assets/640d4326-110d-4975-a8ce-ea298b6a8a9f)


[WD-23540]: https://warthogs.atlassian.net/browse/WD-23540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ