### PR TITLE
fix mobile height calculations to include the open url bar

### DIFF
--- a/scss/_layouts_application.scss
+++ b/scss/_layouts_application.scss
@@ -52,7 +52,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
       'nav  status status';
     grid-template-columns: min-content minmax(0, 1fr) minmax(0, min-content);
     grid-template-rows: min-content 1fr min-content;
-    height: 100vh;
+    height: 100dvh;
     overflow: hidden; // make sure panels transformed off-screen don't make the layout scroll
     width: 100vw;
   }
@@ -69,7 +69,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
 
     bottom: 0;
     box-shadow: $panel-drop-shadow;
-    height: 100vh;
+    height: 100dvh;
     left: 0;
     overflow-y: auto;
     position: fixed;
@@ -94,7 +94,7 @@ $application-layout--side-nav-width-expanded: 15rem !default;
   }
 
   .l-navigation__drawer {
-    height: 100vh;
+    height: 100dvh;
     width: auto;
 
     @media (min-width: $breakpoint-x-small) {

--- a/scss/_layouts_docs.scss
+++ b/scss/_layouts_docs.scss
@@ -90,7 +90,7 @@
 
     // on largest screens we want to keep the table of contents sticky
     .l-docs__sticky-container {
-      max-height: 100vh;
+      max-height: 100dvh;
       overflow-y: auto;
       position: sticky;
       top: 0;

--- a/scss/_layouts_full-width.scss
+++ b/scss/_layouts_full-width.scss
@@ -25,7 +25,7 @@
       $navigation-top-height: $spv--large * 2 + map-get($settings-text-default, line-height);
 
       height: calc(100% - $navigation-top-height); // height of document reduced by height of top nav
-      min-height: calc(100vh - $navigation-top-height);
+      min-height: calc(100dvh - $navigation-top-height);
       position: absolute;
       width: $l-full-screen-aside-width;
       z-index: 1;

--- a/scss/_layouts_site.scss
+++ b/scss/_layouts_site.scss
@@ -6,7 +6,7 @@ $site-layout--breakpoint-sticky-footer: $breakpoint-small !default;
     .l-site {
       display: flex;
       flex-direction: column;
-      min-height: 100vh;
+      min-height: 100dvh;
     }
 
     .l-footer--sticky {

--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -843,8 +843,8 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
 
   .p-navigation--sliding.has-menu-open,
   .p-navigation--reduced.has-menu-open {
-    box-shadow: $colors--theme--background-overlay 0px 0px 0px 100vh;
-    height: 100vh;
+    box-shadow: $colors--theme--background-overlay 0px 0px 0px 100dvh;
+    height: 100dvh;
     overflow-y: hidden;
     position: fixed;
     width: 100vw;
@@ -866,7 +866,7 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
     }
     .p-navigation__nav {
       display: block;
-      height: calc(100vh - $navigation-height);
+      height: calc(100dvh - $navigation-height);
       overflow-x: hidden;
 
       .p-navigation__items {
@@ -893,7 +893,7 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
   .p-navigation--sliding .p-navigation__dropdown,
   .p-navigation--reduced .p-navigation__dropdown {
     display: block;
-    height: calc(100vh - $navigation-height);
+    height: calc(100dvh - $navigation-height);
     left: 100vw;
     position: absolute;
     top: 0;
@@ -1007,6 +1007,7 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
     .p-navigation__dropdown > :last-child {
       // should be enough to make some space at the bottom
       // and workaround the issues of 100vh not taking address toolbar into account
+      // this workaround might not be needed since we moved from 100vh to 100dvh
       padding-bottom: 3rem;
 
       @media (min-width: $breakpoint-navigation-threshold) {

--- a/scss/_patterns_side-navigation.scss
+++ b/scss/_patterns_side-navigation.scss
@@ -240,7 +240,7 @@
     // make whole navigation sticky on large screens
     .p-side-navigation.is-sticky,
     [class*='p-side-navigation--'].is-sticky {
-      max-height: 100vh;
+      max-height: 100dvh;
       overflow-y: auto;
       position: sticky;
       top: 0;


### PR DESCRIPTION
## Done

- fix mobile height calculations to include the open url bar
- Fix is using 100dvh instead of 100vh everywhere

This is a follow-up to #5641 which was fixing a particular issue with modals. This change is adopting the same fix everywhere.