### PR TITLE
Revert "adjust asset manager asset link (#5642)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Vanilla Framework is an extensible CSS framework, built using [Sass](http://sass
 You can link to the latest build to add directly into your markup like so, by replacing the x values with the [version number you wish to link](https://github.com/canonical/vanilla-framework/releases).
 
 ```html
-<link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla_framework_version_x_x_x_min.css" />
+<link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-x.x.x.min.css" />
 ```
 
 ### Including Vanilla in your project via NPM or yarn

--- a/templates/docs/index.html
+++ b/templates/docs/index.html
@@ -30,7 +30,7 @@
 
 <h2>Hotlink</h2>
 <p>You can add Vanilla directly to your markup:</p>
-<pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla_framework_version_{{ version | replace(".", "_") }}_min.css" /&gt;</code></pre>
+<pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla-framework-version-{{ version }}.min.css" /&gt;</code></pre>
 
 <h2>Download</h2>
 <p>Download the latest version of Vanilla from GitHub.</p>

--- a/templates/static/js/example.js
+++ b/templates/static/js/example.js
@@ -67,7 +67,7 @@
       // if it's a demo, use local build.css for better QA, otherwise use latest published Vanilla
       /demos\.haus$/.test(window.location.host)
         ? `${window.location.origin}/static/build/css/build.css`
-        : 'https://assets.ubuntu.com/v1/vanilla_framework_version_' + VANILLA_VERSION.replaceAll('.', '_') + '_min.css',
+        : 'https://assets.ubuntu.com/v1/vanilla-framework-version-' + VANILLA_VERSION + '.min.css',
       // link to example stylesheet (to set margin on body)
       'https://assets.ubuntu.com/v1/4653d9ba-example.css',
     ],


### PR DESCRIPTION
This reverts commit 825b527280a914ffa06e99de4a3a1b4c4de0116c.

## Done

Reverts #5642 to align Vanilla's stylesheet links to the format they are published in.

Fixes #5649 
Fixes https://warthogs.atlassian.net/browse/WD-27057

## QA

- Open [get started page](https://assets.ubuntu.com/v1/vanilla-framework-version-4.34.0.min.css) on demos.haus and ensure the hotlink URL is correct
- Checkout this PR. Open any component docs page locally, and click "edit on codepen". Ensure Vanilla CSS is properly populated into the codepen example. 

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
