### PR TITLE
fix: Logo section pattern rule taking up entire width of the screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.34.0",
+  "version": "4.34.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/templates/_macros/vf_logo-section.jinja
+++ b/templates/_macros/vf_logo-section.jinja
@@ -69,7 +69,7 @@
     {% if has_description %}{{ description_content | safe }}{% endif %}
   {%- endmacro -%}
   <section class="{{ padding_classes }}">
-    <hr class="p-rule" />
+    <hr class="p-rule is-fixed-width" />
     <div class="grid-row--50-50">
       <div class="grid-col">{{- _title_block(title) -}}</div>
       <div class="grid-col">


### PR DESCRIPTION
## Done

- Fixed logo section rule taking full width

## QA

- Open [demo](https://vanilla-framework-5651.demos.haus/docs/examples/patterns/logo-section/combined)
- Verify the rule is taking only as much width as that of the section

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
