### PR TITLE
docs for typographic spacing customization

### DIFF
--- a/templates/docs/settings/spacing-settings.md
+++ b/templates/docs/settings/spacing-settings.md
@@ -122,4 +122,34 @@ Within each map, the following settings can be customised:
 | `sp-after`    | The vertical spacing applied after this text element, controlling space between elements.     |
 | `sp-before`   | The additional spacing added to the nudge for padding-top when text follows other elements.   |
 
+To customise these settings, you can create overrides for whichever text types you need in your project's settings file. For example:
+
+```scss
+// settings.scss (in your project)
+
+// sass:map is needed to merge settings maps
+@use 'sass:map';
+// Import Vanilla's base settings
+@import 'vanilla-framework';
+
+// Define maps that contain settings you want to customise.
+// You only need to specify the settings you want to change.
+$custom-settings-text-p: (
+  nudge: 0.5rem,
+  sp-after: $spv--medium,
+);
+
+// Merge the custom settings with the default settings.
+// Make sure your custom settings map is the second argument, so that it overrides the defaults.
+$settings-text-p: map.merge($settings-text-p, $custom-settings-text-p);
+
+// index.scss (in your project)
+// Import your custom settings
+@import 'settings';
+
+// Include Vanilla AFTER your settings are imported - this causes Vanilla to use your custom settings.
+@include vanilla;
+// or include only the parts you need - see the customising guide below for more details
+```
+
 For more information see [Customising Vanilla](/docs/customising-vanilla/) in your projects, which includes overrides and importing instructions.


### PR DESCRIPTION
## Done

Adds specific documentation for customizing typographic spacing with SCSS. This is a bit more complex than the simple variable overrides documented in the [customization guide](https://vanillaframework.io/docs/customising-vanilla), so an example was requested by @muhammadbassiony .

## QA

- Open [spacing docs]() and verify that they are clear and understandable
- In another project, use the example from the docs and ensure that:
  - Vanilla builds
  - Typographic spacing is adjusted as requested. The example reduces the space below paragraph text, making paragraphs denser than by default.

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [z] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).