### PR TITLE
Add usage guidelines docs

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -12,6 +12,10 @@
       url: /docs/settings/font-settings#heading-levels-new
       status: Updated
       notes: We've added <code>$font-weight-</code> variables for each heading level, allowing for customisation of font weights for headings.
+    - component: Usage guidelines
+      url: /docs/usage-guidelines
+      status: New
+      notes: We've added a new section for usage guidelines, providing best practices for using Vanilla components.
 - version: 4.26.0
   features:
     - component: Icons

--- a/side-navigation.yaml
+++ b/side-navigation.yaml
@@ -8,6 +8,8 @@
       url: /docs/customising-vanilla
     - title: Content Guidelines
       url: /docs/content-guidelines
+    - title: Usage Guidelines
+      url: /docs/usage-guidelines
     - title: What's new in {version}
       url: /docs/whats-new
     - title: Migrating to v4

--- a/templates/docs/examples/docs/usage-guidelines/component-mixing/combined.html
+++ b/templates/docs/examples/docs/usage-guidelines/component-mixing/combined.html
@@ -1,0 +1,11 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Docs / Usage guidelines / Component mixing / Combined{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{% with is_combined = true %}
+<section>{% include 'docs/examples/docs/usage-guidelines/component-mixing/what-to-do.html' %}</section>
+<section>{% include 'docs/examples/docs/usage-guidelines/component-mixing/what-not-to-do.html' %}</section>
+{% endwith %}
+{% endblock %}

--- a/templates/docs/examples/docs/usage-guidelines/component-mixing/what-not-to-do.html
+++ b/templates/docs/examples/docs/usage-guidelines/component-mixing/what-not-to-do.html
@@ -1,0 +1,60 @@
+{% extends "_layouts/examples.html" %}
+
+{% block title %}Docs / Usage guidelines / Component mixing / What not to do{% endblock %}
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% set is_paper = True %}
+{% block content %}
+
+<div class="p-equal-height-row--wrap ">
+  <div class="p-equal-height-row__col">
+    <div class="p-equal-height-row__item p-image-container--2-3 u-hide--small">
+      <img
+        src="https://assets.ubuntu.com/v1/0871d97c-data.jpg"
+        alt=""
+        width="568"
+        height="853"
+        class="p-image-container__image"
+        loading="lazy"
+      >
+    </div>
+    <h3 class="p-equal-height-row__item p-heading--5">1. Data</h3>
+    <p class="p-equal-height-row__item">
+      Your data governance practices obey your country's rules for collection, storage, processing, sharing, and disposal.
+    </p>
+  </div>
+  <div class="p-equal-height-row__col">
+    <div class="p-equal-height-row__item p-image-container--2-3 u-hide--small">
+      <img
+        src="https://assets.ubuntu.com/v1/a8fb93d1-operations.jpg"
+        alt=""
+        width="568"
+        height="853"
+        class="p-image-container__image"
+        loading="lazy"
+      >
+    </div>
+    <h3 class="p-equal-height-row__item p-heading--5">2. Operations</h3>
+    <p class="p-equal-height-row__item">
+      Your organization controls your operations and has full control and oversight of their use and management.
+    </p>
+  </div>
+  <div class="p-equal-height-row__col">
+    <div class="p-equal-height-row__item p-image-container--2-3 u-hide--small">
+      <img
+        src="https://assets.ubuntu.com/v1/7b18db59-technology.jpg"
+        alt=""
+        width="568"
+        height="853"
+        class="p-image-container__image"
+        loading="lazy"
+      >
+    </div>
+    <h3 class="p-equal-height-row__item p-heading--5">3. Technology</h3>
+    <p class="p-equal-height-row__item">
+      Your hardware and software are designed to ensure 100% control and reliability of your data and services.
+    </p>
+  </div>
+</div>
+
+{% endblock %}

--- a/templates/docs/examples/docs/usage-guidelines/component-mixing/what-to-do.html
+++ b/templates/docs/examples/docs/usage-guidelines/component-mixing/what-to-do.html
@@ -1,0 +1,72 @@
+{% extends "_layouts/examples.html" %}
+
+{% block title %}Docs / Usage guidelines / Component mixing / What to do{% endblock %}
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% set is_paper = True %}
+{% block content %}
+
+<div class="p-equal-height-row--wrap ">
+  <div class="p-equal-height-row__col">
+    <div class="p-equal-height-row__item">
+      <div class="p-image-container--2-3 u-hide--small">
+        <img
+          src="https://assets.ubuntu.com/v1/0871d97c-data.jpg"
+          alt=""
+          width="568"
+          height="853"
+          class="p-image-container__image"
+          loading="lazy"
+        >
+      </div>
+    </div>
+    <div class="p-equal-height-row__item">
+      <h3 class="p-heading--5">1. Data</h3>
+    </div>
+    <p class="p-equal-height-row__item">
+      Your data governance practices obey your country's rules for collection, storage, processing, sharing, and disposal.
+    </p>
+  </div>
+  <div class="p-equal-height-row__col">
+    <div class="p-equal-height-row__item">
+      <div class="p-image-container--2-3 u-hide--small">
+        <img
+          src="https://assets.ubuntu.com/v1/a8fb93d1-operations.jpg"
+          alt=""
+          width="568"
+          height="853"
+          class="p-image-container__image"
+          loading="lazy"
+        >
+      </div>
+    </div>
+    <div class="p-equal-height-row__item">
+      <h3 class="p-heading--5">2. Operations</h3>
+    </div>
+    <p class="p-equal-height-row__item">
+      Your organization controls your operations and has full control and oversight of their use and management.
+    </p>
+  </div>
+  <div class="p-equal-height-row__col">
+    <div class="p-equal-height-row__item">
+      <div class="p-image-container--2-3 u-hide--small">
+        <img
+          src="https://assets.ubuntu.com/v1/7b18db59-technology.jpg"
+          alt=""
+          width="568"
+          height="853"
+          class="p-image-container__image"
+          loading="lazy"
+        >
+      </div>
+    </div>
+    <div class="p-equal-height-row__item">
+      <h3 class="p-heading--5">3. Technology</h3>
+    </div>
+    <p class="p-equal-height-row__item">
+      Your hardware and software are designed to ensure 100% control and reliability of your data and services.
+    </p>
+  </div>
+</div>
+
+{% endblock %}

--- a/templates/docs/usage-guidelines.md
+++ b/templates/docs/usage-guidelines.md
@@ -1,0 +1,36 @@
+---
+wrapper_template: '_layouts/docs.html'
+context:
+  title: Usage Guidelines
+  description: Usage guidelines for Vanilla Framework
+---
+
+## Component mixing
+
+Component mixing is the practice of using class names for multiple components on a single element.
+Vanilla components are tested in isolation, so mixing components can lead to unexpected results.
+We recommend that you avoid mixing components. Elements should only use class names from one component, unless otherwise documented.
+
+### Utility classes
+
+Our utility classes are designed with a very narrow scope, and are intended to modify the behavior of other components. 
+Components can be mixed with utility classes, unless otherwise documented.
+
+### What to do
+The following example demonstrates usage of a single component per element, which is the recommended approach.
+Equal height row items wrap image containers and headings, instead of mixing them on the same element.
+
+<div class="embedded-example"><a href="/docs/examples/docs/usage-guidelines/component-mixing/what-to-do" class="js-example">
+  View example of recommended component usage
+</a></div>
+
+### What not to do
+The following is an example of mixing components, which is not recommended.
+
+- Mixing the equal height row item and image container causes the image container to be placed outside its parent.
+- Mixing the equal height row item and heading has no unintended consequences at this time, but may lead to unexpected results in the future.
+
+
+<div class="embedded-example"><a href="/docs/examples/docs/usage-guidelines/component-mixing/what-not-to-do" class="js-example">
+  View example of component mixing, which is not recommended
+</a></div>


### PR DESCRIPTION
## Done

Adds a "usage guidelines" page to cover guidelines/best practices for using Vanilla.

Currently this just includes instructions to avoid component mixing. This has been requested for some time, but I'm adding it now as I've found an [example](https://github.com/canonical/canonical.com/pull/1833) where component mixing can be actively harmful and cause visual regressions. It's on us to make these guidelines clear so this can be avoided in future.

## QA

- Open usage guidelines. Verify they make sense / are easy to follow and understand.

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1138" height="764" alt="Screenshot 2025-08-01 at 12 11 25" src="https://github.com/user-attachments/assets/32d85aaf-1adf-4ab2-9fb7-451427a54b23" />

