### PR TITLE
Fix baseline grid toggle styling on standalone examples

### DIFF
--- a/scss/docs/example.scss
+++ b/scss/docs/example.scss
@@ -1,9 +1,9 @@
 // styles specific for the example pages
-
 @import '../vanilla';
 @include vf-u-baseline-grid;
 @include vf-b-button;
 @include vf-p-segmented-control;
+@include vf-p-switch;
 @include vf-p-forms-inline;
 
 // stylelint-disable selector-max-type -- examples can use type selectors


### PR DESCRIPTION
Import switch component styles in examples.scss to properly style the baseline grid toggle on standalone examples.

Fixes #5286

## Done
- Added `@include vf-p-switch;` to `scss/docs/example.scss` to import switch component styles
- This ensures the baseline grid toggle is properly styled on all standalone examples

## QA
- Open any standalone example page (e.g., https://vanillaframework.io/docs/examples/patterns/accordion/)
- Verify the baseline grid toggle button in the bottom toolbar is now properly styled
- Check that the switch component displays correctly with proper styling

### Check if PR is ready for release
If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:
- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Bug 🐛`
- [ ] Vanilla version in `package.json` should be updated relative to the most recent release, following semver convention
  - This can be a bugfix release (x.x.X) as no APIs are changed
- [ ] Changes to component class names or macros should be listed on the what's new page (N/A for this PR - no class changes)

## Screenshots
N/A - This fix only imports existing switch component styles, no visual changes to document