### PR TITLE
fix: Support legacy imports of scss

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
       "sass": "./_index.scss"
     },
     "./js": "./templates/static/js/index.js",
-    "./js/*": "./templates/static/js/*.js"
+    "./js/*": "./templates/static/js/*.js",
+    "./scss/*": {
+      "sass": "./scss/*"
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Done

* Existing usages use `@import "vanilla-framework/scss/build";`, so we have to export those nested paths as well.

