### PR TITLE
fix(Chip): Chip icon spacing adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.26.0",
+  "version": "4.26.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_chip.scss
+++ b/scss/_patterns_chip.scss
@@ -7,8 +7,6 @@
     align-self: center;
     background-size: map-get($icon-sizes, small);
     flex: 0 0 auto;
-    // Space chip away from the content preceding it in the chip body
-    margin-left: $sph--x-small;
     @media (min-width: $breakpoint-x-large) {
       background-size: math.div(map-get($icon-sizes, small), $font-size-ratio--largescreen); //ensure no rounding happens as it positions the icon off center
     }
@@ -58,6 +56,8 @@
       @include vf-icon-close-themed;
 
       border-radius: 50%;
+      // Space away from the content preceding it in the chip body
+      margin-left: $sph--x-small;
     }
 
     & > [class*='p-icon--'] {


### PR DESCRIPTION
## Done

- Removes the left margin from icons inside chips

Fixes https://github.com/canonical/react-components/pull/1217#discussion_r2194391528

## QA

- Open [icon chip example]() and verify the icon has no left margin

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="232" alt="Screenshot 2025-07-09 at 08 41 50" src="https://github.com/user-attachments/assets/6cb5e579-2028-4a6f-b957-343d7d9e62e0" />

