### PR TITLE
[WD-24276] feat: implemented Single Pricing Block pattern variant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.27.0",
+  "version": "4.28.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.28.0",
+  "version": "4.29.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.28.0
+  features:
+    - component: Single Tier Pricing Block Pattern Variant
+      url: /docs/patterns/pricing-block#1-block
+      status: New
+      notes: We've added a new Single Tier variant for Pricing Block Pattern
 - version: 4.27.0
   features:
     - component: Grid

--- a/releases.yml
+++ b/releases.yml
@@ -1,13 +1,15 @@
+- version: 4.29.0
+  features:
+    - component: Single-tier pricing block pattern variant
+      url: /docs/patterns/pricing-block#1-block
+      status: New
+      notes: We've added a new single-tier variant for the pricing block pattern.
 - version: 4.28.0
   features:
     - component: Equal heights
       url: /docs/patterns/equal-heights
       status: Updated
       notes: We've introduced an option to use <a href="/docs/patterns/images#highlighted-image">highlighted images</a> within the equal heights pattern.
-    - component: Single-tier pricing block pattern variant
-      url: /docs/patterns/pricing-block#1-block
-      status: New
-      notes: We've added a new single-tier variant for the pricing block pattern.
 - version: 4.27.0
   features:
     - component: Grid
@@ -509,7 +511,7 @@
     - component: Divided lists
       url: /docs/patterns/lists#bulleted-with-horizontal-divider
       status: Updated
-      notes: 'We removed the line above the first list item in the bulleted list with horizontal divider.'
+      notes: "We removed the line above the first list item in the bulleted list with horizontal divider."
 - version: 3.13.0
   features:
     - component: Brochure site layout

--- a/releases.yml
+++ b/releases.yml
@@ -511,7 +511,7 @@
     - component: Divided lists
       url: /docs/patterns/lists#bulleted-with-horizontal-divider
       status: Updated
-      notes: "We removed the line above the first list item in the bulleted list with horizontal divider."
+      notes: 'We removed the line above the first list item in the bulleted list with horizontal divider.'
 - version: 3.13.0
   features:
     - component: Brochure site layout

--- a/templates/_macros/vf_pricing-block.jinja
+++ b/templates/_macros/vf_pricing-block.jinja
@@ -1,7 +1,7 @@
 {#
   Params
   - title_text (string) (required): The text to be displayed as the heading
-  - top_rule_variant (string) (optional): Variant of the top rule, default is default
+  - top_rule_variant (string) (optional): Variant of the top rule, default is "highlighted". Options are "muted", "highlighted", "none".
   - tiers (Array<{
       tier_name_text: String (optional),
       tier_price_text: String,
@@ -18,13 +18,13 @@
   - description (optional): paragraph-style content below the title
 #}
 {%- macro vf_pricing_block(
-  top_rule_variant="default",
+  top_rule_variant="highlighted",
   title_text="",
   tiers=[]
   ) -%}
   {% set top_rule_variant = top_rule_variant | trim %}
-  {% if top_rule_variant not in ['default', 'muted', 'highlighted', 'none'] %}
-    {% set top_rule_variant = "default" %}
+  {% if top_rule_variant not in ['muted', 'highlighted', 'none'] %}
+    {% set top_rule_variant = "highlighted" %}
   {% endif %}
   {% set section_description = caller('section_description') %}
   {% set has_tier_descriptions = (tiers | selectattr("tier_description_html") | list | length) > 0 %}
@@ -80,9 +80,7 @@
     {%- endfor -%}
   {%- endmacro -%}
   {%- macro _top_rule() -%}
-    {% if top_rule_variant == 'default' %}
-      <hr class="p-rule is-fixed-width" />
-    {% elif top_rule_variant == 'muted' %}
+    {% if top_rule_variant == 'muted' %}
       <hr class="p-rule--muted is-fixed-width" />
     {% elif top_rule_variant == 'highlighted' %}
       <hr class="p-rule--highlight is-fixed-width" />

--- a/templates/_macros/vf_pricing-block.jinja
+++ b/templates/_macros/vf_pricing-block.jinja
@@ -1,8 +1,9 @@
 {#
   Params
   - title_text (string) (required): The text to be displayed as the heading
+  - is_rule_highlighted (boolean) (optional): Whether to toggle a strong horizontal rule
   - tiers (Array<{
-      tier_name_text: String,
+      tier_name_text: String (optional),
       tier_price_text: String,
       tier_price_explanation: String,
       tier_description_html?: String,
@@ -17,6 +18,7 @@
   - description (optional): paragraph-style content below the title
 #}
 {%- macro vf_pricing_block(
+  is_rule_highlighted=True,
   title_text="",
   tiers=[]
   ) -%}
@@ -29,7 +31,6 @@
   {% else %}
     {% set base_class_name = "p-pricing-block" %}
   {% endif %}
-
   {%- macro _tier_offerings_list(tier) %}
     <p class="u-text--muted">What's included</p>
     <hr class="p-rule--muted u-no-margin--bottom" />
@@ -47,42 +48,46 @@
       {% endfor -%}
     </ul>
   {%- endmacro -%}
-
+  {%- macro _tiers() -%}
+    {%- for tier in tiers %}
+      <div class="p-pricing-block__tier">
+        <div class="p-pricing-block__section">
+          <div class="p-section--shallow">
+            <h3 class="p-heading--{% if tiers|length == 1 and (not 'tier_name_text' in tier) %}2{% else %}4{% endif %}">
+              {% if 'tier_name_text' in tier %}
+                {{ tier.get("tier_name_text") }}
+                <br />
+              {% endif %}
+              <strong>{{ tier.get("tier_price_text") }}</strong>
+              <span class="u-text--muted">{{ tier.get("tier_price_explanation") }}</span>
+            </h3>
+          </div>
+        </div>
+        {%- if has_tier_descriptions -%}
+          {% set description = tier.get("tier_description_html") if tier.get("tier_description_html") else '' %}
+          <div class="p-pricing-block__section"
+               {% if not description %}role="presentation"{% endif %}>{{ description }}</div>
+        {%- endif %}
+        <div class="p-pricing-block__section">{{ _tier_offerings_list(tier) }}</div>
+        {% if tier.cta_html %}
+          <div class="p-pricing-block__section">{{ tier.cta_html }}</div>
+        {% endif -%}
+      </div>
+    {%- endfor -%}
+  {%- endmacro -%}
   <div class="p-section">
     <div class="p-section--shallow">
-      <hr class="p-rule--highlight is-fixed-width" />
+      <hr class="p-rule{% if is_rule_highlighted %}--highlight{% endif %} is-fixed-width" />
       <div class="grid-row">
         <div class="grid-col-4 grid-col-medium-4 grid-col-small-4">
           <h2>{{ title_text }}</h2>
         </div>
-        {%- if section_description -%}
-          <div class="grid-col-4 grid-col-medium-4 grid-col-small-4">{{ section_description }}</div>
-        {%- endif -%}
+        <div class="grid-col-4 grid-col-medium-4 grid-col-small-4">
+          {{ section_description }}
+          {% if tiers|length == 1 %}{{ _tiers() }}{% endif %}
+        </div>
       </div>
     </div>
-
-    <div class="{{ base_class_name }}">
-      {%- for tier in tiers %}
-        <div class="p-pricing-block__tier">
-          <div class="p-pricing-block__section">
-            <div class="p-section--shallow">
-              <h3 class="p-heading--4">
-                {{ tier.get("tier_name_text") }}
-                <br />
-                <strong>{{ tier.get("tier_price_text") }}</strong>
-                <span class="u-text--muted">{{ tier.get("tier_price_explanation") }}</span>
-              </h3>
-            </div>
-          </div>
-          {%- if has_tier_descriptions -%}
-            {% set description = tier.get("tier_description_html") if tier.get("tier_description_html") else '' %}
-            <div class="p-pricing-block__section"
-                 {% if not description %}role="presentation"{% endif %}>{{ description }}</div>
-          {%- endif %}
-          <div class="p-pricing-block__section">{{ _tier_offerings_list(tier) }}</div>
-          {% if tier.cta_html %}<div class="p-pricing-block__section">{{ tier.cta_html }}</div>{% endif -%}
-        </div>
-      {%- endfor -%}
-    </div>
+    {% if tiers|length > 1 %}<div class="{{ base_class_name }}">{{ _tiers() }}</div>{% endif %}
   </div>
 {% endmacro -%}

--- a/templates/_macros/vf_pricing-block.jinja
+++ b/templates/_macros/vf_pricing-block.jinja
@@ -76,16 +76,14 @@
     {%- endfor -%}
   {%- endmacro -%}
   <div class="p-section">
-    <div class="p-section--shallow">
-      <hr class="p-rule{% if is_rule_highlighted %}--highlight{% endif %} is-fixed-width" />
-      <div class="grid-row">
-        <div class="grid-col-4 grid-col-medium-4 grid-col-small-4">
-          <h2>{{ title_text }}</h2>
-        </div>
-        <div class="grid-col-4 grid-col-medium-4 grid-col-small-4">
-          {{ section_description }}
-          {% if tiers|length == 1 %}{{ _tiers() }}{% endif %}
-        </div>
+    <hr class="p-rule{% if is_rule_highlighted %}--highlight{% endif %} is-fixed-width" />
+    <div class="grid-row">
+      <div class="grid-col-4 grid-col-medium-4 grid-col-small-4">
+        <h2>{{ title_text }}</h2>
+      </div>
+      <div class="grid-col-4 grid-col-medium-4 grid-col-small-4">
+        {{ section_description }}
+        {% if tiers|length == 1 %}{{ _tiers() }}{% endif %}
       </div>
     </div>
     {% if tiers|length > 1 %}<div class="{{ base_class_name }}">{{ _tiers() }}</div>{% endif %}

--- a/templates/_macros/vf_pricing-block.jinja
+++ b/templates/_macros/vf_pricing-block.jinja
@@ -1,7 +1,7 @@
 {#
   Params
   - title_text (string) (required): The text to be displayed as the heading
-  - is_rule_highlighted (boolean) (optional): Whether to toggle a strong horizontal rule
+  - top_rule_variant (string) (optional): Variant of the top rule, default is default
   - tiers (Array<{
       tier_name_text: String (optional),
       tier_price_text: String,
@@ -18,10 +18,14 @@
   - description (optional): paragraph-style content below the title
 #}
 {%- macro vf_pricing_block(
-  is_rule_highlighted=True,
+  top_rule_variant="default",
   title_text="",
   tiers=[]
   ) -%}
+  {% set top_rule_variant = top_rule_variant | trim %}
+  {% if top_rule_variant not in ['default', 'muted', 'highlighted', 'none'] %}
+    {% set top_rule_variant = "default" %}
+  {% endif %}
   {% set section_description = caller('section_description') %}
   {% set has_tier_descriptions = (tiers | selectattr("tier_description_html") | list | length) > 0 %}
   {% if tiers|length == 2 %}
@@ -75,18 +79,25 @@
       </div>
     {%- endfor -%}
   {%- endmacro -%}
+  {%- macro _top_rule() -%}
+    {% if top_rule_variant == 'default' %}
+      <hr class="p-rule is-fixed-width" />
+    {% elif top_rule_variant == 'muted' %}
+      <hr class="p-rule--muted is-fixed-width" />
+    {% elif top_rule_variant == 'highlighted' %}
+      <hr class="p-rule--highlight is-fixed-width" />
+    {% elif top_rule_variant == 'none' %}
+      {# No rule #}
+    {% endif %}
+  {%- endmacro -%}
   <div class="p-section">
-    <hr class="p-rule{% if is_rule_highlighted %}--highlight{% endif %} is-fixed-width" />
+    {{ _top_rule() }}
     <div class="grid-row">
       <div class="grid-col-4 grid-col-medium-4 grid-col-small-4">
         <h2>{{ title_text }}</h2>
       </div>
       <div class="grid-col-4 grid-col-medium-4 grid-col-small-4">
-        {% if section_description %}
-          <div class="p-section--shallow">
-            {{ section_description }}
-          </div>
-        {% endif %}
+        {% if section_description %}<div class="p-section--shallow">{{ section_description }}</div>{% endif %}
         {% if tiers|length == 1 %}{{ _tiers() }}{% endif %}
       </div>
     </div>

--- a/templates/_macros/vf_pricing-block.jinja
+++ b/templates/_macros/vf_pricing-block.jinja
@@ -82,7 +82,11 @@
         <h2>{{ title_text }}</h2>
       </div>
       <div class="grid-col-4 grid-col-medium-4 grid-col-small-4">
-        {{ section_description }}
+        {% if section_description %}
+          <div class="p-section--shallow">
+            {{ section_description }}
+          </div>
+        {% endif %}
         {% if tiers|length == 1 %}{{ _tiers() }}{% endif %}
       </div>
     </div>

--- a/templates/docs/examples/patterns/pricing-block/1-block.html
+++ b/templates/docs/examples/patterns/pricing-block/1-block.html
@@ -1,0 +1,67 @@
+{% extends '_layouts/examples.html' %}
+{% from '_macros/vf_pricing-block.jinja' import vf_pricing_block %}
+{% block title %}Pricing block / 1-block{% endblock %}
+{% block standalone_css %}patterns_all{% endblock %}
+{% block content %}
+  {% call(slot) vf_pricing_block(
+    title_text='Kubernetes pricing',
+    tiers=[
+    {
+    'tier_name_text': 'Kubernetes Explorer',
+    'tier_price_text': '$3099',
+    'tier_price_explanation': 'per year, per VM',
+    'tier_description_html': '<p>Three-day Kubernetes training to ramp up your team\'s skills.</p>',
+    'tier_label_text': 'What\'s included',
+    'tier_offerings': [
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': 'High availability'
+    },
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': '<a href="#">Public clouds</a>, VMware, <a href="#">OpenStack</a>'
+    },
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': 'Storage and SDN basic options'
+    },
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': 'Logging, monitoring, alerting'
+    },
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': 'Kubernetes lifecycle management'
+    },
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': 'Security essentials'
+    },
+    {
+    'list_item_style': 'crossed',
+    'list_item_content_html': 'Support or Fully Managed'
+    },
+    {
+    'list_item_style': 'crossed',
+    'list_item_content_html': 'Third-party integrations'
+    },
+    {
+    'list_item_style': 'crossed',
+    'list_item_content_html': 'GPU acceleration'
+    },
+    {
+    'list_item_style': 'crossed',
+    'list_item_content_html': 'GPU acceleration'
+    }
+    ],
+    'cta_html': '<a href="#">Three-day Kubernetes training to ramp up your team’s skills.</a>'
+    },
+    ]
+    ) -%}
+    {%- if slot == 'section_description' -%}
+      <p>
+        A low total cost of ownership. Up to five times lower than public clouds. A low total cost of ownership. Up to five times lower than public clouds. A low total cost of ownership. Up to five times lower than public clouds.
+      </p>
+    {%- endif -%}
+  {% endcall %}
+{% endblock content %}

--- a/templates/docs/examples/patterns/pricing-block/block-with-description-and-highlighted-rule.html
+++ b/templates/docs/examples/patterns/pricing-block/block-with-description-and-highlighted-rule.html
@@ -1,0 +1,67 @@
+{% extends '_layouts/examples.html' %}
+{% from '_macros/vf_pricing-block.jinja' import vf_pricing_block %}
+{% block title %}Pricing block / Block-with-optional-elements{% endblock %}
+{% block standalone_css %}patterns_all{% endblock %}
+{% block content %}
+  {% call(slot) vf_pricing_block(
+    title_text='Kubernetes pricing',
+    tiers=[
+    {
+    'tier_name_text': 'Kubernetes Explorer',
+    'tier_price_text': '$3099',
+    'tier_price_explanation': 'per year, per VM',
+    'tier_description_html': '<p>Three-day Kubernetes training to ramp up your team\'s skills.</p>',
+    'tier_label_text': 'What\'s included',
+    'tier_offerings': [
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': 'High availability'
+    },
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': '<a href="#">Public clouds</a>, VMware, <a href="#">OpenStack</a>'
+    },
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': 'Storage and SDN basic options'
+    },
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': 'Logging, monitoring, alerting'
+    },
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': 'Kubernetes lifecycle management'
+    },
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': 'Security essentials'
+    },
+    {
+    'list_item_style': 'crossed',
+    'list_item_content_html': 'Support or Fully Managed'
+    },
+    {
+    'list_item_style': 'crossed',
+    'list_item_content_html': 'Third-party integrations'
+    },
+    {
+    'list_item_style': 'crossed',
+    'list_item_content_html': 'GPU acceleration'
+    },
+    {
+    'list_item_style': 'crossed',
+    'list_item_content_html': 'GPU acceleration'
+    }
+    ],
+    'cta_html': '<a href="#">Three-day Kubernetes training to ramp up your team’s skills.</a>'
+    },
+    ]
+    ) -%}
+    {%- if slot == 'section_description' -%}
+      <p>
+        A low total cost of ownership. Up to five times lower than public clouds. A low total cost of ownership. Up to five times lower than public clouds. A low total cost of ownership. Up to five times lower than public clouds.
+      </p>
+    {%- endif -%}
+  {% endcall %}
+{% endblock content %}

--- a/templates/docs/examples/patterns/pricing-block/block-with-description-and-highlighted-rule.html
+++ b/templates/docs/examples/patterns/pricing-block/block-with-description-and-highlighted-rule.html
@@ -4,7 +4,6 @@
 {% block standalone_css %}patterns_all{% endblock %}
 {% block content %}
   {% call(slot) vf_pricing_block(
-    top_rule_variant="highlighted",
     title_text='Kubernetes pricing',
     tiers=[
     {

--- a/templates/docs/examples/patterns/pricing-block/block-with-description-and-highlighted-rule.html
+++ b/templates/docs/examples/patterns/pricing-block/block-with-description-and-highlighted-rule.html
@@ -1,6 +1,6 @@
 {% extends '_layouts/examples.html' %}
 {% from '_macros/vf_pricing-block.jinja' import vf_pricing_block %}
-{% block title %}Pricing block / Block-with-optional-elements{% endblock %}
+{% block title %}Pricing block / With optional elements{% endblock %}
 {% block standalone_css %}patterns_all{% endblock %}
 {% block content %}
   {% call(slot) vf_pricing_block(

--- a/templates/docs/examples/patterns/pricing-block/block-with-description-and-highlighted-rule.html
+++ b/templates/docs/examples/patterns/pricing-block/block-with-description-and-highlighted-rule.html
@@ -4,6 +4,7 @@
 {% block standalone_css %}patterns_all{% endblock %}
 {% block content %}
   {% call(slot) vf_pricing_block(
+    top_rule_variant="highlighted",
     title_text='Kubernetes pricing',
     tiers=[
     {

--- a/templates/docs/examples/patterns/pricing-block/block-without-description-and-muted-rule.html
+++ b/templates/docs/examples/patterns/pricing-block/block-without-description-and-muted-rule.html
@@ -1,6 +1,6 @@
 {% extends '_layouts/examples.html' %}
 {% from '_macros/vf_pricing-block.jinja' import vf_pricing_block %}
-{% block title %}Pricing block / Block-without-optional-elements{% endblock %}
+{% block title %}Pricing block / Without optional elements{% endblock %}
 {% block standalone_css %}patterns_all{% endblock %}
 {% block content %}
   {% call(slot) vf_pricing_block(

--- a/templates/docs/examples/patterns/pricing-block/block-without-description-and-muted-rule.html
+++ b/templates/docs/examples/patterns/pricing-block/block-without-description-and-muted-rule.html
@@ -1,0 +1,62 @@
+{% extends '_layouts/examples.html' %}
+{% from '_macros/vf_pricing-block.jinja' import vf_pricing_block %}
+{% block title %}Pricing block / Block-without-optional-elements{% endblock %}
+{% block standalone_css %}patterns_all{% endblock %}
+{% block content %}
+  {% call(slot) vf_pricing_block(
+    is_rule_highlighted=False,
+    title_text='Kubernetes pricing',
+    tiers=[
+    {
+    'tier_price_text': '$3099',
+    'tier_price_explanation': 'per year, per VM',
+    'tier_description_html': '<p>Three-day Kubernetes training to ramp up your team\'s skills.</p>',
+    'tier_label_text': 'What\'s included',
+    'tier_offerings': [
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': 'High availability'
+    },
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': '<a href="#">Public clouds</a>, VMware, <a href="#">OpenStack</a>'
+    },
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': 'Storage and SDN basic options'
+    },
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': 'Logging, monitoring, alerting'
+    },
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': 'Kubernetes lifecycle management'
+    },
+    {
+    'list_item_style': 'ticked',
+    'list_item_content_html': 'Security essentials'
+    },
+    {
+    'list_item_style': 'crossed',
+    'list_item_content_html': 'Support or Fully Managed'
+    },
+    {
+    'list_item_style': 'crossed',
+    'list_item_content_html': 'Third-party integrations'
+    },
+    {
+    'list_item_style': 'crossed',
+    'list_item_content_html': 'GPU acceleration'
+    },
+    {
+    'list_item_style': 'crossed',
+    'list_item_content_html': 'GPU acceleration'
+    }
+    ],
+    'cta_html': '<a href="#">Three-day Kubernetes training to ramp up your team’s skills.</a>'
+    },
+    ]
+    ) -%}
+  {% endcall %}
+{% endblock content %}

--- a/templates/docs/examples/patterns/pricing-block/block-without-description-and-muted-rule.html
+++ b/templates/docs/examples/patterns/pricing-block/block-without-description-and-muted-rule.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_all{% endblock %}
 {% block content %}
   {% call(slot) vf_pricing_block(
-    is_rule_highlighted=False,
+    top_rule_variant="muted",
     title_text='Kubernetes pricing',
     tiers=[
     {

--- a/templates/docs/examples/patterns/pricing-block/combined.html
+++ b/templates/docs/examples/patterns/pricing-block/combined.html
@@ -1,10 +1,17 @@
 {% extends "_layouts/examples.html" %}
 {% block title %}Pricing block / Combined{% endblock %}
-
 {% block standalone_css %}patterns_all{% endblock %}
-
 {% block content %}
   {% with is_combined = true %}
+    <section>
+      {% include 'docs/examples/patterns/pricing-block/1-block.html' %}
+    </section>
+    <section>
+      {% include 'docs/examples/patterns/pricing-block/block-with-description-and-highlighted-rule.html' %}
+    </section>
+    <section>
+      {% include 'docs/examples/patterns/pricing-block/block-without-description-and-muted-rule.html' %}
+    </section>
     <section>
       {% include 'docs/examples/patterns/pricing-block/2-blocks.html' %}
     </section>

--- a/templates/docs/patterns/pricing-block/index.md
+++ b/templates/docs/patterns/pricing-block/index.md
@@ -6,10 +6,10 @@ context:
 
 The Pricing block pattern is used to display individual cards representing different tiers of pricing and their associated offerings, positioned below a title and a description of the product. It uses the 4-4-8 grid pattern with subgrid, to retain alignment between rows. There are three variations of the block layout, depending on the number of cards displayed, ranging from two to four:
 
+- 4 blocks, 25-25-25-25 split
+- 3 blocks, 25-75 split
+- 2 blocks, 50-50 split
 - 1 block
-- 2 block, 50-50 split
-- 3 block, 25-75 split
-- 4 block, 25-25-25-25 split
 - Block with description and a highlighted rule
 - Block without description and a muted rule
 

--- a/templates/docs/patterns/pricing-block/index.md
+++ b/templates/docs/patterns/pricing-block/index.md
@@ -122,16 +122,18 @@ The `vf_pricing_block` Jinja macro can be used to generate a pricing tier compar
         </td>
         <td>
           One of: <br>
-          <code>'default'</code><br>
-          <code>'muted'</code><br>
           <code>'highlighted'</code><br>
+          <code>'muted'</code><br>
           <code>'none'</code><br>
         </td>
         <td>
-          <code>'default'</code>
+          <code>'highlighted'</code>
         </td>
         <td>
-          Variant of the top rule
+            Variant of the top rule.<br>
+            Use <code>'highlighted'</code> for a <a href="/docs/patterns/rule#highlighted">highlighted rule</a>. This should be used when the pricing block is a standalone section.<br>
+            Use <code>'muted'</code> for a <a href="/docs/patterns/rule#muted">muted rule</a>. This should be used when the pricing block is a subsection and has other subsections before it.<br>
+            Use <code>'none'</code> for no rule. This should be used when the pricing block is the first or only item in a subsection.
         </td>
       </tr>
       <tr>

--- a/templates/docs/patterns/pricing-block/index.md
+++ b/templates/docs/patterns/pricing-block/index.md
@@ -6,9 +6,12 @@ context:
 
 The Pricing block pattern is used to display individual cards representing different tiers of pricing and their associated offerings, positioned below a title and a description of the product. It uses the 4-4-8 grid pattern with subgrid, to retain alignment between rows. There are three variations of the block layout, depending on the number of cards displayed, ranging from two to four:
 
+- 1 block
 - 2 block, 50-50 split
 - 3 block, 25-75 split
 - 4 block, 25-25-25-25 split
+- Block with description and a highlighted rule
+- Block without description and a muted rule
 
 The Pricing block pattern is composed of the following elements:
 
@@ -17,7 +20,7 @@ The Pricing block pattern is composed of the following elements:
 | Title (**required**)                                     | <code>h2</code> title text                                                    |
 | Description                                              | <code>p</code> description text                                               |
 | Tiers (**required**)                                     | An `Array<Object>` of individual tiers representing different pricing options |
-| Tiers[].Name (**required**)                              | <code>h2</code> tier title                                                    |
+| Tiers[].Name (**optional**)                              | <code>h2</code> tier title                                                    |
 | Tiers[].Price (**required**)                             | The price of the tier                                                         |
 | Tiers[].Price explanation (**required**)                 | The timeframe/coverage for the pricing tier                                   |
 | Tier[].Description                                       | Descriptive text for the pricing tier                                         |
@@ -32,7 +35,7 @@ The Pricing block pattern is composed of the following elements:
 The cards are evenly spread across the available space, with any gaps in content not affecting the alignment of the grid.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/pricing-block/4-blocks" class="js-example" data-lang="jinja">
-View example of the tiered list pattern
+View example of 4 pricing blocks
 </a></div>
 
 ## 3-blocks
@@ -40,7 +43,7 @@ View example of the tiered list pattern
 With 3 tier blocks, a 25-75 split will be used on large screens.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/pricing-block/3-blocks" class="js-example" data-lang="jinja">
-View example of the tiered list pattern
+View example of 3 pricing blocks
 </a></div>
 
 ## 2-blocks
@@ -48,7 +51,31 @@ View example of the tiered list pattern
 With two tier blocks, they will take all the available space.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/pricing-block/2-blocks" class="js-example" data-lang="jinja">
-View example of the tiered list pattern
+View example of 2 pricing blocks
+</a></div>
+
+## 1-block
+
+A single pricing block will take all the available space.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/pricing-block/1-block" class="js-example" data-lang="jinja">
+View example of the single pricing block
+</a></div>
+
+## Block with description and a highlighted rule
+
+A pricing block with description and a highlighted rule
+
+<div class="embedded-example"><a href="/docs/examples/patterns/pricing-block/block-with-description-and-highlighted-rule" class="js-example" data-lang="jinja">
+View example of the pricing block with description and a highlighted rule
+</a></div>
+
+## Block without description and a muted rule
+
+A pricing block with a muted rule and no description
+
+<div class="embedded-example"><a href="/docs/examples/patterns/pricing-block/block-without-description-and-muted-rule" class="js-example" data-lang="jinja">
+View example of the pricing block with a muted rule and no description
 </a></div>
 
 ## Jinja Macro
@@ -88,6 +115,23 @@ The `vf_pricing_block` Jinja macro can be used to generate a pricing tier compar
       </tr>
       <tr>
         <td>
+          <code>is_rule_highlighted</code>
+        </td>
+        <td>
+          Yes
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>True</code>
+        </td>
+        <td>
+          Whether the rule should be highlighted or muted
+        </td>
+      </tr>
+      <tr>
+        <td>
           <code>tiers</code>
         </td>
         <td>
@@ -108,7 +152,7 @@ The `vf_pricing_block` Jinja macro can be used to generate a pricing tier compar
           <code>tiers[].tier_name_text</code>
         </td>
         <td>
-          Yes
+          No
         </td>
         <td>
           <code>string</code>

--- a/templates/docs/patterns/pricing-block/index.md
+++ b/templates/docs/patterns/pricing-block/index.md
@@ -115,19 +115,23 @@ The `vf_pricing_block` Jinja macro can be used to generate a pricing tier compar
       </tr>
       <tr>
         <td>
-          <code>is_rule_highlighted</code>
+          <code>top_rule_variant</code>
         </td>
         <td>
-          Yes
+          No
         </td>
         <td>
-          <code>boolean</code>
+          One of: <br>
+          <code>'default'</code><br>
+          <code>'muted'</code><br>
+          <code>'highlighted'</code><br>
+          <code>'none'</code><br>
         </td>
         <td>
-          <code>True</code>
+          <code>'default'</code>
         </td>
         <td>
-          Whether the rule should be highlighted or muted
+          Variant of the top rule
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
## Done

- Implemented the single tier pricing block variant for pricing block pattern.

Fixes [WD-24276](https://warthogs.atlassian.net/browse/WD-24276) and #5584 

## QA

- Open Demos
  - [Single Pricing Block](https://vanilla-framework-5607.demos.haus/docs/examples/patterns/pricing-block/1-block?theme=light)
  - [Pricing Block without Description and a Muted Rule](https://vanilla-framework-5607.demos.haus/docs/examples/patterns/pricing-block/block-without-description-and-muted-rule?theme=light)
  -  [Pricing Block with Description and Highlighted Rule](https://vanilla-framework-5607.demos.haus/docs/examples/patterns/pricing-block/block-with-description-and-highlighted-rule?theme=light)
- Match with [Figma](https://www.figma.com/design/1brHCsyeTE6FU7hfJd6ao2/%F0%9F%9A%A7---WIP--Sites---Core-component-library?node-id=1577-5462&t=EQkerjdImmubFOus-0)
- Review [Documentation](https://vanilla-framework-5607.demos.haus/docs/patterns/pricing-block)

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

[WD-24276]: https://warthogs.atlassian.net/browse/WD-24276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ