### PR TITLE
fix(badge): reset text-indent to prevent inheritance (#5629)

### DIFF
--- a/scss/_patterns_badge.scss
+++ b/scss/_patterns_badge.scss
@@ -17,6 +17,7 @@
     overflow: hidden;
     padding: 0 $spv--x-small;
     text-align: center;
+    text-indent: 0;
   }
 
   .p-badge,


### PR DESCRIPTION
## Done

Badges inside p-checkbox inherited a negative text-indent, causing the text to disappear. 
This change resets text-indent to 0 for p-badge to prevent inheritance.

Fixes #5629 

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

