### PR TITLE
[WD-26329] fix: h4 style not applied to text spotlight pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.32.0",
+  "version": "4.32.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/templates/_macros/vf_text-spotlight.jinja
+++ b/templates/_macros/vf_text-spotlight.jinja
@@ -7,7 +7,7 @@
 #}
 {%- macro vf_text_spotlight(title_text, item_heading_level=2, list_items=[], caller=None) -%}
   {% set has_list = list_items | length >= 2 and list_items | length <= 7 %}
-  {% set item_heading_level = item_heading_level | trim %}
+  {% set item_heading_level = item_heading_level | trim | int %}
   {%- if item_heading_level not in [2, 4] -%}
     {%- set item_heading_level = 2 -%}
   {%- endif -%}


### PR DESCRIPTION
## Done

- Fixed H4 style not applied to items in text-spotlight pattern

Fixes [WD-26329](https://warthogs.atlassian.net/browse/WD-26329)

## QA

- Open [combined examples](https://vanilla-framework-5631.demos.haus/docs/examples/patterns/text-spotlight/combined)
- Verify all examples are working as expected

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

### Before

<img width="1894" height="572" alt="image" src="https://github.com/user-attachments/assets/b4cae0c1-7e99-4af9-8672-e5c4513abbfe" />

### After

<img width="1915" height="491" alt="image" src="https://github.com/user-attachments/assets/d53d679b-6c29-41b6-b6a3-8948e88a2b26" />



[WD-26329]: https://warthogs.atlassian.net/browse/WD-26329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ