### PR TITLE
fix: crossed list items use muted text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.29.0",
+  "version": "4.29.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -350,6 +350,7 @@ $list-step-bullet-margin: $sph--x-large;
 
   .p-list__item.is-crossed {
     @include vf-list-item-has-prefix;
+    @extend %muted-text;
 
     &::before {
       @extend %vf-list-item-state-base;

--- a/templates/_macros/vf_pricing-block.jinja
+++ b/templates/_macros/vf_pricing-block.jinja
@@ -44,7 +44,7 @@
         {% if item_style == 'ticked' -%}
           {% set item_class = "is-ticked" -%}
         {% elif item_style == 'crossed' -%}
-          {% set item_class = "is-crossed u-text--muted" -%}
+          {% set item_class = "is-crossed" -%}
         {% else -%}
           {% set item_class = "has-bullet" -%}
         {%- endif -%}


### PR DESCRIPTION
## Done

Sets `.p-list__item.is-crossed` to use muted text color.

With more capacity, I could finish #5537 to also update the icon to use the same muted text color. TBD by design if it is okay for these muted crossed list items to have different color than the icon in the meantime.

Fixes #5609 
Fixes [WD-24542](https://warthogs.atlassian.net/browse/WD-24542)

## QA

- Open [demo](https://vanilla-framework-5616.demos.haus/)

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="296" height="503" alt="Screenshot 2025-08-13 at 12 44 55" src="https://github.com/user-attachments/assets/b48dc3f4-7b29-4884-80e6-e5949a926c54" />

<img width="1279" height="178" alt="Screenshot 2025-08-13 at 12 45 32" src="https://github.com/user-attachments/assets/22882921-6a71-4667-8c18-26f042fde631" />



[WD-24542]: https://warthogs.atlassian.net/browse/WD-24542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ