### PR TITLE
[WD-26516] feat: Introduced new param and slot to the Newsletter signup pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.32.1",
+  "version": "4.33.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -3,7 +3,7 @@
     - component: Newsletter signup pattern
       url: /docs/patterns/newsletter-signup
       status: Updated
-      notes: We've introduced a new param and a slot to the Newsletter signup pattern
+      notes: We've introduced a new parameter and slot to the Newsletter signup pattern
 - version: 4.32.0
   features:
     - component: Divided section

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.33.0
+  features:
+    - component: Newsletter signup pattern
+      url: /docs/patterns/newsletter-signup
+      status: Updated
+      notes: We've introduced a new param and a slot to the Newsletter signup pattern
 - version: 4.32.0
   features:
     - component: Divided section

--- a/templates/_macros/vf_newsletter-signup.jinja
+++ b/templates/_macros/vf_newsletter-signup.jinja
@@ -9,13 +9,15 @@
       @param form_action: Action URL for the form submission, typically the form endpoint.
       @param return_url: URL to return to after form submission
       @param top_rule_variant (string) (optional): Variant of the top rule, default is "default". Options are "muted", "highlighted", "default", "none".
+      @param hide_newsletter_block_rule (boolean) (optional): Whether to hide the newsletter block rule on medium/small screens. Default is false.
 
     All Slots:
       @slot description: Description text, one or more paragraphs
       @slot addendum: Additional content to include in the form, such as a disclaimer or additional information
       @slot hidden_fields: Additional hidden fields to include in the form
+      @slot honeypot_fields: hidden honeypot fields for spam prevention
 #}
-{%- macro vf_newsletter_signup(form_id, return_url, title_text, form_action="https://ubuntu.com/marketo/submit", input_label="Work email", checkbox_id="canonicalUpdatesOptIn", checkbox_label="I agree to receive information about Canonical's products and services.", layout="25-75", top_rule_variant="default", caller=None) -%}
+{%- macro vf_newsletter_signup(form_id, return_url, title_text, form_action="https://ubuntu.com/marketo/submit", input_label="Work email", checkbox_id="canonicalUpdatesOptIn", checkbox_label="I agree to receive information about Canonical's products and services.", layout="25-75", top_rule_variant="default", hide_newsletter_block_rule=false, caller=None) -%}
   {% set layout = layout | trim %}
   {% if layout not in ['50-50', '25-75', '2-col', '4-col'] %}
     {% set layout = "25-75" %}
@@ -27,6 +29,7 @@
   {% set description = caller('description') %}
   {% set addendum = caller('addendum') %}
   {% set hidden_fields = caller('hidden_fields') %}
+  {% set honeypot_fields = caller('honeypot_fields') %}
   {% set is_section_level = layout in ['50-50', '25-75'] %}
   {% set is_grid_level = layout in ['2-col', '4-col'] %}
   {% set heading_level = 'h2' if is_section_level else 'h3' %}
@@ -49,7 +52,7 @@
         {%- endfor -%}
       {% endif %}
       <div class="grid-col{% if layout == '4-col' %}-4{% endif %} {% if is_grid_level %}p-newsletter-signup--{{ layout }}{% endif %}">
-        {%- if is_grid_level -%}
+        {%- if is_grid_level and not hide_newsletter_block_rule -%}
           <hr class="p-rule--muted u-hide--large {% if layout == '2-col' %}u-hide--medium{% endif %}" />
         {%- endif -%}
         <{{ heading_level }}>{{ title_text }}</{{ heading_level }}>
@@ -150,6 +153,28 @@
                    name="preferredLanguage"
                    maxlength="255"
                    value="" />
+          {% endif %}
+          {% if honeypot_fields %}
+            {{ honeypot_fields | safe }}
+          {% else %}
+            <div class="u-off-screen">
+              <label class="website" for="website">Website:</label>
+              <input name="website"
+                     type="text"
+                     class="website"
+                     autocomplete="off"
+                     value=""
+                     id="website"
+                     tabindex="-1" />
+              <label class="name" for="name">Name:</label>
+              <input name="name"
+                     type="text"
+                     class="name"
+                     autocomplete="off"
+                     value=""
+                     id="name"
+                     tabindex="-1" />
+            </div>
           {% endif %}
         </form>
       </div>

--- a/templates/docs/examples/patterns/newsletter-signup/2-col.html
+++ b/templates/docs/examples/patterns/newsletter-signup/2-col.html
@@ -1,6 +1,6 @@
 {% extends "_layouts/examples.html" %}
 {% from '_macros/vf_newsletter-signup.jinja' import vf_newsletter_signup %}
-{% block title %}Newsletter signup{% endblock %}
+{% block title %}Newsletter signup | 2-col{% endblock %}
 {% block standalone_css %}patterns_all{% endblock %}
 {% block content %}
     {% call(slot) vf_newsletter_signup(layout="2-col", title_text="Newsletter signup", form_id="mktoForm_4960", return_url="https://ubuntu.com/#contact-form-success", input_label='Work email', checkbox_id='canonicalUpdatesOptIn', checkbox_label='I agree to receive information about Canonical\'s products and services.') %}

--- a/templates/docs/examples/patterns/newsletter-signup/25-75.html
+++ b/templates/docs/examples/patterns/newsletter-signup/25-75.html
@@ -1,6 +1,6 @@
 {% extends "_layouts/examples.html" %}
 {% from '_macros/vf_newsletter-signup.jinja' import vf_newsletter_signup %}
-{% block title %}Newsletter signup{% endblock %}
+{% block title %}Newsletter signup | 25-75{% endblock %}
 {% block standalone_css %}patterns_all{% endblock %}
 {% block content %}
     {% call(slot) vf_newsletter_signup(layout="25-75", title_text="Newsletter signup", form_id="mktoForm_4960", return_url="https://ubuntu.com/#contact-form-success", input_label='Work email', checkbox_id='canonicalUpdatesOptIn', checkbox_label='I agree to receive information about Canonical\'s products and services.') %}

--- a/templates/docs/examples/patterns/newsletter-signup/4-col.html
+++ b/templates/docs/examples/patterns/newsletter-signup/4-col.html
@@ -1,6 +1,6 @@
 {% extends "_layouts/examples.html" %}
 {% from '_macros/vf_newsletter-signup.jinja' import vf_newsletter_signup %}
-{% block title %}Newsletter signup{% endblock %}
+{% block title %}Newsletter signup | 4-col{% endblock %}
 {% block standalone_css %}patterns_all{% endblock %}
 {% block content %}
     {% call(slot) vf_newsletter_signup(layout="4-col", title_text="Newsletter signup", form_id="mktoForm_4960", return_url="https://ubuntu.com/#contact-form-success", input_label='Work email', checkbox_id='canonicalUpdatesOptIn', checkbox_label='I agree to receive information about Canonical\'s products and services.') %}

--- a/templates/docs/examples/patterns/newsletter-signup/50-50.html
+++ b/templates/docs/examples/patterns/newsletter-signup/50-50.html
@@ -1,6 +1,6 @@
 {% extends "_layouts/examples.html" %}
 {% from '_macros/vf_newsletter-signup.jinja' import vf_newsletter_signup %}
-{% block title %}Newsletter signup{% endblock %}
+{% block title %}Newsletter signup | 50-50{% endblock %}
 {% block standalone_css %}patterns_all{% endblock %}
 {% block content %}
     {% call(slot) vf_newsletter_signup(layout="50-50", title_text="Newsletter signup", form_id="mktoForm_4960", return_url="https://ubuntu.com/#contact-form-success", input_label='Work email', checkbox_id='canonicalUpdatesOptIn', checkbox_label='I agree to receive information about Canonical\'s products and services.') %}

--- a/templates/docs/examples/patterns/newsletter-signup/x-col-without-newsletter-block-rule.html
+++ b/templates/docs/examples/patterns/newsletter-signup/x-col-without-newsletter-block-rule.html
@@ -1,0 +1,75 @@
+{% extends "_layouts/examples.html" %}
+{% from '_macros/vf_newsletter-signup.jinja' import vf_newsletter_signup %}
+{% block title %}Newsletter signup | Col-x without newsletter block rule{% endblock %}
+{% block standalone_css %}patterns_all{% endblock %}
+{% block content %}
+  <section class="p-section">
+    {% call(slot) vf_newsletter_signup(layout="2-col", title_text="Newsletter signup", form_id="mktoForm_4960", return_url="https://ubuntu.com/#contact-form-success", input_label='Work email', checkbox_id='canonicalUpdatesOptIn', checkbox_label='I agree to receive information about Canonical\'s products and services.', hide_newsletter_block_rule=true) %}
+      {%- if slot == 'description' -%}
+        <p>Get the latest Ubuntu news and updates in your inbox.</p>
+      {%- endif -%}
+      {%- if slot == 'col_1' -%}
+        <h5 class="p-heading--5">Continuous security</h5>
+        <p>
+          Imagine a world where every device is trustworthy. We designed every
+          aspect of Ubuntu Core to create the most secure embedded Linux ever, with
+          a 10 year LTS commitment.
+        </p>
+        <a href="#">
+          <p>Learn more about Ubuntu security&nbsp;›</p>
+        </a>
+      {%- endif -%}
+      {%- if slot == 'col_2' -%}
+        <h5 class="p-heading--5">Continuous security</h5>
+        <p>
+          Imagine a world where every device is trustworthy. We designed every
+          aspect of Ubuntu Core to create the most secure embedded Linux ever, with
+          a 10 year LTS commitment.
+        </p>
+        <a href="#">
+          <p>Learn more about Ubuntu security&nbsp;›</p>
+        </a>
+      {% endif %}
+      {%- if slot == 'col_3' -%}
+        <h5 class="p-heading--5">Continuous security</h5>
+        <p>
+          Imagine a world where every device is trustworthy. We designed every
+          aspect of Ubuntu Core to create the most secure embedded Linux ever, with
+          a 10 year LTS commitment.
+        </p>
+        <a href="#">
+          <p>Learn more about Ubuntu security&nbsp;›</p>
+        </a>
+      {% endif %}
+    {% endcall %}
+  </section>
+  <section class="p-section">
+    {% call(slot) vf_newsletter_signup(layout="4-col", title_text="Newsletter signup", form_id="mktoForm_4960", return_url="https://ubuntu.com/#contact-form-success", input_label='Work email', checkbox_id='canonicalUpdatesOptIn', checkbox_label='I agree to receive information about Canonical\'s products and services.', hide_newsletter_block_rule=true) %}
+      {%- if slot == 'description' -%}
+        <p>Get the latest Ubuntu news and updates in your inbox.</p>
+      {%- endif -%}
+      {%- if slot == 'col_1' -%}
+        <h5 class="p-heading--5">Continuous security</h5>
+        <p>
+          Imagine a world where every device is trustworthy. We designed every
+          aspect of Ubuntu Core to create the most secure embedded Linux ever, with
+          a 10 year LTS commitment.
+        </p>
+        <a href="#">
+          <p>Learn more about Ubuntu security&nbsp;›</p>
+        </a>
+      {%- endif -%}
+      {%- if slot == 'col_2' -%}
+        <h5 class="p-heading--5">Continuous security</h5>
+        <p>
+          Imagine a world where every device is trustworthy. We designed every
+          aspect of Ubuntu Core to create the most secure embedded Linux ever, with
+          a 10 year LTS commitment.
+        </p>
+        <a href="#">
+          <p>Learn more about Ubuntu security&nbsp;›</p>
+        </a>
+      {% endif %}
+    {% endcall %}
+  </section>
+{% endblock %}

--- a/templates/docs/patterns/newsletter-signup/index.md
+++ b/templates/docs/patterns/newsletter-signup/index.md
@@ -14,6 +14,7 @@ Newsletter signup is a form which allows users to subscribe to a newsletter for 
 - [50-50](#50-50)
 - [col-2](#col-2)
 - [col-4](#col-4)
+- [x-col-without-newsletter-block-rule-on-smaller-screens](#x-col-without-newsletter-block-rule-on-smaller-screens)
 
 The Newsletter signup pattern is composed of the following elements:
 
@@ -63,6 +64,17 @@ For the other adjacent content in the grid, you can utilize <a href="#col_slots"
 
 <div class="embedded-example"><a href="/docs/examples/patterns/newsletter-signup/4-col" class="js-example" data-lang="jinja">
 View example of the 4-col newsletter signup
+</a></div>
+
+## x-col-without-newsletter-block-rule-on-smaller-screens
+
+The <code>2-col</code> variant comes with a [muted-rule](/docs/patterns/rule#muted) on small screens.<br/>
+Similarly, the <code>4-col</code> variant comes with a [muted-rule](/docs/patterns/rule#muted) on both small and medium screens.<br/>
+To hide this rule, you can pass <code>hide_newsletter_block_rule</code>.<br />
+The following example shows both 2-col and 4-col variants not having a muted rule on medium/small screens.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/newsletter-signup/x-col-without-newsletter-block-rule" class="js-example" data-lang="jinja">
+View example of the 2-col/4-col newsletter signup without a newsletter block-level rule on smaller screens
 </a></div>
 
 ## Jinja Macro
@@ -259,6 +271,24 @@ The `vf_newsletter_signup` Jinja macro can be used to generate a Newsletter sign
           </ul>
         </td>
       </tr>
+      <tr>
+        <td>
+          <code>hide_newsletter_block_rule</code>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>False</code>
+        </td>
+        <td>
+          Whether to hide the newsletter block rule on medium/small screens.<br />
+          Only applicable to <code>2-col</code> and <code>4-col</code> variants
+        </td>
+      </tr>
     </tbody>
   </table>
 </div>
@@ -306,6 +336,17 @@ The `vf_newsletter_signup` Jinja macro can be used to generate a Newsletter sign
         </td>
         <td>
           Additional hidden fields to include in the form
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>honeypot_fields</code>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          Hidden honeypot fields for spam prevention
         </td>
       </tr>
       <tr id="col_slots">

--- a/templates/docs/patterns/newsletter-signup/index.md
+++ b/templates/docs/patterns/newsletter-signup/index.md
@@ -14,7 +14,7 @@ Newsletter signup is a form which allows users to subscribe to a newsletter for 
 - [50-50](#50-50)
 - [col-2](#col-2)
 - [col-4](#col-4)
-- [x-col-without-newsletter-block-rule-on-smaller-screens](#x-col-without-newsletter-block-rule-on-smaller-screens)
+- [newsletter-block-rule-on-smaller-screens](#newsletter-block-rule-on-smaller-screens)
 
 The Newsletter signup pattern is composed of the following elements:
 
@@ -66,7 +66,7 @@ For the other adjacent content in the grid, you can utilize <a href="#col_slots"
 View example of the 4-col newsletter signup
 </a></div>
 
-## x-col-without-newsletter-block-rule-on-smaller-screens
+## Newsletter block rule on smaller screens
 
 The <code>2-col</code> variant comes with a [muted-rule](/docs/patterns/rule#muted) on small screens.<br/>
 Similarly, the <code>4-col</code> variant comes with a [muted-rule](/docs/patterns/rule#muted) on both small and medium screens.<br/>


### PR DESCRIPTION
## Done

- Added `honeypot_fields` slot with default values, for spam prevention
- Added `hide_newsletter_block_rule` param, to hide the block-level muted rule on medium/smaller screens for 2-col, 4-col variants.

Fixes [WD-26516](https://warthogs.atlassian.net/browse/WD-26516)

## QA

- Review [Newsletter pattern docs](https://vanilla-framework-5637.demos.haus/docs/patterns/newsletter-signup)
- Review [release notes](https://vanilla-framework-5637.demos.haus/docs/whats-new)
- Review [new example](https://vanilla-framework-5637.demos.haus/docs/examples/patterns/newsletter-signup/x-col-without-newsletter-block-rule)
- Review [combined examples](https://vanilla-framework-5637.demos.haus/docs/examples/patterns/newsletter-signup/combined)

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

[WD-26516]: https://warthogs.atlassian.net/browse/WD-26516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ