### PR TITLE
For modal height use dvh to make it respect open url bars in mobile browsers

### DIFF
--- a/scss/_patterns_modal.scss
+++ b/scss/_patterns_modal.scss
@@ -8,7 +8,7 @@
     background: $colors--theme--background-overlay;
     bottom: 0;
     display: flex;
-    height: 100vh;
+    height: 100dvh;
     justify-content: center;
     left: 0;
     margin: 0;


### PR DESCRIPTION
## Done

- For modal height use dvh to make it respect open url bars in mobile browsers
- Related issue reported in https://github.com/canonical/lxd-ui/issues/1496 with respect to a Network ACL configuration modal. The buttons in the footer are cut, as the height of the modal (100vh) does not take into account the reduced available height due to the open url bar. The change to 100dvh respects that and resolves the issue.