### PR TITLE
feat: added support for highlighting images in equal-heights macro

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.27.0",
+  "version": "4.27.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.27.1",
+  "version": "4.28.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.28.0
+  features:
+    - component: Equal heights
+      url: /docs/patterns/equal-heights
+      status: Updated
+      notes: We've introduced option to highlight images in equal heights pattern.
 - version: 4.27.0
   features:
     - component: Grid

--- a/releases.yml
+++ b/releases.yml
@@ -3,7 +3,7 @@
     - component: Equal heights
       url: /docs/patterns/equal-heights
       status: Updated
-      notes: We've introduced option to highlight images in equal heights pattern.
+      notes: We've introduced an option to use <a href="/docs/patterns/images#highlighted-image">highlighted images</a> within the equal heights pattern.
 - version: 4.27.0
   features:
     - component: Grid

--- a/templates/_macros/vf_equal-heights.jinja
+++ b/templates/_macros/vf_equal-heights.jinja
@@ -3,6 +3,7 @@
   - title_text (string) (required): The text to be displayed as the heading
   - subtitle_text (string) (optional): The text to be displayed as the subtitle
   - subtitle_heading_level (int) (optional): The heading level for the subtitle. Can be 4 or 5. Defaults to 5.
+  - highlight_images (boolean) (optional): If the images need to be highlighted, which means adding a subtle grey background. Not added by default.
   - image_aspect_ratio_small (string) (optional): The aspect ratio for item images on small screens. Defaults to "square". Can be "square", "2-3", "3-2", "16-9", "cinematic". Defaults to "square".
   - image_aspect_ratio_medium (string) (optional): The aspect ratio for item images on medium screens. Defaults to "square". Can be "square", "2-3", "3-2", "16-9", "cinematic". Defaults to "square".
   - image_aspect_ratio_large (string) (optional): The aspect ratio for item images on large screens. Defaults to "2-3". Can be "square", "2-3", "3-2", "16-9", "cinematic". Defaults to "2-3".
@@ -12,6 +13,7 @@
   title_text,
   subtitle_text="",
   subtitle_heading_level=5,
+  highlight_images=false,
   image_aspect_ratio_small="square",
   image_aspect_ratio_medium="square",
   image_aspect_ratio_large="2-3",
@@ -67,7 +69,7 @@
               {#- Image item (required) -#}
               <div class="p-equal-height-row__item">
                 <div
-                  class="p-image-container--{{ image_aspect_ratio_small }}-on-small p-image-container--{{ image_aspect_ratio_medium }}-on-medium p-image-container--{{ image_aspect_ratio_large }}-on-large is-cover">
+                  class="p-image-container--{{ image_aspect_ratio_small }}-on-small p-image-container--{{ image_aspect_ratio_medium }}-on-medium p-image-container--{{ image_aspect_ratio_large }}-on-large is-cover{% if highlight_images %} is-highlighted{% endif %}" >
                   {#- The consumer must pass in an img.p-image-container__image for the image to be properly formatted -#}
                   {{- image | safe -}}
                 </div>

--- a/templates/docs/examples/patterns/equal-heights/4-columns-highlighted-images.html
+++ b/templates/docs/examples/patterns/equal-heights/4-columns-highlighted-images.html
@@ -1,0 +1,66 @@
+{% extends "_layouts/examples.html" %}
+
+{% from "_macros/vf_equal-heights.jinja" import vf_equal_heights %}
+
+{% block title %}Equal heights / 4 columns / Highlighted images{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+  {% call(slot) vf_equal_heights(
+    title_text="Why choose Charmed Kubeflow?",
+    image_aspect_ratio_medium="2-3",
+    image_aspect_ratio_small="2-3",
+    highlight_images=True,
+    items=[
+    {
+    "title_text": "One solution, any cloud
+    ",
+    "image_html":  '<img src="https://assets.ubuntu.com/v1/566c5295-one-solution.png"
+     class="p-image-container__image"
+     width="568"
+     height="853"
+     alt="" />',
+    "description_html": "<p>Deploy Kubeflow on public clouds, private infrastructure, or air-gapped environments.</p>",
+    },
+    {
+    "title_text": "Multi-user collaboration",
+    "image_html":  '<img src="https://assets.ubuntu.com/v1/1b774c6e-multi-user.png"
+     class="p-image-container__image"
+     width="568"
+     height="853"
+     alt="" />',
+    "description_html": "<p>Enable secure workspaces with role-based access for data science teams.</p>",
+    },
+    {
+    "title_text": "Scale with confidence",
+    "image_html":  '<img src="https://assets.ubuntu.com/v1/faa2c0b5-scale-with.png"
+     class="p-image-container__image"
+     width="568"
+     height="853"
+     alt="" />',
+    "description_html": "<p>Run parallel experiments at any scale, with GPU acceleration built-in.</p>",
+    },
+    {
+    "title_text": "Open and cost-efficient",
+    "image_html":  '<img src="https://assets.ubuntu.com/v1/c9c7d08a-open-and.png"
+     class="p-image-container__image"
+     width="568"
+     height="853"
+     alt="" />',
+    "description_html": "<p>No licensing fees. No usage limits. Backed by Canonical’s enterprise-grade support.</p>",
+    }
+    ]
+    ) %}
+    {% if slot == "description" %}
+      <p>
+        The fastest way to deploy production-ready Kubeflow, with full support and zero lock-in. Run anywhere, scale effortlessly, and empower your data scientists.
+      </p>
+    {% endif %}
+    {% if slot == "cta" %}
+      <a href="https://drive.google.com/file/d/1rXCpoDB6EnSgqtinuV2aITIjLHv1WyVc/view"
+         class="p-button">Explore Charmed Kubeflow</a>
+    {% endif %}
+  {% endcall %}
+
+{% endblock %}

--- a/templates/docs/examples/patterns/equal-heights/4-columns-highlighted-images.html
+++ b/templates/docs/examples/patterns/equal-heights/4-columns-highlighted-images.html
@@ -58,7 +58,7 @@
       </p>
     {% endif %}
     {% if slot == "cta" %}
-      <a href="https://drive.google.com/file/d/1rXCpoDB6EnSgqtinuV2aITIjLHv1WyVc/view"
+      <a href="#"
          class="p-button">Explore Charmed Kubeflow</a>
     {% endif %}
   {% endcall %}

--- a/templates/docs/examples/patterns/equal-heights/combined.html
+++ b/templates/docs/examples/patterns/equal-heights/combined.html
@@ -15,5 +15,6 @@
 <section>{% include 'docs/examples/patterns/equal-heights/3-columns-no-cta-responsive.html' %}</section>
 <section>{% include 'docs/examples/patterns/equal-heights/mixed-column-items-responsive.html' %}</section>
 <section>{% include 'docs/examples/patterns/equal-heights/minimal-responsive.html' %}</section>
+<section>{% include 'docs/examples/patterns/equal-heights/4-columns-highlighted-images.html' %}</section>
 {% endwith %}
 {% endblock %}

--- a/templates/docs/patterns/equal-heights/index.md
+++ b/templates/docs/patterns/equal-heights/index.md
@@ -17,7 +17,7 @@ The equal heights pattern is composed of the following elements:
 | title_text (**required**)         | `H2` title text.                                                                                                                                                                                                             |
 | subtitle_text                     | `H4` or `H5` subtitle text, depending on `subtitle_heading_level`.                                                                                                                                                           |
 | subtitle_heading_level            | Heading level of the subtitles. May be `4` or `5`. Defaults to `5`.                                                                                                                                                          |
-| highlight_images                  | If the images need to be highlighted, which means adding a subtle grey background. Not added by default.                                                                                                                     |
+| highlight_images                  | If the images need to be [highlighted](https://vanillaframework.io/docs/patterns/images#highlighted-image). Not added by default.                                                                                            |
 | image_aspect_ratio_small          | The aspect ratio to apply to item images on [small screens](/docs/settings/breakpoint-settings). Can be any of the [image container aspect ratio identifiers](/docs/patterns/images#class-reference). Defaults to "square".  |
 | image_aspect_ratio_medium         | The aspect ratio to apply to item images on [medium screens](/docs/settings/breakpoint-settings). Can be any of the [image container aspect ratio identifiers](/docs/patterns/images#class-reference). Defaults to "square". |
 | image_aspect_ratio_large          | The aspect ratio to apply to item images on [large screens](/docs/settings/breakpoint-settings). Can be any of the [image container aspect ratio identifiers](/docs/patterns/images#class-reference). Defaults to "2-3".     |
@@ -61,6 +61,14 @@ In the following example, the second and fourth items are missing descriptions, 
 This demonstrates what **not** to do with this pattern.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/equal-heights/mixed-column-items-responsive" class="js-example" data-lang="jinja">
+View example of the equal heights pattern
+</a></div>
+
+## Highlighted Images
+
+To [highlight](https://vanillaframework.io/docs/patterns/images#highlighted-image) images with in the pattern, set `highlight_images=True`. This is generally used when images are illustrations.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/equal-heights/4-columns-highlighted-images" class="js-example" data-lang="jinja">
 View example of the equal heights pattern
 </a></div>
 
@@ -143,7 +151,7 @@ shown below.
            <code>False</code>
         </td>
         <td>
-          If the images need to be highlighted.
+          If the images need to be <a href="https://vanillaframework.io/docs/patterns/images#highlighted-image">highlighted</a>.
         </td>
       </tr>
       <tr>

--- a/templates/docs/patterns/equal-heights/index.md
+++ b/templates/docs/patterns/equal-heights/index.md
@@ -17,6 +17,7 @@ The equal heights pattern is composed of the following elements:
 | title_text (**required**)         | `H2` title text.                                                                                                                                                                                                             |
 | subtitle_text                     | `H4` or `H5` subtitle text, depending on `subtitle_heading_level`.                                                                                                                                                           |
 | subtitle_heading_level            | Heading level of the subtitles. May be `4` or `5`. Defaults to `5`.                                                                                                                                                          |
+| highlight_images                  | If the images need to be highlighted, which means adding a subtle grey background. Not added by default.                                                                                                                     |
 | image_aspect_ratio_small          | The aspect ratio to apply to item images on [small screens](/docs/settings/breakpoint-settings). Can be any of the [image container aspect ratio identifiers](/docs/patterns/images#class-reference). Defaults to "square".  |
 | image_aspect_ratio_medium         | The aspect ratio to apply to item images on [medium screens](/docs/settings/breakpoint-settings). Can be any of the [image container aspect ratio identifiers](/docs/patterns/images#class-reference). Defaults to "square". |
 | image_aspect_ratio_large          | The aspect ratio to apply to item images on [large screens](/docs/settings/breakpoint-settings). Can be any of the [image container aspect ratio identifiers](/docs/patterns/images#class-reference). Defaults to "2-3".     |
@@ -127,6 +128,22 @@ shown below.
         </td>
         <td>
           Heading level of the subtitles. May be <code>4</code> or <code>5</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>highlight_images</code>
+        </td>
+        <td>
+          No </td>
+        <td>
+          boolean
+        </td>
+        <td>
+           <code>False</code>
+        </td>
+        <td>
+          If the images need to be highlighted.
         </td>
       </tr>
       <tr>

--- a/templates/docs/patterns/equal-heights/index.md
+++ b/templates/docs/patterns/equal-heights/index.md
@@ -66,7 +66,7 @@ View example of the equal heights pattern
 
 ## Highlighted Images
 
-To [highlight](https://vanillaframework.io/docs/patterns/images#highlighted-image) images with in the pattern, set `highlight_images=True`. This is generally used when images are illustrations.
+To [highlight](https://vanillaframework.io/docs/patterns/images#highlighted-image) images within the pattern, set `highlight_images=True`. This is generally used when images are illustrations.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/equal-heights/4-columns-highlighted-images" class="js-example" data-lang="jinja">
 View example of the equal heights pattern
@@ -151,7 +151,7 @@ shown below.
            <code>False</code>
         </td>
         <td>
-          If the images need to be <a href="https://vanillaframework.io/docs/patterns/images#highlighted-image">highlighted</a>.
+          Whether to <a href="https://vanillaframework.io/docs/patterns/images#highlighted-image">highlight</a> images within the pattern.
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
## Done

added support for highlighting images in equal-heights macro

Fixes [list issues/bugs if needed]

## QA

- Check out demo [demo](https://canonical-com-1818.demos.haus/mlops/kubeflow) and code at https://github.com/canonical/canonical.com/pull/1818
- Review updated documentation:
  - Documentation for equal-height-row

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
