### PR TITLE
Fix modal autoscroll/focus on page load

### DIFF
--- a/templates/docs/examples/patterns/modal/_script.js
+++ b/templates/docs/examples/patterns/modal/_script.js
@@ -1,6 +1,5 @@
 // This is an example modal implementation inspired by
 // https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html
-
 (function () {
   // This is not a production ready code, just serves as an example
   // of how the focus should be controlled within the modal dialog.
@@ -12,7 +11,6 @@
   // Traps the focus within the currently open modal dialog
   function trapFocus(event) {
     if (ignoreFocusChanges) return;
-
     if (currentDialog.contains(event.target)) {
       lastFocus = event.target;
     } else {
@@ -75,6 +73,7 @@
         modal.style.display = 'flex';
         focusFirstDescendant(modal);
         focusAfterClose = sourceEl;
+
         document.addEventListener('focus', trapFocus, true);
       } else {
         modal.style.display = 'none';
@@ -106,14 +105,10 @@
   // Add handler for closing modals using ESC key.
   document.addEventListener('keydown', function (e) {
     e = e || window.event;
-
     if (e.code === 'Escape') {
       closeModals();
     } else if (e.keyCode === 27) {
       closeModals();
     }
   });
-
-  // init the dialog that is initially opened in the example
-  toggleModal(document.querySelector('#modal'), document.querySelector('[aria-controls=modal]'), true);
 })();


### PR DESCRIPTION
Fixes #5119

Removed the automatic modal opening on page load that was causing unwanted autoscroll and focus behavior. The modal documentation page now loads normally without automatically opening and focusing the modal, which was causing the page to scroll to the close button.

The modal functionality still works as expected - users can open modals by clicking the appropriate triggers.

## Done
- Removed lines 117-118 from `_script.js` that initialized the modal on page load
- Modal examples documentation page now loads without auto-focusing

## QA
- Open the modal pattern documentation page
- Verify the page loads at the top without automatically scrolling
- Verify no modal is open by default
- Click on "Open modal" buttons to verify modals still open correctly
- Verify ESC key still closes modals

### Check if PR is ready for release
- [x] PR should have one of the following labels: `Bug 🐛`
- [ ] Vanilla version in `package.json` should be updated (maintainers will handle)
- [ ] Changes listed on the what's new page (if needed by maintainers)