### PR TITLE
fix: correct image container class selector to use * instead of ^

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.28.1",
+  "version": "4.28.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.28.0",
+  "version": "4.28.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_image.scss
+++ b/scss/_patterns_image.scss
@@ -103,7 +103,7 @@ $aspect-ratios: (
 
 @mixin vf-p-image {
   .p-image-container,
-  [class^='p-image-container--'] {
+  [class*='p-image-container--'] {
     display: block;
     position: relative;
     width: 100%;


### PR DESCRIPTION
## Done
The change from ^= to *= ensures the selector matches any class containing 'p-image-container--' rather than just those starting with it, fixing potential styling issues

Fixes [Percy regression](https://percy.io/bb49709b/web/ubuntu.com-eaf28f99/builds/42016720/changed/2248032285?browser=chrome&browser_ids=64&group_snapshots_by=similar_diff&subcategories=unreviewed%2Cchanges_requested&utm_source=github_status_private&viewLayout=overlay&viewMode=new&width=1280&widths=375%2C1280) blocking [Vanilla upgrade](https://github.com/canonical/ubuntu.com/pull/15231)

## QA

- Open [demo](https://ubuntu-com-15417.demos.haus/) and check that images display well compared to https://ubuntu-com-15231.demos.haus/  where  when the class name of the image container does not begin with p-container, it breaks the image layout.

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots
### Before
<img width="2880" height="8946" alt="image" src="https://github.com/user-attachments/assets/5dfb4814-0603-4240-abf7-1ab0d7f25f49" />

### After
<img width="2880" height="9074" alt="image" src="https://github.com/user-attachments/assets/dfcbf981-2e5a-4203-b850-5a5becee2ecd" />


[if relevant, include a screenshot or screen capture]
