### PR TITLE
adjust asset manager asset link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Vanilla Framework is an extensible CSS framework, built using [Sass](http://sass
 You can link to the latest build to add directly into your markup like so, by replacing the x values with the [version number you wish to link](https://github.com/canonical/vanilla-framework/releases).
 
 ```html
-<link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-x.x.x.min.css" />
+<link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla_framework_version_x_x_x_min.css" />
 ```
 
 ### Including Vanilla in your project via NPM or yarn

--- a/templates/docs/index.html
+++ b/templates/docs/index.html
@@ -30,7 +30,7 @@
 
 <h2>Hotlink</h2>
 <p>You can add Vanilla directly to your markup:</p>
-<pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-{{ version }}.min.css" /&gt;</code></pre>
+<pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla_framework_version_{{ version | replace(".", "_") }}_min.css" /&gt;</code></pre>
 
 <h2>Download</h2>
 <p>Download the latest version of Vanilla from GitHub.</p>

--- a/templates/static/js/example.js
+++ b/templates/static/js/example.js
@@ -67,7 +67,7 @@
       // if it's a demo, use local build.css for better QA, otherwise use latest published Vanilla
       /demos\.haus$/.test(window.location.host)
         ? `${window.location.origin}/static/build/css/build.css`
-        : 'https://assets.ubuntu.com/v1/vanilla-framework-version-' + VANILLA_VERSION + '.min.css',
+        : 'https://assets.ubuntu.com/v1/vanilla_framework_version_' + VANILLA_VERSION.replaceAll('.', '_') + '_min.css',
       // link to example stylesheet (to set margin on body)
       'https://assets.ubuntu.com/v1/4653d9ba-example.css',
     ],


### PR DESCRIPTION
## Done

A recent [asset API change](https://github.com/canonical/assets.ubuntu.com/pull/295) has changed asset handling such that asset names are now sanitized before uploading. This has caused our asset manager CSS uploads, which used to live at, for example, https://assets.ubuntu.com/v1/vanilla_framework_version-4.33.0.min.css, to instead be uploaded as https://assets.ubuntu.com/v1/vanilla_framework_version_4_33_0_min.css .

This PR changes the places we consume the asset manager URLs to use the new asset name format.

Fixes https://chat.canonical.com/canonical/pl/mxgy18rwjigcig8koeurcefn7h

## QA

- Checkout PR locally, run with `dotrun`
- Open [get started page hotlink section](http://0.0.0.0:8101/docs#hotlink). Copy the asset link and verify it goes to https://assets.ubuntu.com/v1/vanilla_framework_version_4_33_0_min.css which contains Vanilla CSS.
- Open any component docs page and scroll to an example. Click "Edit on Codepen" and verify that vanilla CSS is present. Click the gear on the CSS section on CodePen and you should see an asset link to https://assets.ubuntu.com/v1/vanilla_framework_version_4_33_0.min.css. 

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).