### PR TITLE
[WD-22567] feat: Implement Text Spotlight section pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.26.0",
+  "version": "4.27.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.27.0",
+  "version": "4.26.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,15 +1,13 @@
-- version: 4.27.0
-  features:
-    - component: Text Spotlight Pattern
-      url: /docs/patterns/text-spotlight
-      status: New
-      notes: We've introduced a new Text Spotlight section pattern.
 - version: 4.26.0
   features:
     - component: Icons
       url: /docs/patterns/icons#recently-added-icons-new
       status: New
       notes: We've added the new <code>p-icon--history</code><i class="p-icon--history"/> icon.
+    - component: Text Spotlight Pattern
+      url: /docs/patterns/text-spotlight
+      status: New
+      notes: We've introduced a new Text Spotlight section pattern.
     - component: CTA Section Pattern
       url: /docs/patterns/cta-section
       status: New

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.27.0
+  features:
+    - component: Text Spotlight Pattern
+      url: /docs/patterns/text-spotlight
+      status: New
+      notes: We've introduced a new Text Spotlight section pattern.
 - version: 4.26.0
   features:
     - component: Icons

--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -131,6 +131,8 @@
       url: /docs/patterns/linked-logo-section
     - title: CTA section
       url: /docs/patterns/cta-section
+    - title: Text spotlight
+      url: /docs/patterns/text-spotlight
 - heading: Utilities
   ordering: alphabetical
   subheadings:

--- a/templates/_macros/vf_text-spotlight.jinja
+++ b/templates/_macros/vf_text-spotlight.jinja
@@ -1,0 +1,36 @@
+# All Params
+  # title_text: H2 title text
+# All Slots
+  # list_item_[1-7]: List item content, assumed to be li.p-list__item, H2 text
+
+{%- macro vf_text_spotlight(title_text, caller=None) -%}
+  {% set has_list = caller('list_item_1')|trim|length > 0 %}
+  {% set max_list_items = 7 %}
+  {% set list_items = [] %}
+  {% if has_list %}
+    {% for list_item_index in range(1, max_list_items + 1) %}
+      {% set list_item_content = caller('list_item_' + list_item_index|string) %}
+      {% set has_list_item_content = list_item_content|trim|length > 0 %}
+      {% if has_list_item_content %}{{ list_items.append(list_item_content) or "" }}{% endif %}
+    {% endfor %}
+  {% endif %}
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--25-75-on-large">
+      <div class="col">
+        <h2 class="p-text--small-caps">{{ title_text }}</h2>
+      </div>
+      <div class="col">
+        {%- if list_items|length > 0 %}
+          <ul class="p-list--divided">
+            {%- for list_item in list_items -%}
+              <li class="p-list__item u-no-padding--bottom">
+                <p class="p-heading--2">{{- list_item -}}</p>
+              </li>
+            {%- endfor -%}
+          </ul>
+        {%- endif -%}
+      </div>
+    </div>
+  </section>
+{%- endmacro -%}

--- a/templates/_macros/vf_text-spotlight.jinja
+++ b/templates/_macros/vf_text-spotlight.jinja
@@ -1,19 +1,11 @@
-# All Params
-  # title_text: H2 title text
-# All Slots
-  # list_item_[1-7]: List item content, H2 text styled content rendered in a paragraph
-
-{%- macro vf_text_spotlight(title_text, caller=None) -%}
-  {% set has_list = caller('list_item_1')|trim|length > 0 %}
-  {% set max_list_items = 7 %}
-  {% set list_items = [] %}
-  {% if has_list %}
-    {% for list_item_index in range(1, max_list_items + 1) %}
-      {% set list_item_content = caller('list_item_' + list_item_index|string) %}
-      {% set has_list_item_content = list_item_content|trim|length > 0 %}
-      {% if has_list_item_content %}{{ list_items.append(list_item_content) or "" }}{% endif %}
-    {% endfor %}
-  {% endif %}
+{#
+    All Params:
+      @param title_text: H2 title text
+      @param list_items (Array<string>)
+      An array of HTML strings to be rendered
+#}
+{%- macro vf_text_spotlight(title_text, list_items=[], caller=None) -%}
+  {% set has_list = list_items | length >= 2 and list_items | length <= 7 %}
   <section class="p-section">
     <hr class="p-rule is-fixed-width" />
     <div class="row--25-75-on-large">
@@ -21,7 +13,7 @@
         <h2 class="p-text--small-caps">{{ title_text }}</h2>
       </div>
       <div class="col">
-        {%- if list_items|length >= 2 and list_items|length <= 7 -%}
+        {%- if has_list -%}
           {%- for list_item in list_items -%}
             <p class="p-heading--2">{{- list_item -}}</p>
             {%- if not loop.last %}<hr class="p-rule--muted" />{%- endif %}

--- a/templates/_macros/vf_text-spotlight.jinja
+++ b/templates/_macros/vf_text-spotlight.jinja
@@ -21,14 +21,11 @@
         <h2 class="p-text--small-caps">{{ title_text }}</h2>
       </div>
       <div class="col">
-        {%- if list_items|length > 0 %}
-          <ul class="p-list--divided">
-            {%- for list_item in list_items -%}
-              <li class="p-list__item u-no-padding--bottom">
-                <p class="p-heading--2">{{- list_item -}}</p>
-              </li>
-            {%- endfor -%}
-          </ul>
+        {%- if list_items|length >= 2 and list_items|length <= 7 -%}
+          {%- for list_item in list_items -%}
+            <p class="p-heading--2">{{- list_item -}}</p>
+            {%- if not loop.last %}<hr class="p-rule" />{%- endif %}
+          {%- endfor -%}
         {%- endif -%}
       </div>
     </div>

--- a/templates/_macros/vf_text-spotlight.jinja
+++ b/templates/_macros/vf_text-spotlight.jinja
@@ -24,7 +24,7 @@
         {%- if list_items|length >= 2 and list_items|length <= 7 -%}
           {%- for list_item in list_items -%}
             <p class="p-heading--2">{{- list_item -}}</p>
-            {%- if not loop.last %}<hr class="p-rule" />{%- endif %}
+            {%- if not loop.last %}<hr class="p-rule--muted" />{%- endif %}
           {%- endfor -%}
         {%- endif -%}
       </div>

--- a/templates/_macros/vf_text-spotlight.jinja
+++ b/templates/_macros/vf_text-spotlight.jinja
@@ -1,7 +1,7 @@
 # All Params
   # title_text: H2 title text
 # All Slots
-  # list_item_[1-7]: List item content, assumed to be li.p-list__item, H2 text
+  # list_item_[1-7]: List item content, H2 text styled content rendered in a paragraph
 
 {%- macro vf_text_spotlight(title_text, caller=None) -%}
   {% set has_list = caller('list_item_1')|trim|length > 0 %}
@@ -26,6 +26,13 @@
             <p class="p-heading--2">{{- list_item -}}</p>
             {%- if not loop.last %}<hr class="p-rule--muted" />{%- endif %}
           {%- endfor -%}
+        {%- else -%}
+          <div class="p-notification--caution">
+            <div class="p-notification__content">
+              <h5 class="p-notification__title">Caution</h5>
+              <p class="p-notification__message">List items must be between 2 and 7.</p>
+            </div>
+          </div>
         {%- endif -%}
       </div>
     </div>

--- a/templates/docs/examples/patterns/text-spotlight/combined.html
+++ b/templates/docs/examples/patterns/text-spotlight/combined.html
@@ -1,0 +1,11 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Text Spotlight / Combined{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{% with is_combined = true %}
+<section>{% include 'docs/examples/patterns/text-spotlight/default.html' %}</section>
+<section>{% include 'docs/examples/patterns/text-spotlight/links.html' %}</section>
+{% endwith %}
+{% endblock %}

--- a/templates/docs/examples/patterns/text-spotlight/default.html
+++ b/templates/docs/examples/patterns/text-spotlight/default.html
@@ -1,0 +1,26 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_text-spotlight.jinja" import vf_text_spotlight %}
+{% block title %}Text Spotlight{% endblock %}
+{% block standalone_css %}patterns_all{% endblock %}
+{% set is_paper = true %}
+{% block content %}
+    {% call(slot) vf_text_spotlight(
+        title_text='Why choose <br class="u-hide--medium u-hide--small"/>Data Science Stack?',
+        ) -%}
+        {%- if slot == 'list_item_1' -%}
+            Improve developer productivity
+        {%- endif -%}
+        {%- if slot == 'list_item_2' -%}
+            Easy to use on any AI workstation
+        {%- endif -%}
+        {%- if slot == 'list_item_3' -%}
+            Run your ML workloads in a secure environment
+        {%- endif -%}
+        {%- if slot == 'list_item_4' -%}
+            Begin your AI journey on Ubuntu
+        {%- endif -%}
+        {%- if slot == 'list_item_5' -%}
+            One vendor to support your AI stack
+        {%- endif -%}
+    {% endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/text-spotlight/default.html
+++ b/templates/docs/examples/patterns/text-spotlight/default.html
@@ -5,22 +5,14 @@
 {% set is_paper = true %}
 {% block content %}
     {% call(slot) vf_text_spotlight(
-        title_text='Why choose <br class="u-hide--medium u-hide--small"/>Data Science Stack?',
+        title_text='Why choose <br class="u-hide--medium u-hide--small" />Data Science Stack?',
+        list_items=[
+        'Improve developer productivity',
+        'Easy to use on any AI workstation',
+        'Run your ML workloads in a secure environment',
+        'Begin your AI journey on Ubuntu',
+        'One vendor to support your AI stack'
+        ]
         ) -%}
-        {%- if slot == 'list_item_1' -%}
-            Improve developer productivity
-        {%- endif -%}
-        {%- if slot == 'list_item_2' -%}
-            Easy to use on any AI workstation
-        {%- endif -%}
-        {%- if slot == 'list_item_3' -%}
-            Run your ML workloads in a secure environment
-        {%- endif -%}
-        {%- if slot == 'list_item_4' -%}
-            Begin your AI journey on Ubuntu
-        {%- endif -%}
-        {%- if slot == 'list_item_5' -%}
-            One vendor to support your AI stack
-        {%- endif -%}
     {% endcall -%}
 {% endblock %}

--- a/templates/docs/examples/patterns/text-spotlight/links.html
+++ b/templates/docs/examples/patterns/text-spotlight/links.html
@@ -6,27 +6,15 @@
 {% block content %}
     {% call(slot) vf_text_spotlight(
         title_text='Working here',
+        list_items=[
+        '<a href="https://canonical.com/careers/hiring-process">Hiring process</a>',
+        '<a href="https://canonical.com/careers/company-culture">Company culture</a>',
+        '<a href="https://canonical.com/careers/company-culture/remote-work">Remote work</a>',
+        '<a href="https://canonical.com/careers/progression">Progression</a>',
+        '<a href="https://canonical.com/careers/diversity">Diversity</a>',
+        '<a href="https://canonical.com/careers/sustainability">Sustainability</a>',
+        '<a href="https://canonical.com/careers/application/faq">FAQs</a>'
+        ]
         ) -%}
-        {%- if slot == 'list_item_1' -%}
-            <a href="https://canonical.com/careers/hiring-process">Hiring process</a>
-        {%- endif -%}
-        {%- if slot == 'list_item_2' -%}
-            <a href="https://canonical.com/careers/company-culture">Company culture</a>
-        {%- endif -%}
-        {%- if slot == 'list_item_3' -%}
-            <a href="https://canonical.com/careers/company-culture/remote-work">Remote work</a>
-        {%- endif -%}
-        {%- if slot == 'list_item_4' -%}
-            <a href="https://canonical.com/careers/progression">Progression</a>
-        {%- endif -%}
-        {%- if slot == 'list_item_5' -%}
-            <a href="https://canonical.com/careers/diversity">Diversity</a>
-        {%- endif -%}
-        {%- if slot == 'list_item_6' -%}
-            <a href="https://canonical.com/careers/sustainability">Sustainability</a>
-        {%- endif -%}
-        {%- if slot == 'list_item_7' -%}
-            <a href="https://canonical.com/careers/application/faq">FAQs</a>
-        {%- endif -%}
     {% endcall -%}
 {% endblock %}

--- a/templates/docs/examples/patterns/text-spotlight/links.html
+++ b/templates/docs/examples/patterns/text-spotlight/links.html
@@ -1,0 +1,32 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_text-spotlight.jinja" import vf_text_spotlight %}
+{% block title %}Text Spotlight{% endblock %}
+{% block standalone_css %}patterns_all{% endblock %}
+{% set is_paper = true %}
+{% block content %}
+    {% call(slot) vf_text_spotlight(
+        title_text='Working here',
+        ) -%}
+        {%- if slot == 'list_item_1' -%}
+            <a href="https://canonical.com/careers/hiring-process">Hiring process</a>
+        {%- endif -%}
+        {%- if slot == 'list_item_2' -%}
+            <a href="https://canonical.com/careers/company-culture">Company culture</a>
+        {%- endif -%}
+        {%- if slot == 'list_item_3' -%}
+            <a href="https://canonical.com/careers/company-culture/remote-work">Remote work</a>
+        {%- endif -%}
+        {%- if slot == 'list_item_4' -%}
+            <a href="https://canonical.com/careers/progression">Progression</a>
+        {%- endif -%}
+        {%- if slot == 'list_item_5' -%}
+            <a href="https://canonical.com/careers/diversity">Diversity</a>
+        {%- endif -%}
+        {%- if slot == 'list_item_6' -%}
+            <a href="https://canonical.com/careers/sustainability">Sustainability</a>
+        {%- endif -%}
+        {%- if slot == 'list_item_7' -%}
+            <a href="https://canonical.com/careers/application/faq">FAQs</a>
+        {%- endif -%}
+    {% endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/text-spotlight/links.html
+++ b/templates/docs/examples/patterns/text-spotlight/links.html
@@ -1,6 +1,6 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_text-spotlight.jinja" import vf_text_spotlight %}
-{% block title %}Text Spotlight{% endblock %}
+{% block title %}Text Spotlight / Links{% endblock %}
 {% block standalone_css %}patterns_all{% endblock %}
 {% set is_paper = true %}
 {% block content %}

--- a/templates/docs/patterns/text-spotlight/index.md
+++ b/templates/docs/patterns/text-spotlight/index.md
@@ -15,11 +15,10 @@ A Text Spotlight is a prominent section typically used to quickly capture user's
 
 The Text Spotlight pattern is composed of the following elements:
 
-| Element              | Description                                                                                                          |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| Rule (**required**)  | [Default rule](/docs/patterns/rule#default)                                                                          |
-| Title (**required**) | Title text (to be placed in `h2` heading)                                                                            |
-| List (**required**)  | A [divided list](/docs/patterns/lists#ticked-with-horizontal-divider) with up to 7 list items (minimum 2, maximum 7) |
+| Element              | Description                                                                 |
+| -------------------- | --------------------------------------------------------------------------- |
+| Title (**required**) | Title text (to be placed in `h2` heading)                                   |
+| List (**required**)  | A list of paragraphs separated with horizontal rules (minimum 2, maximum 7) |
 
 ## Default
 

--- a/templates/docs/patterns/text-spotlight/index.md
+++ b/templates/docs/patterns/text-spotlight/index.md
@@ -71,31 +71,21 @@ The `vf_text-spotlight` Jinja macro can be used to generate a Text Spolight Patt
           <code>h2</code> title text
         </td>
       </tr>
-    </tbody>
-  </table>
-</div>
-
-### Slots
-
-<div style="overflow: auto;">
-  <table>
-    <thead>
-      <tr>
-        <th style="width: 220px;">Name</th>
-        <th style="width: 160px;">Required?</th>
-        <th style="width: 250px;">Description</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr>
         <td>
-          <code>list_item_[1-7]</code>
+          <code>list_items</code>
         </td>
         <td>
           Yes
         </td>
         <td>
-          Contents of the list item rendered in an H2 styled <code>p</code> tag. Must be between 2 and 7.
+          <code>Array&lt;string&gt;</code>
+        </td>
+        <td>
+          <code>Yes</code>
+        </td>
+        <td>
+          An array of text or HTML strings
         </td>
       </tr>
     </tbody>

--- a/templates/docs/patterns/text-spotlight/index.md
+++ b/templates/docs/patterns/text-spotlight/index.md
@@ -76,13 +76,13 @@ The `vf_text-spotlight` Jinja macro can be used to generate a Text Spolight Patt
           <code>list_items</code>
         </td>
         <td>
-          <code>[]</code>
+          Yes
         </td>
         <td>
           <code>Array&lt;string&gt;</code>
         </td>
         <td>
-          <code>Yes</code>
+          <code>[]</code>
         </td>
         <td>
           An array of text or HTML strings

--- a/templates/docs/patterns/text-spotlight/index.md
+++ b/templates/docs/patterns/text-spotlight/index.md
@@ -76,7 +76,7 @@ The `vf_text-spotlight` Jinja macro can be used to generate a Text Spolight Patt
           <code>list_items</code>
         </td>
         <td>
-          Yes
+          <code>[]</code>
         </td>
         <td>
           <code>Array&lt;string&gt;</code>

--- a/templates/docs/patterns/text-spotlight/index.md
+++ b/templates/docs/patterns/text-spotlight/index.md
@@ -1,0 +1,125 @@
+---
+wrapper_template: '_layouts/docs.html'
+context:
+  title: Text Spotlight | Patterns
+---
+
+{% from "docs/macros/patterns/wip-notice.jinja" import pattern_wip_notice %}
+
+{{- pattern_wip_notice() }}
+
+A CTA section is a prominent section typically used to quickly capture user's attention to specific action items / benefits or advantages of selecting a specific product.
+
+- [Default](#default)
+- [Links](#links)
+
+The CTA section pattern is composed of the following elements:
+
+| Element | Description                                                                                    |
+| ------- | ---------------------------------------------------------------------------------------------- |
+| Rule    | [Default rule](/docs/patterns/rule#default)                                                    |
+| Title   | Title text (to be placed in `h2` heading)                                                      |
+| List    | A [divided list](/docs/patterns/lists#ticked-with-horizontal-divider) with up to 7 list items. |
+
+## Default
+
+You can use pass default text items in the list.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/text-spotlight/default" class="js-example" data-lang="jinja">
+View example of the default text spotlight section
+</a></div>
+
+## Links
+
+You can also pass links as text items in the list
+
+<div class="embedded-example"><a href="/docs/examples/patterns/text-spotlight/links" class="js-example" data-lang="jinja">
+View example of the text spotlight section with links
+</a></div>
+
+## Jinja Macro
+
+The `vf_text-spotlight` Jinja macro can be used to generate a Text Spolight Pattern. The API for the macro is shown below.
+
+### Parameters
+
+<div style="overflow: auto;">
+  <table>
+    <thead>
+      <tr>
+        <th style="width: 220px;">Name</th>
+        <th style="width: 160px;">Required?</th>
+        <th style="width: 160px;">Type</th>
+        <th style="width: 160px;">Default</th>
+        <th style="width: 250px;">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>title_text</code>
+        </td>
+        <td>
+          Yes
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>
+          <code>N/A</code>
+        </td>
+        <td>
+          <code>h2</code> title text
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+### Slots
+
+<div style="overflow: auto;">
+  <table>
+    <thead>
+      <tr>
+        <th style="width: 220px;">Name</th>
+        <th style="width: 160px;">Required?</th>
+        <th style="width: 250px;">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>list_item_[1-7]</code>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          Contents of a <code>.p-list__item</code> element for the list item.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+## Import
+
+### Jinja Macro
+
+To import the Text Spotlight Jinja macro, copy the following import statement into your
+Jinja template.
+
+```jinja
+{% raw -%}
+{% from "_macros/vf_text-spotlight.jinja" import vf_text_spotlight %}
+{%- endraw -%}
+```
+
+View the [building with Jinja macros guide](/docs/building-vanilla#jinja-macros)
+for macro installation instructions.
+
+### SCSS
+
+Since Patterns leverage many other parts of Vanilla in their composition and content, we
+recommend [importing the entirety of Vanilla](/docs#install) for full support.

--- a/templates/docs/patterns/text-spotlight/index.md
+++ b/templates/docs/patterns/text-spotlight/index.md
@@ -8,18 +8,18 @@ context:
 
 {{- pattern_wip_notice() }}
 
-A CTA section is a prominent section typically used to quickly capture user's attention to specific action items / benefits or advantages of selecting a specific product.
+A Text Spotlight is a prominent section typically used to quickly capture user's attention to specific action items / benefits or advantages of selecting a specific product.
 
 - [Default](#default)
 - [Links](#links)
 
-The CTA section pattern is composed of the following elements:
+The Text Spotlight pattern is composed of the following elements:
 
-| Element | Description                                                                                    |
-| ------- | ---------------------------------------------------------------------------------------------- |
-| Rule    | [Default rule](/docs/patterns/rule#default)                                                    |
-| Title   | Title text (to be placed in `h2` heading)                                                      |
-| List    | A [divided list](/docs/patterns/lists#ticked-with-horizontal-divider) with up to 7 list items. |
+| Element              | Description                                                                                                          |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Rule (**required**)  | [Default rule](/docs/patterns/rule#default)                                                                          |
+| Title (**required**) | Title text (to be placed in `h2` heading)                                                                            |
+| List (**required**)  | A [divided list](/docs/patterns/lists#ticked-with-horizontal-divider) with up to 7 list items (minimum 2, maximum 7) |
 
 ## Default
 
@@ -93,10 +93,10 @@ The `vf_text-spotlight` Jinja macro can be used to generate a Text Spolight Patt
           <code>list_item_[1-7]</code>
         </td>
         <td>
-          No
+          Yes
         </td>
         <td>
-          Contents of a <code>.p-list__item</code> element for the list item.
+          Contents of a <code>.p-list__item</code> element for the list item. Must be between 2 and 7.
         </td>
       </tr>
     </tbody>

--- a/templates/docs/patterns/text-spotlight/index.md
+++ b/templates/docs/patterns/text-spotlight/index.md
@@ -96,7 +96,7 @@ The `vf_text-spotlight` Jinja macro can be used to generate a Text Spolight Patt
           Yes
         </td>
         <td>
-          Contents of a <code>.p-list__item</code> element for the list item. Must be between 2 and 7.
+          Contents of the list item rendered in an H2 styled <code>p</code> tag. Must be between 2 and 7.
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
## Done

- Implemented Text Spotlight section pattern
- Added Docs
- Added Examples

Fixes [WD-22567](https://warthogs.atlassian.net/browse/WD-22567)

## QA

- Open demos:
   - [Default](https://vanilla-framework-5572.demos.haus/docs/examples/patterns/text-spotlight/default.html)
   - [Links](https://vanilla-framework-5572.demos.haus/docs/examples/patterns/text-spotlight/links.html)
   - [All combined](https://vanilla-framework-5572.demos.haus/docs/examples/patterns/text-spotlight/combined.html)
- Match the above demos with [figma](https://www.figma.com/design/1brHCsyeTE6FU7hfJd6ao2/%F0%9F%9A%A7---WIP--Sites---Core-component-library?node-id=362-18300&p=f&t=gKjFSDfyAErg2OUz-0)
- Review [documentation](https://vanilla-framework-5572.demos.haus/docs/patterns/text-spotlight)

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


[WD-22567]: https://warthogs.atlassian.net/browse/WD-22567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ