### PR TITLE
WD-26007 - Add more sliding animations to the navigation

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -11,7 +11,13 @@
     - component: Navigation
       url: /docs/patterns/navigation
       status: Updated
-      notes: The sliding navigation pattern has been updated so that the menu in mobile view slides in an out and the dropdowns in desktop view slide down and up.
+      notes: |
+        The sliding navigation pattern has been updated so that the menu in mobile view slides in an out and
+        the dropdowns in desktop view slide down and up.
+        There is a breaking change in the "is-full-width" sliding navigation. Now the class needs to be added
+        along with the "p-navigation__item--dropdown-toggle" class (see examples).
+        There is a new "desktop-no-shadow" class that can be added along with "p-navigation--sliding" to not
+        display the shadow overlay all over the page when a dropdown is open in desktop view.
 - version: 4.30.0
   features:
     - component: Basic section

--- a/releases.yml
+++ b/releases.yml
@@ -12,12 +12,8 @@
       url: /docs/patterns/navigation
       status: Updated
       notes: |
-        The sliding navigation pattern has been updated so that the menu in mobile view slides in an out and
-        the dropdowns in desktop view slide down and up.
-        There is a breaking change in the "is-full-width" sliding navigation. Now the class needs to be added
-        along with the "p-navigation__item--dropdown-toggle" class (see examples).
-        There is a new "desktop-no-shadow" class that can be added along with "p-navigation--sliding" to not
-        display the shadow overlay all over the page when a dropdown is open in desktop view.
+        The sliding navigation pattern has been updated so that the menu in mobile view slides in an out from the right side.
+        Classes added so that dropdowns in desktop view slide down and up. This requires additional markup (examples updated).
 - version: 4.30.0
   features:
     - component: Basic section

--- a/releases.yml
+++ b/releases.yml
@@ -8,6 +8,10 @@
       url: /docs/patterns/text-spotlight#default
       status: Updated
       notes: We have added an optional <a href="/docs/patterns/text-spotlight#jinja-macro">item_heading_level</a> param to the text spotlight pattern.
+    - component: Navigation
+      url: /docs/patterns/navigation
+      status: Updated
+      notes: The sliding navigation pattern has been updated so that the menu in mobile view slides in an out and the dropdowns in desktop view slide down and up.
 - version: 4.30.0
   features:
     - component: Basic section

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -190,6 +190,20 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
     }
   }
 
+  .p-navigation--sliding {
+    @property --right {
+      inherits: false;
+      initial-value: 0%;
+      syntax: '<percentage>';
+    }
+
+    @property --up {
+      inherits: false;
+      initial-value: 0%;
+      syntax: '<percentage>';
+    }
+  }
+
   // navigation row
   .p-navigation__row,
   .p-navigation__row--full-width {
@@ -1061,6 +1075,86 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
       }
       @media (min-width: $breakpoint-navigation-threshold) {
         display: none;
+      }
+    }
+  }
+
+  @media (width < $breakpoint-navigation-threshold) {
+    .p-navigation--sliding {
+      .p-navigation__nav {
+        display: block;
+        margin-top: 3.5rem;
+        min-width: 100%;
+        position: absolute;
+        transform: translateX(var(--right));
+        // same function as for the global-nav dropdown
+        transition: transform 0.333s cubic-bezier(0.215, 0.61, 0.355, 1);
+        // starts on the right outside of the screen
+        --right: 110%;
+      }
+
+      &.has-menu-open {
+        overflow-x: hidden;
+      }
+
+      &.has-menu-open .p-navigation__nav {
+        --right: 0%;
+      }
+
+      &.menu-closing .p-navigation__nav {
+        --right: 110%;
+      }
+
+      .p-navigation__items--section {
+        margin: 0;
+        padding: 0;
+      }
+    }
+  }
+
+  @media (min-width: $breakpoint-navigation-threshold) {
+    .p-navigation--sliding {
+      &.has-menu-open {
+        box-shadow: none;
+      }
+
+      .p-navigation__items {
+        justify-content: space-between;
+
+        &--section {
+          display: flex;
+          margin: 0;
+          padding: 0;
+        }
+      }
+
+      .p-navigation__item--dropdown-toggle {
+        position: relative;
+      }
+
+      .p-navigation__dropdown--container {
+        // a bit extra % to be able to show the shadow of the box if present
+        clip-path: rect(0 105% 105% 0);
+        display: block;
+        min-width: 100%;
+        position: absolute;
+      }
+
+      .p-navigation__dropdown--container > .p-navigation__dropdown {
+        display: block;
+        position: static;
+        transform: translateY(calc(-1 * var(--up)));
+        // same function as for the global-nav dropdown
+        transition: transform 0.333s cubic-bezier(0.215, 0.61, 0.355, 1);
+
+        &[aria-hidden='true'] {
+          // extra 10% to not let the shadow show underneath the navbar
+          --up: 110%;
+        }
+
+        &[aria-hidden='false'] {
+          --up: 0%;
+        }
       }
     }
   }

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -1103,32 +1103,21 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
       &.menu-closing .p-navigation__nav {
         --right: 110%;
       }
-
-      .p-navigation__items--section {
-        margin: 0;
-        padding: 0;
-      }
     }
   }
 
   @media (min-width: $breakpoint-navigation-threshold) {
     .p-navigation--sliding {
-      &.has-menu-open {
+      &.has-menu-open.desktop-no-shadow {
         box-shadow: none;
-      }
-
-      .p-navigation__items {
-        justify-content: space-between;
-
-        &--section {
-          display: flex;
-          margin: 0;
-          padding: 0;
-        }
       }
 
       .p-navigation__item--dropdown-toggle {
         position: relative;
+
+        &.is-full-width {
+          position: initial;
+        }
       }
 
       .p-navigation__dropdown--container {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -977,23 +977,23 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
     &.is-active {
       transform: translateX(-25vw);
       @media (min-width: $breakpoint-navigation-threshold) {
-        transform: none;
+        transform: translateY(calc(-1 * var(--up)));
       }
       .p-navigation__dropdown {
         transform: translateX(25vw);
         @media (min-width: $breakpoint-navigation-threshold) {
-          transform: none;
+          transform: translateY(calc(-1 * var(--up)));
         }
         &[aria-hidden='false'],
         &:not([aria-hidden]) {
           transform: translateX(-75vw);
           @media (min-width: $breakpoint-navigation-threshold) {
-            transform: none;
+            transform: translateY(calc(-1 * var(--up)));
           }
           &.is-active {
             transform: translateX(-100vw);
             @media (min-width: $breakpoint-navigation-threshold) {
-              transform: none;
+              transform: translateY(calc(-1 * var(--up)));
             }
           }
         }
@@ -1087,8 +1087,7 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
         min-width: 100%;
         position: absolute;
         transform: translateX(var(--right));
-        // same function as for the global-nav dropdown
-        transition: transform 0.333s cubic-bezier(0.215, 0.61, 0.355, 1);
+        transition: transform $sliding-nav-animation-settings;
         // starts on the right outside of the screen
         --right: 110%;
       }
@@ -1144,8 +1143,7 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
         display: block;
         position: static;
         transform: translateY(calc(-1 * var(--up)));
-        // same function as for the global-nav dropdown
-        transition: transform 0.333s cubic-bezier(0.215, 0.61, 0.355, 1);
+        transition: transform $sliding-nav-animation-settings;
 
         &[aria-hidden='true'] {
           // extra 10% to not let the shadow show underneath the navbar

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -191,17 +191,8 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
   }
 
   .p-navigation--sliding {
-    @property --right {
-      inherits: false;
-      initial-value: 0%;
-      syntax: '<percentage>';
-    }
-
-    @property --up {
-      inherits: false;
-      initial-value: 0%;
-      syntax: '<percentage>';
-    }
+    --vf-nav-sliding-right: 0%;
+    --vf-nav-sliding-up: 0%;
   }
 
   // navigation row
@@ -977,23 +968,23 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
     &.is-active {
       transform: translateX(-25vw);
       @media (min-width: $breakpoint-navigation-threshold) {
-        transform: translateY(calc(-1 * var(--up)));
+        transform: none;
       }
       .p-navigation__dropdown {
         transform: translateX(25vw);
         @media (min-width: $breakpoint-navigation-threshold) {
-          transform: translateY(calc(-1 * var(--up)));
+          transform: translateY(calc(-1 * var(--vf-nav-sliding-up)));
         }
         &[aria-hidden='false'],
         &:not([aria-hidden]) {
           transform: translateX(-75vw);
           @media (min-width: $breakpoint-navigation-threshold) {
-            transform: translateY(calc(-1 * var(--up)));
+            transform: translateY(calc(-1 * var(--vf-nav-sliding-up)));
           }
           &.is-active {
             transform: translateX(-100vw);
             @media (min-width: $breakpoint-navigation-threshold) {
-              transform: translateY(calc(-1 * var(--up)));
+              transform: translateY(calc(-1 * var(--vf-nav-sliding-up)));
             }
           }
         }
@@ -1086,10 +1077,10 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
         margin-top: 3.5rem;
         min-width: 100%;
         position: absolute;
-        transform: translateX(var(--right));
+        transform: translateX(var(--vf-nav-sliding-right));
         transition: transform $sliding-nav-animation-settings;
         // starts on the right outside of the screen
-        --right: 110%;
+        --vf-nav-sliding-right: 110%;
       }
 
       &.has-menu-open {
@@ -1097,27 +1088,19 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
       }
 
       &.has-menu-open .p-navigation__nav {
-        --right: 0%;
+        --vf-nav-sliding-right: 0%;
       }
 
       &.menu-closing .p-navigation__nav {
-        --right: 110%;
+        --vf-nav-sliding-right: 110%;
       }
     }
   }
 
   @media (min-width: $breakpoint-navigation-threshold) {
     .p-navigation--sliding {
-      &.has-menu-open.desktop-no-shadow {
-        box-shadow: none;
-      }
-
-      .p-navigation__item--dropdown-toggle {
+      .p-navigation__item--dropdown-toggle.is-container-parent {
         position: relative;
-
-        &.is-full-width {
-          position: initial;
-        }
       }
 
       .p-navigation__dropdown--container {
@@ -1131,16 +1114,16 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
       .p-navigation__dropdown--container > .p-navigation__dropdown {
         display: block;
         position: static;
-        transform: translateY(calc(-1 * var(--up)));
+        transform: translateY(calc(-1 * var(--vf-nav-sliding-up)));
         transition: transform $sliding-nav-animation-settings;
 
         &[aria-hidden='true'] {
           // extra 10% to not let the shadow show underneath the navbar
-          --up: 110%;
+          --vf-nav-sliding-up: 110%;
         }
 
         &[aria-hidden='false'] {
-          --up: 0%;
+          --vf-nav-sliding-up: 0%;
         }
       }
     }

--- a/templates/docs/examples/patterns/navigation/_script-sliding.js
+++ b/templates/docs/examples/patterns/navigation/_script-sliding.js
@@ -7,9 +7,7 @@ const initNavigationSliding = () => {
   const menuButton = document.querySelector('.js-menu-button');
   const dropdownNavLists = document.querySelectorAll('.p-navigation__dropdown');
   // const topNavList = [...dropdownNavLists].filter((list) => !list.parentNode.closest('.p-navigation__dropdown'))[0];
-  const topNavLists = document.querySelectorAll(
-    '.p-navigation__nav > .p-navigation__items'
-  );
+  const topNavLists = document.querySelectorAll('.p-navigation__nav > .p-navigation__items');
 
   const hasSearch = searchButtons.length > 0;
 
@@ -17,7 +15,7 @@ const initNavigationSliding = () => {
     if (hasSearch) {
       closeSearch();
     }
-    
+
     menuButton.innerHTML = 'Menu';
     navigation.classList.add('menu-closing');
     const closeMenuHandler = () => {
@@ -101,9 +99,7 @@ const initNavigationSliding = () => {
     // to set the position of the sliding panel properly
     const topLevelNavigation = dropdownToggleButton.closest('.p-navigation__nav');
     if (topLevelNavigation) {
-      const topLevelItems = topLevelNavigation.querySelectorAll(
-        ':scope > .p-navigation__items'
-      );
+      const topLevelItems = topLevelNavigation.querySelectorAll(':scope > .p-navigation__items');
       // eslint-disable-next-line no-restricted-syntax
       for (const item of topLevelItems) {
         // in case there are more than one top level navigation lists, we need to
@@ -182,7 +178,7 @@ const initNavigationSliding = () => {
     const isList = target.classList.contains('js-dropdown-nav-list');
     if (!isList) {
       // find all lists in the target dropdown and make them focusable
-      target.querySelectorAll('.js-dropdown-nav-list').forEach(element => {
+      target.querySelectorAll('.js-dropdown-nav-list').forEach((element) => {
         setListFocusable(element);
       });
     } else {

--- a/templates/docs/examples/patterns/navigation/_script-sliding.js
+++ b/templates/docs/examples/patterns/navigation/_script-sliding.js
@@ -5,8 +5,8 @@ const initNavigationSliding = () => {
   const toggles = document.querySelectorAll('.p-navigation__nav .p-navigation__link[aria-controls]:not(.js-back-button)');
   const searchButtons = document.querySelectorAll('.js-search-button');
   const menuButton = document.querySelector('.js-menu-button');
-  const dropdownNavLists = document.querySelectorAll('.p-navigation__dropdown');
-  const topNavList = [...dropdownNavLists].filter((list) => !list.parentNode.closest('.p-navigation__dropdown'))[0];
+  const dropdownNavLists = document.querySelectorAll('.js-dropdown-nav-list');
+  const topNavList = [...dropdownNavLists].filter((list) => !list.parentNode.closest('.js-dropdown-nav-list'))[0];
 
   const hasSearch = searchButtons.length > 0;
 
@@ -26,7 +26,7 @@ const initNavigationSliding = () => {
       resetToggles();
     };
 
-    // the time is aproximately the time of the sliding animation
+    // the time is approximately the time of the sliding animation
     setTimeout(closeMenuHandler, ANIMATION_SNAP_DURATION);
   };
 

--- a/templates/docs/examples/patterns/navigation/_script-sliding.js
+++ b/templates/docs/examples/patterns/navigation/_script-sliding.js
@@ -6,8 +6,7 @@ const initNavigationSliding = () => {
   const searchButtons = document.querySelectorAll('.js-search-button');
   const menuButton = document.querySelector('.js-menu-button');
   const dropdownNavLists = document.querySelectorAll('.p-navigation__dropdown');
-  // const topNavList = [...dropdownNavLists].filter((list) => !list.parentNode.closest('.p-navigation__dropdown'))[0];
-  const topNavLists = document.querySelectorAll('.p-navigation__nav > .p-navigation__items');
+  const topNavList = [...dropdownNavLists].filter((list) => !list.parentNode.closest('.p-navigation__dropdown'))[0];
 
   const hasSearch = searchButtons.length > 0;
 

--- a/templates/docs/examples/patterns/navigation/combined.html
+++ b/templates/docs/examples/patterns/navigation/combined.html
@@ -15,6 +15,11 @@
 </section>
 <section>
   {% with spacing_below = 15 %}
+  {% include 'docs/examples/patterns/navigation/sliding-deprecated.html' %}
+  {% endwith %}
+</section>
+<section>
+  {% with spacing_below = 15 %}
     {% include 'docs/examples/patterns/navigation/dropdown.html' %}
   {% endwith %}
 </section>

--- a/templates/docs/examples/patterns/navigation/dropdown-full-width.html
+++ b/templates/docs/examples/patterns/navigation/dropdown-full-width.html
@@ -31,26 +31,37 @@
       <ul class="p-navigation__items is-active js-dropdown-nav-list js-navigation-sliding-panel">
         <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" role="menuitem" id="products">
           <a class="p-navigation__link" href="#products" aria-controls="products-content" tabindex="0">Products</a>
-          {{ build_fake_dropdown('products-content', 'Products', links_count=11, sub_links_count=10, quick_links_count=5) }}
+          <div class="p-navigation__dropdown--container">
+            {{ build_fake_dropdown('products-content', 'Products', links_count=11, sub_links_count=10, quick_links_count=5) }}
+          </div>
         </li>
         <li class="p-navigation__item--dropdown-toggle is-active js-navigation-dropdown-toggle" role="menuitem" id="use-case">
           <a class="p-navigation__link" href="#use-case" aria-controls="use-case-content" tabindex="0">Use cases</a>
-          {{ build_fake_dropdown('use-case-content', 'Use cases', True) }}
+          <div class="p-navigation__dropdown--container">
+            {{ build_fake_dropdown('use-case-content', 'Use cases', True) }}
+          </div>
         </li>
         <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" role="menuitem" id="support">
           <a class="p-navigation__link" href="#support" aria-controls="support-content" tabindex="0">Support</a>
-          {{ build_fake_dropdown('support-content', 'Support', links_count=2, sub_links_count=8, quick_links_count=5) }}
+          <div class="p-navigation__dropdown--container">
+            {{ build_fake_dropdown('support-content', 'Support', links_count=2, sub_links_count=8, quick_links_count=5) }}
+          </div>
         </li>
         <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" role="menuitem" id="community">
           <a class="p-navigation__link" href="#community" aria-controls="community-content" tabindex="0">Community</a>
-          {{ build_fake_dropdown('community-content', 'Community', links_count=5, sub_links_count=7, quick_links_count=5) }}
+          <div class="p-navigation__dropdown--container">
+            {{ build_fake_dropdown('community-content', 'Community', links_count=5, sub_links_count=7, quick_links_count=5) }}
+          </div>
         </li>
         <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" role="menuitem" id="get-ubuntu">
           <a class="p-navigation__link" href="#get-ubuntu" aria-controls="get-ubuntu-content" tabindex="0">Get Ubuntu</a>
-          {{ build_fake_dropdown('get-ubuntu-content', 'Get Ubuntu', links_count=6, sub_links_count=3, quick_links_count=8, has_cta_button=True ) }}
+          <div class="p-navigation__dropdown--container">
+            {{ build_fake_dropdown('get-ubuntu-content', 'Get Ubuntu', links_count=6, sub_links_count=3, quick_links_count=8, has_cta_button=True ) }}
+          </div>
         </li>
         <li class="p-navigation__item--dropdown-toggle is-right-shifted js-navigation-dropdown-toggle" role="menuitem" id="all-canonical">
           <button aria-controls="canonical-products" class="p-navigation__link" id="all-canonical-link" aria-expanded="false">All Canonical</button>
+          <div class="p-navigation__dropdown--container">
             <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="canonical-products" aria-hidden="true" data-level="1">
               <li class="p-navigation__item--dropdown-close" id="link-6-back">
                 <button aria-controls="canonical-products" class="p-navigation__link js-back-button">
@@ -64,6 +75,7 @@
                 <a href="#" class="p-navigation__dropdown-item">TODO....</a>
               </li>
             </ul>
+          </div>
         </li>
         <li class="p-navigation__item js-account" role="menuitem" id="canonical-login">
           <a href="#sign-in" class="p-navigation__link" tabindex="0">Sign in</a>

--- a/templates/docs/examples/patterns/navigation/dropdown-full-width.html
+++ b/templates/docs/examples/patterns/navigation/dropdown-full-width.html
@@ -29,23 +29,23 @@
     </div>
     <nav class="p-navigation__nav js-show-nav" aria-label="Categories">
       <ul class="p-navigation__items is-active js-dropdown-nav-list js-navigation-sliding-panel">
-        <li class="p-navigation__item--dropdown-toggle is-full-width js-navigation-dropdown-toggle" role="menuitem" id="products">
+        <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" role="menuitem" id="products">
           <a class="p-navigation__link" href="#products" aria-controls="products-content" tabindex="0">Products</a>
           {{ build_fake_dropdown('products-content', 'Products', links_count=11, sub_links_count=10, quick_links_count=5) }}
         </li>
-        <li class="p-navigation__item--dropdown-toggle is-full-width is-active js-navigation-dropdown-toggle" role="menuitem" id="use-case">
+        <li class="p-navigation__item--dropdown-toggle is-active js-navigation-dropdown-toggle" role="menuitem" id="use-case">
           <a class="p-navigation__link" href="#use-case" aria-controls="use-case-content" tabindex="0">Use cases</a>
           {{ build_fake_dropdown('use-case-content', 'Use cases', True) }}
         </li>
-        <li class="p-navigation__item--dropdown-toggle is-full-width js-navigation-dropdown-toggle" role="menuitem" id="support">
+        <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" role="menuitem" id="support">
           <a class="p-navigation__link" href="#support" aria-controls="support-content" tabindex="0">Support</a>
           {{ build_fake_dropdown('support-content', 'Support', links_count=2, sub_links_count=8, quick_links_count=5) }}
         </li>
-        <li class="p-navigation__item--dropdown-toggle is-full-width js-navigation-dropdown-toggle" role="menuitem" id="community">
+        <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" role="menuitem" id="community">
           <a class="p-navigation__link" href="#community" aria-controls="community-content" tabindex="0">Community</a>
           {{ build_fake_dropdown('community-content', 'Community', links_count=5, sub_links_count=7, quick_links_count=5) }}
         </li>
-        <li class="p-navigation__item--dropdown-toggle is-full-width js-navigation-dropdown-toggle" role="menuitem" id="get-ubuntu">
+        <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" role="menuitem" id="get-ubuntu">
           <a class="p-navigation__link" href="#get-ubuntu" aria-controls="get-ubuntu-content" tabindex="0">Get Ubuntu</a>
           {{ build_fake_dropdown('get-ubuntu-content', 'Get Ubuntu', links_count=6, sub_links_count=3, quick_links_count=8, has_cta_button=True ) }}
         </li>

--- a/templates/docs/examples/patterns/navigation/dropdown-full-width.html
+++ b/templates/docs/examples/patterns/navigation/dropdown-full-width.html
@@ -29,39 +29,28 @@
     </div>
     <nav class="p-navigation__nav js-show-nav" aria-label="Categories">
       <ul class="p-navigation__items is-active js-dropdown-nav-list js-navigation-sliding-panel">
-        <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" role="menuitem" id="products">
+        <li class="p-navigation__item--dropdown-toggle is-full-width js-navigation-dropdown-toggle" role="menuitem" id="products">
           <a class="p-navigation__link" href="#products" aria-controls="products-content" tabindex="0">Products</a>
-          <div class="p-navigation__dropdown--container">
-            {{ build_fake_dropdown('products-content', 'Products', links_count=11, sub_links_count=10, quick_links_count=5) }}
-          </div>
+          {{ build_fake_dropdown('products-content', 'Products', links_count=11, sub_links_count=10, quick_links_count=5) }}
         </li>
-        <li class="p-navigation__item--dropdown-toggle is-active js-navigation-dropdown-toggle" role="menuitem" id="use-case">
+        <li class="p-navigation__item--dropdown-toggle is-full-width is-active js-navigation-dropdown-toggle" role="menuitem" id="use-case">
           <a class="p-navigation__link" href="#use-case" aria-controls="use-case-content" tabindex="0">Use cases</a>
-          <div class="p-navigation__dropdown--container">
-            {{ build_fake_dropdown('use-case-content', 'Use cases', True) }}
-          </div>
+          {{ build_fake_dropdown('use-case-content', 'Use cases', True) }}
         </li>
-        <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" role="menuitem" id="support">
+        <li class="p-navigation__item--dropdown-toggle is-full-width js-navigation-dropdown-toggle" role="menuitem" id="support">
           <a class="p-navigation__link" href="#support" aria-controls="support-content" tabindex="0">Support</a>
-          <div class="p-navigation__dropdown--container">
-            {{ build_fake_dropdown('support-content', 'Support', links_count=2, sub_links_count=8, quick_links_count=5) }}
-          </div>
+          {{ build_fake_dropdown('support-content', 'Support', links_count=2, sub_links_count=8, quick_links_count=5) }}
         </li>
-        <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" role="menuitem" id="community">
+        <li class="p-navigation__item--dropdown-toggle is-full-width js-navigation-dropdown-toggle" role="menuitem" id="community">
           <a class="p-navigation__link" href="#community" aria-controls="community-content" tabindex="0">Community</a>
-          <div class="p-navigation__dropdown--container">
-            {{ build_fake_dropdown('community-content', 'Community', links_count=5, sub_links_count=7, quick_links_count=5) }}
-          </div>
+          {{ build_fake_dropdown('community-content', 'Community', links_count=5, sub_links_count=7, quick_links_count=5) }}
         </li>
-        <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" role="menuitem" id="get-ubuntu">
+        <li class="p-navigation__item--dropdown-toggle is-full-width js-navigation-dropdown-toggle" role="menuitem" id="get-ubuntu">
           <a class="p-navigation__link" href="#get-ubuntu" aria-controls="get-ubuntu-content" tabindex="0">Get Ubuntu</a>
-          <div class="p-navigation__dropdown--container">
-            {{ build_fake_dropdown('get-ubuntu-content', 'Get Ubuntu', links_count=6, sub_links_count=3, quick_links_count=8, has_cta_button=True ) }}
-          </div>
+          {{ build_fake_dropdown('get-ubuntu-content', 'Get Ubuntu', links_count=6, sub_links_count=3, quick_links_count=8, has_cta_button=True ) }}
         </li>
         <li class="p-navigation__item--dropdown-toggle is-right-shifted js-navigation-dropdown-toggle" role="menuitem" id="all-canonical">
           <button aria-controls="canonical-products" class="p-navigation__link" id="all-canonical-link" aria-expanded="false">All Canonical</button>
-          <div class="p-navigation__dropdown--container">
             <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="canonical-products" aria-hidden="true" data-level="1">
               <li class="p-navigation__item--dropdown-close" id="link-6-back">
                 <button aria-controls="canonical-products" class="p-navigation__link js-back-button">
@@ -75,7 +64,6 @@
                 <a href="#" class="p-navigation__dropdown-item">TODO....</a>
               </li>
             </ul>
-          </div>
         </li>
         <li class="p-navigation__item js-account" role="menuitem" id="canonical-login">
           <a href="#sign-in" class="p-navigation__link" tabindex="0">Sign in</a>

--- a/templates/docs/examples/patterns/navigation/sliding-dark.html
+++ b/templates/docs/examples/patterns/navigation/sliding-dark.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_navigation{% endblock %}
 
 {% block content %}
-<header id="navigation" class="p-navigation--sliding desktop-no-shadow is-dark">
+<header id="navigation" class="p-navigation--sliding is-dark">
   <div class="p-navigation__row--25-75">
     <div class="p-navigation__banner">
       <div class="p-navigation__tagged-logo">
@@ -32,7 +32,7 @@
         <li class="p-navigation__item">
           <a class="p-navigation__link" href="#">Partners</a>
         </li>
-        <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-1">
+        <li class="p-navigation__item--dropdown-toggle is-container-parent js-navigation-dropdown-toggle" id="link-1">
           <button href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link">
             LXD
           </button>
@@ -61,7 +61,7 @@
             </ul>
           </div>
         </li>
-        <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-2">
+        <li class="p-navigation__item--dropdown-toggle is-container-parent js-navigation-dropdown-toggle" id="link-2">
           <button href="#link-2-menu" aria-controls="link-2-menu" class="p-navigation__link">
             LXCFS
           </button>
@@ -81,7 +81,7 @@
               <li>
                 <a href="#" class="p-navigation__dropdown-item">Getting started</a>
               </li>
-              <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-4">
+              <li class="p-navigation__item--dropdown-toggle is-container-parent js-navigation-dropdown-toggle" id="link-4">
                 <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link">
                   Nested Layer
                 </button>

--- a/templates/docs/examples/patterns/navigation/sliding-dark.html
+++ b/templates/docs/examples/patterns/navigation/sliding-dark.html
@@ -36,70 +36,76 @@
           <button href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link">
             LXD
           </button>
-          <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-1-menu" aria-hidden="true" data-level="1">
-            <li class="p-navigation__item--dropdown-close" id="link-1-back">
-              <button href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link js-back-button">
-                Back
-              </button>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Introduction</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">News</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Getting started - Command line</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Getting started - OpenStack</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Getting started - OpenNebula</a>
-            </li>
-          </ul>
+          <div class="p-navigation__dropdown--container">
+            <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-1-menu" aria-hidden="true" data-level="1">
+              <li class="p-navigation__item--dropdown-close" id="link-1-back">
+                <button href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link js-back-button">
+                  Back
+                </button>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Introduction</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">News</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Getting started - Command line</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Getting started - OpenStack</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Getting started - OpenNebula</a>
+              </li>
+            </ul>
+          </div>
         </li>
         <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-2">
           <button href="#link-2-menu" aria-controls="link-2-menu" class="p-navigation__link">
             LXCFS
           </button>
-          <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-2-menu" aria-hidden="true" data-level="1">
-            <li class="p-navigation__item--dropdown-close" id="link-2-back">
-              <button href="#link-2-menu" aria-controls="link-2-menu" class="p-navigation__link js-back-button">
-                Back
-              </button>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Introduction</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">News</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Getting started</a>
-            </li>
-            <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-4">
-              <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link">
-                Nested Layer
-              </button>
-              <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-4-menu" aria-hidden="true" data-level="2">
-                <li class="p-navigation__item--dropdown-close" id="link-4-back">
-                  <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link js-back-button">
-                    Back
-                  </button>
-                </li>
-                <li>
-                  <a href="#" class="p-navigation__dropdown-item">Introduction</a>
-                </li>
-                <li>
-                  <a href="#" class="p-navigation__dropdown-item">News</a>
-                </li>
-                <li>
-                  <a href="#" class="p-navigation__dropdown-item">Getting started</a>
-                </li>
-              </ul>
-            </li>
-          </ul>
+          <div class="p-navigation__dropdown--container">
+            <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-2-menu" aria-hidden="true" data-level="1">
+              <li class="p-navigation__item--dropdown-close" id="link-2-back">
+                <button href="#link-2-menu" aria-controls="link-2-menu" class="p-navigation__link js-back-button">
+                  Back
+                </button>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Introduction</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">News</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Getting started</a>
+              </li>
+              <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-4">
+                <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link">
+                  Nested Layer
+                </button>
+                <div class="p-navigation__dropdown--container">
+                  <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-4-menu" aria-hidden="true" data-level="2">
+                    <li class="p-navigation__item--dropdown-close" id="link-4-back">
+                      <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link js-back-button">
+                        Back
+                      </button>
+                    </li>
+                    <li>
+                      <a href="#" class="p-navigation__dropdown-item">Introduction</a>
+                    </li>
+                    <li>
+                      <a href="#" class="p-navigation__dropdown-item">News</a>
+                    </li>
+                    <li>
+                      <a href="#" class="p-navigation__dropdown-item">Getting started</a>
+                    </li>
+                  </ul>
+                </div>
+              </li>
+            </ul>
+          </div>
         </li>
       </ul>
     </nav>

--- a/templates/docs/examples/patterns/navigation/sliding-dark.html
+++ b/templates/docs/examples/patterns/navigation/sliding-dark.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_navigation{% endblock %}
 
 {% block content %}
-<header id="navigation" class="p-navigation--sliding is-dark">
+<header id="navigation" class="p-navigation--sliding desktop-no-shadow is-dark">
   <div class="p-navigation__row--25-75">
     <div class="p-navigation__banner">
       <div class="p-navigation__tagged-logo">

--- a/templates/docs/examples/patterns/navigation/sliding-deprecated.html
+++ b/templates/docs/examples/patterns/navigation/sliding-deprecated.html
@@ -1,0 +1,120 @@
+{% extends "_layouts/examples.html" %}
+{% block title %}Navigation / Sliding deprecated{% endblock %}
+
+{% block standalone_css %}patterns_navigation{% endblock %}
+
+{% block content %}
+<header id="navigation" class="p-navigation--sliding is-dark">
+  <div class="p-navigation__row--25-75">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__tagged-logo">
+        <a class="p-navigation__link" href="#">
+          <div class="p-navigation__logo-tag">
+            <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg" alt="" >
+          </div>
+          <span class="p-navigation__logo-title">Ubuntu</span>
+        </a>
+      </div>
+      <ul class="p-navigation__items">
+        <li class="p-navigation__item">
+          <button class="js-menu-button p-navigation__link">Menu</button>
+        </li>
+      </ul>
+    </div>
+    <nav class="p-navigation__nav" aria-label="Example main">
+      <ul class="p-navigation__items js-dropdown-nav-list js-navigation-sliding-panel">
+        <li class="p-navigation__item is-selected">
+          <a class="p-navigation__link" href="#">Products</a>
+        </li>
+        <li class="p-navigation__item">
+          <a class="p-navigation__link" href="#">Services</a>
+        </li>
+        <li class="p-navigation__item">
+          <a class="p-navigation__link" href="#">Partners</a>
+        </li>
+        <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-1">
+          <button href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link">
+            LXD
+          </button>
+          <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-1-menu" aria-hidden="true" data-level="1">
+            <li class="p-navigation__item--dropdown-close" id="link-1-back">
+              <button href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link js-back-button">
+                Back
+              </button>
+            </li>
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">Introduction</a>
+            </li>
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">News</a>
+            </li>
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">Getting started - Command line</a>
+            </li>
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">Getting started - OpenStack</a>
+            </li>
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">Getting started - OpenNebula</a>
+            </li>
+          </ul>
+        </li>
+        <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-2">
+          <button href="#link-2-menu" aria-controls="link-2-menu" class="p-navigation__link">
+            LXCFS
+          </button>
+          <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-2-menu" aria-hidden="true" data-level="1">
+            <li class="p-navigation__item--dropdown-close" id="link-2-back">
+              <button href="#link-2-menu" aria-controls="link-2-menu" class="p-navigation__link js-back-button">
+                Back
+              </button>
+            </li>
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">Introduction</a>
+            </li>
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">News</a>
+            </li>
+            <li>
+              <a href="#" class="p-navigation__dropdown-item">Getting started</a>
+            </li>
+            <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-4">
+              <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link">
+                Nested Layer
+              </button>
+              <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-4-menu" aria-hidden="true" data-level="2">
+                <li class="p-navigation__item--dropdown-close" id="link-4-back">
+                  <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link js-back-button">
+                    Back
+                  </button>
+                </li>
+                <li>
+                  <a href="#" class="p-navigation__dropdown-item">Introduction</a>
+                </li>
+                <li>
+                  <a href="#" class="p-navigation__dropdown-item">News</a>
+                </li>
+                <li>
+                  <a href="#" class="p-navigation__dropdown-item">Getting started</a>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>
+{% endblock %}
+
+{% block script %}
+    <script>
+        {% include 'docs/examples/patterns/navigation/_script-sliding.js' %}
+    </script>
+{% endblock %}
+
+{% block style %}
+<style>
+    body { margin: 0; }
+</style>
+{% endblock %}

--- a/templates/docs/examples/patterns/navigation/sliding-search.html
+++ b/templates/docs/examples/patterns/navigation/sliding-search.html
@@ -41,70 +41,76 @@
           <button href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link">
             LXD
           </button>
-          <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-1-menu" aria-hidden="true">
-            <li class="p-navigation__item--dropdown-close" id="link-1-back">
-              <button href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link js-back-button">
-                Back
-              </button>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Introduction</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">News</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Getting started - Command line</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Getting started - OpenStack</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Getting started - OpenNebula</a>
-            </li>
-          </ul>
+          <div class="p-navigation__dropdown--container">
+            <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-1-menu" aria-hidden="true">
+              <li class="p-navigation__item--dropdown-close" id="link-1-back">
+                <button href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link js-back-button">
+                  Back
+                </button>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Introduction</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">News</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Getting started - Command line</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Getting started - OpenStack</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Getting started - OpenNebula</a>
+              </li>
+            </ul>
+          </div>
         </li>
         <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-2">
           <button href="#link-2-menu" aria-controls="link-2-menu" class="p-navigation__link">
             LXCFS
           </button>
-          <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-2-menu" aria-hidden="true">
-            <li class="p-navigation__item--dropdown-close" id="link-2-back">
-              <button href="#link-2-menu" aria-controls="link-2-menu" class="p-navigation__link js-back-button">
-                Back
-              </button>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Introduction</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">News</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Getting started</a>
-            </li>
-            <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-4">
-              <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link">
-                Nested Layer
-              </button>
-              <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-4-menu" aria-hidden="true">
-                <li class="p-navigation__item--dropdown-close" id="link-4-back">
-                  <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link js-back-button">
-                    Back
-                  </button>
-                </li>
-                <li>
-                  <a href="#" class="p-navigation__dropdown-item">Introduction</a>
-                </li>
-                <li>
-                  <a href="#" class="p-navigation__dropdown-item">News</a>
-                </li>
-                <li>
-                  <a href="#" class="p-navigation__dropdown-item">Getting started</a>
-                </li>
-              </ul>
-            </li>
-          </ul>
+          <div class="p-navigation__dropdown--container">
+            <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-2-menu" aria-hidden="true">
+              <li class="p-navigation__item--dropdown-close" id="link-2-back">
+                <button href="#link-2-menu" aria-controls="link-2-menu" class="p-navigation__link js-back-button">
+                  Back
+                </button>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Introduction</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">News</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Getting started</a>
+              </li>
+              <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-4">
+                <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link">
+                  Nested Layer
+                </button>
+                <div class="p-navigation__dropdown--container">
+                  <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-4-menu" aria-hidden="true">
+                    <li class="p-navigation__item--dropdown-close" id="link-4-back">
+                      <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link js-back-button">
+                        Back
+                      </button>
+                    </li>
+                    <li>
+                      <a href="#" class="p-navigation__dropdown-item">Introduction</a>
+                    </li>
+                    <li>
+                      <a href="#" class="p-navigation__dropdown-item">News</a>
+                    </li>
+                    <li>
+                      <a href="#" class="p-navigation__dropdown-item">Getting started</a>
+                    </li>
+                  </ul>
+                </div>
+              </li>
+            </ul>
+          </div>
         </li>
       </ul>
       <ul class="p-navigation__items">

--- a/templates/docs/examples/patterns/navigation/sliding-search.html
+++ b/templates/docs/examples/patterns/navigation/sliding-search.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_navigation{% endblock %}
 
 {% block content %}
-<header id="navigation" class="p-navigation--sliding desktop-no-shadow is-dark">
+<header id="navigation" class="p-navigation--sliding is-dark">
   <div class="p-navigation__row--25-75">
     <div class="p-navigation__banner">
       <div class="p-navigation__tagged-logo">
@@ -37,7 +37,7 @@
         <li class="p-navigation__item">
           <a class="p-navigation__link" href="#">Partners</a>
         </li>
-        <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-1">
+        <li class="p-navigation__item--dropdown-toggle is-container-parent js-navigation-dropdown-toggle" id="link-1">
           <button href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link">
             LXD
           </button>
@@ -66,7 +66,7 @@
             </ul>
           </div>
         </li>
-        <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-2">
+        <li class="p-navigation__item--dropdown-toggle is-container-parent js-navigation-dropdown-toggle" id="link-2">
           <button href="#link-2-menu" aria-controls="link-2-menu" class="p-navigation__link">
             LXCFS
           </button>
@@ -86,7 +86,7 @@
               <li>
                 <a href="#" class="p-navigation__dropdown-item">Getting started</a>
               </li>
-              <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-4">
+              <li class="p-navigation__item--dropdown-toggle is-container-parent js-navigation-dropdown-toggle" id="link-4">
                 <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link">
                   Nested Layer
                 </button>

--- a/templates/docs/examples/patterns/navigation/sliding-search.html
+++ b/templates/docs/examples/patterns/navigation/sliding-search.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_navigation{% endblock %}
 
 {% block content %}
-<header id="navigation" class="p-navigation--sliding is-dark">
+<header id="navigation" class="p-navigation--sliding desktop-no-shadow is-dark">
   <div class="p-navigation__row--25-75">
     <div class="p-navigation__banner">
       <div class="p-navigation__tagged-logo">

--- a/templates/docs/examples/patterns/navigation/sliding.html
+++ b/templates/docs/examples/patterns/navigation/sliding.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_navigation{% endblock %}
 
 {% block content %}
-<header id="navigation" class="p-navigation--sliding desktop-no-shadow">
+<header id="navigation" class="p-navigation--sliding">
   <div class="p-navigation__row--25-75">
     <div class="p-navigation__banner">
       <div class="p-navigation__tagged-logo">
@@ -32,7 +32,7 @@
         <li class="p-navigation__item">
           <a class="p-navigation__link" href="#">Partners</a>
         </li>
-        <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-1">
+        <li class="p-navigation__item--dropdown-toggle is-container-parent js-navigation-dropdown-toggle" id="link-1">
           <button href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link">
             LXD
           </button>
@@ -61,7 +61,7 @@
             </ul>
           </div>
         </li>
-        <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-2">
+        <li class="p-navigation__item--dropdown-toggle is-container-parent js-navigation-dropdown-toggle" id="link-2">
           <button href="#link-2-menu" aria-controls="link-2-menu" class="p-navigation__link">
             LXCFS
           </button>
@@ -81,7 +81,7 @@
               <li>
                 <a href="#" class="p-navigation__dropdown-item">Getting started</a>
               </li>
-              <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-4">
+              <li class="p-navigation__item--dropdown-toggle is-container-parent js-navigation-dropdown-toggle" id="link-4">
                 <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link">
                   Nested Layer
                 </button>

--- a/templates/docs/examples/patterns/navigation/sliding.html
+++ b/templates/docs/examples/patterns/navigation/sliding.html
@@ -4,7 +4,7 @@
 {% block standalone_css %}patterns_navigation{% endblock %}
 
 {% block content %}
-<header id="navigation" class="p-navigation--sliding">
+<header id="navigation" class="p-navigation--sliding desktop-no-shadow">
   <div class="p-navigation__row--25-75">
     <div class="p-navigation__banner">
       <div class="p-navigation__tagged-logo">

--- a/templates/docs/examples/patterns/navigation/sliding.html
+++ b/templates/docs/examples/patterns/navigation/sliding.html
@@ -36,70 +36,76 @@
           <button href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link">
             LXD
           </button>
-          <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-1-menu" aria-hidden="true" data-level="1">
-            <li class="p-navigation__item--dropdown-close" id="link-1-back">
-              <button href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link js-back-button">
-                Back
-              </button>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Introduction</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">News</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Getting started - Command line</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Getting started - OpenStack</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Getting started - OpenNebula</a>
-            </li>
-          </ul>
+          <div class="p-navigation__dropdown--container">
+            <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-1-menu" aria-hidden="true" data-level="1">
+              <li class="p-navigation__item--dropdown-close" id="link-1-back">
+                <button href="#link-1-menu" aria-controls="link-1-menu" class="p-navigation__link js-back-button">
+                  Back
+                </button>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Introduction</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">News</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Getting started - Command line</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Getting started - OpenStack</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Getting started - OpenNebula</a>
+              </li>
+            </ul>
+          </div>
         </li>
         <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-2">
           <button href="#link-2-menu" aria-controls="link-2-menu" class="p-navigation__link">
             LXCFS
           </button>
-          <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-2-menu" aria-hidden="true" data-level="1">
-            <li class="p-navigation__item--dropdown-close" id="link-2-back">
-              <button href="#link-2-menu" aria-controls="link-2-menu" class="p-navigation__link js-back-button">
-                Back
-              </button>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Introduction</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">News</a>
-            </li>
-            <li>
-              <a href="#" class="p-navigation__dropdown-item">Getting started</a>
-            </li>
-            <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-4">
-              <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link">
-                Nested Layer
-              </button>
-              <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-4-menu" aria-hidden="true" data-level="2">
-                <li class="p-navigation__item--dropdown-close" id="link-4-back">
-                  <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link js-back-button">
-                    Back
-                  </button>
-                </li>
-                <li>
-                  <a href="#" class="p-navigation__dropdown-item">Introduction</a>
-                </li>
-                <li>
-                  <a href="#" class="p-navigation__dropdown-item">News</a>
-                </li>
-                <li>
-                  <a href="#" class="p-navigation__dropdown-item">Getting started</a>
-                </li>
-              </ul>
-            </li>
-          </ul>
+          <div class="p-navigation__dropdown--container">
+            <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-2-menu" aria-hidden="true" data-level="1">
+              <li class="p-navigation__item--dropdown-close" id="link-2-back">
+                <button href="#link-2-menu" aria-controls="link-2-menu" class="p-navigation__link js-back-button">
+                  Back
+                </button>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Introduction</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">News</a>
+              </li>
+              <li>
+                <a href="#" class="p-navigation__dropdown-item">Getting started</a>
+              </li>
+              <li class="p-navigation__item--dropdown-toggle js-navigation-dropdown-toggle" id="link-4">
+                <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link">
+                  Nested Layer
+                </button>
+                <div class="p-navigation__dropdown--container">
+                  <ul class="p-navigation__dropdown js-dropdown-nav-list js-navigation-sliding-panel" id="link-4-menu" aria-hidden="true" data-level="2">
+                    <li class="p-navigation__item--dropdown-close" id="link-4-back">
+                      <button href="#link-4-menu" aria-controls="link-4-menu" class="p-navigation__link js-back-button">
+                        Back
+                      </button>
+                    </li>
+                    <li>
+                      <a href="#" class="p-navigation__dropdown-item">Introduction</a>
+                    </li>
+                    <li>
+                      <a href="#" class="p-navigation__dropdown-item">News</a>
+                    </li>
+                    <li>
+                      <a href="#" class="p-navigation__dropdown-item">Getting started</a>
+                    </li>
+                  </ul>
+                </div>
+              </li>
+            </ul>
+          </div>
         </li>
       </ul>
     </nav>


### PR DESCRIPTION
## Done

Add styles to make the navigation of the menu in mobile view slide in and out (from the right side).
Add styles to make the item's dropdown in desktop view slide down and up.
Add necessary HTML and JS to the examples for the new changes to work.

Fixes #5620 / [WD-26007](https://warthogs.atlassian.net/browse/WD-26007)

## QA

- Open the following URLs:
  - [Docs](https://vanilla-framework-5624.demos.haus/docs/patterns/navigation)
  - [Example: Sliding](https://vanilla-framework-5624.demos.haus/docs/examples/patterns/navigation/sliding)
  - [Example: Sliding dark](https://vanilla-framework-5624.demos.haus/docs/examples/patterns/navigation/sliding-dark)
  - [Example: Sliding with search](https://vanilla-framework-5624.demos.haus/docs/examples/patterns/navigation/sliding-search)
  - [Example: Sliding full width](https://vanilla-framework-5624.demos.haus/docs/examples/patterns/navigation/dropdown-full-width)
- Check that the menu in mobile view slides in and out from the right of the screen.
- Check that the dropdown items in desktop view slide down and up.

The other navigation types should not be affected by these changes.
- Open the following URLs:
  - [Example: Reduced](https://vanilla-framework-5624.demos.haus/docs/examples/patterns/navigation/reduced)
  - [Example: Dropdown](https://vanilla-framework-5624.demos.haus/docs/examples/patterns/navigation/dropdown)
- Check that the navigation still works as before.

## Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


[WD-26007]: https://warthogs.atlassian.net/browse/WD-26007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ