### PR TITLE
Add docs requiring cover images to have a defined aspect ratio or height

### DIFF
--- a/templates/docs/patterns/hero/index.md
+++ b/templates/docs/patterns/hero/index.md
@@ -57,7 +57,7 @@ View example of the hero pattern in 50/50 that is split on medium and small
 The above hero layouts place the hero image in the right column by default. However, this is not suitable for very wide
 images.
 If you have a very wide image or otherwise want your image to take up the full hero width, place the title by itself in
-the first column and place the image in a <code>.p-image-container .is-cover</code> at the same level as the grid
+the first column and place the image in a [cover image container](/docs/patterns/images#cover-image) at the same level as the grid
 columns.
 This will make the image take up the full width of the hero.
 
@@ -82,7 +82,7 @@ This places the image in a small column beside the primary hero content.
 View example of the hero pattern in 50/50 split
 </a></div>
 
-This layout also supports a full-width image. Place the image in a <code>.p-image-container .is-cover</code>at the same
+This layout also supports a full-width image. Place the image in a [cover image container](/docs/patterns/images#cover-image) at the same
 level as the hero grid columns to make it take full width beneath the rest of the hero. This is identical to the
 full-width image layout for the [50/50 layout](#50-50-with-full-width-image).
 

--- a/templates/docs/patterns/images.md
+++ b/templates/docs/patterns/images.md
@@ -178,7 +178,11 @@ View example of an image container with aspect ratios that respond to the screen
 
 ## Cover image
 
-Cover images are used to fill the entire container, cropping the image if necessary. This can be combined with the aspect ratio modifier to crop the image to a specific aspect ratio.
+Cover images are used to fill the entire container, cropping the image if necessary.
+This requires the image container to have its dimensions defined, with either:
+
+- An [aspect ratio class](#image-container-with-aspect-ratio)
+- A fixed, explicit `height`
 
 <div class="embedded-example"><a href="/docs/examples/patterns/image/container/cover" class="js-example">
 View example of cover image


### PR DESCRIPTION
## Done

- Documentation update to help prevent improperly rendered cover images, as seen with:
  - https://github.com/canonical/ubuntu.com/pull/15431
  - https://github.com/canonical/ubuntu.com/pull/15432
  - https://github.com/canonical/canonical.com/pull/1860
  - https://github.com/canonical/canonical-design/pull/57
  - https://github.com/canonical/university.canonical.com/pull/33
- Updates the language of the cover image to make it clearer that image dimensions are required in the form of an aspect ratio or explicit height. 
- Updates HTML (non-Jinja) instructions for the hero pattern to reference the cover image container documentation rather than simply using `.p-image-container.is-cover` (which lacks an explicit aspect ratio)

## QA

- Review [cover image documentation]() and verify it clearly indicates 
- Review [50/50 full-width hero documentation]() and verify it directs you to the cover image documentation
- Review [signpost hero documentation]() and verify it directs you to the cover image documentation

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1091" height="1087" alt="image" src="https://github.com/user-attachments/assets/cb76426a-2bfb-487e-84c5-d383156e16da" />

