### PR TITLE
fix typo in notification accessibility page title

### DIFF
--- a/templates/docs/patterns/notification/accessibility.md
+++ b/templates/docs/patterns/notification/accessibility.md
@@ -1,7 +1,7 @@
 ---
 wrapper_template: '_layouts/docs.html'
 context:
-  title: Nofitication | Components
+  title: Notification | Components
 ---
 
 ## How it works


### PR DESCRIPTION
## Done

Fixes a typo in the the title on the [notification accessibility page](https://vanillaframework.io/docs/patterns/notification/accessibility)

## QA

- Open [demo](https://vanilla-framework-5653.demos.haus/docs/patterns/notification/accessibility)
- Verify the title of the notification accessibility page is not misspelled

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).
