### PR TITLE
fix(Typography): root font size is derived from `$settings-text-default`

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -7,8 +7,8 @@
 @import 'global_functions';
 
 // Settings
-@import 'settings_font';
 @import 'settings_spacing';
+@import 'settings_font';
 @import 'settings_animations';
 @import 'settings_assets';
 @import 'settings_breakpoints';

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -8,8 +8,8 @@ $increase-font-size-on-larger-screens: true !default;
 $font-size-ratio--largescreen: 1.125 !default;
 $font-size-largescreen: map-get($settings-text-default, font-size) * $font-size-ratio--largescreen;
 $base-font-sizes: (
-  base: map-get($settings-text-default, font-size),
-  large: $font-size-largescreen,
+  base: #{map-get($settings-text-default, font-size)}rem,
+  large: #{$font-size-largescreen}rem,
 ) !default;
 
 // TODO removeme? This variable is not used in Vanilla - worth seeing if it's used downstream.

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -8,7 +8,7 @@ $increase-font-size-on-larger-screens: true !default;
 $font-size-ratio--largescreen: 1.125 !default;
 $font-size-largescreen: #{$font-size-ratio--largescreen}rem;
 $base-font-sizes: (
-  base: 1rem,
+  base: map-get($settings-text-default, font-size),
   large: $font-size-largescreen,
 ) !default;
 

--- a/scss/_settings_font.scss
+++ b/scss/_settings_font.scss
@@ -6,7 +6,7 @@ $font-display-option: fallback !default;
 $font-allow-cyrillic-greek-latin: false !default;
 $increase-font-size-on-larger-screens: true !default;
 $font-size-ratio--largescreen: 1.125 !default;
-$font-size-largescreen: #{$font-size-ratio--largescreen}rem;
+$font-size-largescreen: map-get($settings-text-default, font-size) * $font-size-ratio--largescreen;
 $base-font-sizes: (
   base: map-get($settings-text-default, font-size),
   large: $font-size-largescreen,


### PR DESCRIPTION
## Done

Sets the root font size to the default text side introduced by #5578 

Fixes #5573 
Fixes [WD-23671](https://warthogs.atlassian.net/browse/WD-23671)
Fixes #5615 
Fixes [WD-24793](https://warthogs.atlassian.net/browse/WD-24793)

## QA

- See that Percy passes
- Click around the demo and see nothing looks out of place

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).



[WD-23671]: https://warthogs.atlassian.net/browse/WD-23671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-24793]: https://warthogs.atlassian.net/browse/WD-24793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ