### PR TITLE
Fix dismiss button alignment in borderless notifications

### DIFF
--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -1,5 +1,4 @@
 @import 'settings';
-
 /*
   @classreference
   notification:
@@ -18,78 +17,75 @@
             Borderless variant of notification. Used when notification is embeded into another container element.
         "&.is-inline":
             Inline version of notification with title and message rendered side by side.
-
     Content container:
         .p-notification__content:
             Container element for notification content (title and message).
-
     Title:
         .p-notification__title:
             The notification title.
-
     Message:
         .p-notification__message:
             Text of the notification message.
-
     Close button:
         .p-notification__close:
             The button to close the notification.
-
-    Meta-data container:
-        .p-notification__meta:
-            The container element for notification meta-data (timestamp and action buttons).
-
-    Timestamp:
-        .p-notification__timestamp:
-            Notification timestamp or date.
-
-    Actions container:
-        .p-notification__actions:
-            Container element for notification action buttons.
-
-    Action button:
-        .p-notification__action:
-            Single action button.
+    Status:
+        .p-notification__status:
+            The status text for screen readers.
 */
 
-// space on the left of the icon + icon width + space on the right of the icon
-$notification-content-icon-space: 2 * $sph--large + map-get($icon-sizes, default);
-
-// the icon is a background element, so it needs to be manually positioned to match the text next to it;
-// Step 1: push down by the same amount applied as padding top on text ($spv-nudge)
-// Step 2: to center the icon within the line-height of text, we subtract icon height from text line-height and multiply by .5; this is the amount we need to push the icon down by
-$borderless-notification-icon-vert-offset: $spv-nudge + 0.5 * (map-get($settings-text-default, line-height) - map-get($icon-sizes, default));
-// Step 3: Add the notification padding-top (if it exists); we have two cases, so at this point we create a second var that contains the first one + the notification padding-top
-$notification-icon-vert-offset: $spv--small + $borderless-notification-icon-vert-offset;
-
-// normally, paragraphs use a large margin-bottom (currently 1.5rem) to ensure elements that follow are sufficiently spaced.
-// within the insulated context of a notification, less space is needed, as the notification itself has an ample margin on it.
-// We still need a little space so things like the border on the __meta do not crash into the preceding text element, so we use a reduced amount of margin
-// being text, it still needs to align to the baseline grid. So we need to subtract $spv-nudge (the amount applied to this text as padding-top) from the total amount of margin-bottom.
-// As a result, padding-top + margin-bottom == an exact multiple of the base spacing unit, $sp-unit (which is .5rem)
-$notification-text-margin-bottom: $spv--large - $spv-nudge;
-
-// Notification style patterns
 @mixin vf-p-notification {
-  // The mixin for basic notification styling
-  %vf-notification {
-    @extend %vf-is-bordered;
+  $color-information: $color-information;
+  $color-positive: $color-positive;
+  $color-caution: $color-caution;
+  $color-negative: $color-negative;
 
-    background: $colors--theme--background-default;
-    background-position: $sph--large $notification-icon-vert-offset;
+  $border-width: 4px;
+
+  $states: (
+    'information': $color-information,
+    'positive': $color-positive,
+    'caution': $color-caution,
+    'negative': $color-negative,
+  );
+
+  @include vf-b-placeholders;
+  @include vf-b-typography;
+
+  // stylelint-disable max-nesting-depth -- allow deeper nesting for modifiers
+  %vf-notification-icon {
+    background-position: $sph--large $spv--small;
     background-repeat: no-repeat;
     background-size: map-get($icon-sizes, default);
-    border-color: $colors--theme--border-default;
-    color: $colors--theme--text-default;
-    margin-bottom: $spv--x-large;
-    padding-bottom: calc($spv--small - 1px);
-    padding-left: $notification-content-icon-space;
-    padding-top: calc($spv--small - 1px);
+    padding-left: 2 * $sph--large + map-get($icon-sizes, default);
+  }
+
+  .p-notification {
+    @extend %vf-has-box-shadow;
+    @extend %vf-has-round-corners;
+    @extend %vf-notification-icon;
+
+    border: $border-width solid $color-mid-light;
+    display: grid;
+    grid-template-areas: 'content close';
+    grid-template-columns: 1fr auto;
+    margin-bottom: $spv--small;
+    padding-bottom: calc($spv--small - $border-width);
+    padding-right: $sph--large * 0.5;
+    padding-top: calc($spv--small - $border-width);
     position: relative;
 
     &::before {
-      left: -1px !important;
+      background-color: $color-information;
+      content: '';
+      height: 100%;
+      left: 0;
+      position: absolute;
+      top: 0;
+      width: $border-width;
     }
+
+    $borderless-notification-icon-vert-offset: $spv-nudge;
 
     &.is-borderless {
       background-position: 0 $borderless-notification-icon-vert-offset;
@@ -100,156 +96,71 @@ $notification-text-margin-bottom: $spv--large - $spv-nudge;
       &::before {
         display: none;
       }
-    }
 
-    &.is-inline {
-      .p-notification__content {
-        margin-bottom: $notification-text-margin-bottom;
-      }
-
-      .p-notification__meta {
-        padding-top: 0;
-
-        &::after {
-          // unset pseudo border
-          content: none;
-        }
-      }
-
-      .p-notification__title,
-      .p-notification__message {
-        display: inline;
+      .p-notification__close {
+        top: 0;
       }
     }
 
     .p-notification__content {
-      @extend %common-default-text-properties;
-
-      margin-bottom: $notification-text-margin-bottom;
-      max-width: unset;
-      padding-right: 2 * $sph--large;
+      grid-area: content;
     }
 
     .p-notification__title {
-      font-size: 1rem;
-      font-weight: $font-weight-bold;
-      line-height: map-get($settings-text-default, line-height);
-      margin: 0;
-      padding: 0;
+      @extend %bold;
+
+      display: inline;
+      padding-right: $sph--small;
     }
 
     .p-notification__message {
-      margin: 0;
-      max-width: unset;
-      padding: 0;
+      display: inline;
+
+      > *:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    .p-notification__status {
+      @extend %vf-hide-text;
+    }
+
+    // status specific overrides
+    @each $state, $color in $states {
+      &--#{$state} {
+        &::before {
+          background-color: $color;
+        }
+      }
     }
 
     .p-notification__close {
-      @extend %vf-hide-text;
-      @include vf-icon-close-themed;
-
-      background-color: transparent;
-      background-position: center;
-      background-repeat: no-repeat;
-      background-size: unset;
+      appearance: none;
+      background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath fill='%23111' d='M13.693 2.308 11.385 0 6.846 4.538 2.308 0 0 2.308l4.538 4.538L0 11.385l2.308 2.307 4.538-4.538 4.539 4.538 2.307-2.307-4.538-4.539z'/%3E%3C/svg%3E") 50% 50% no-repeat;
       border: 0;
-      // set the height of the button to be size of an icon + padding on top and bottom
-      height: calc(2 * $spv--small + $default-icon-size);
-      position: absolute;
+      cursor: pointer;
+      grid-area: close;
+      height: 1rem;
+      margin: 0;
+      padding: 0;
+      position: relative;
       right: $sph--large * 0.5;
       top: $spv--small;
-      width: $default-icon-size;
+      width: 1rem;
     }
 
-    .p-notification__meta {
-      @extend %vf-pseudo-border--top;
+    &.is-inline {
+      .p-notification__content {
+        align-items: baseline;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+      }
 
-      align-items: flex-start;
-      display: flex;
-      justify-content: space-between;
-      margin-bottom: $spv--small;
-      padding-right: $sph--large;
-      padding-top: $spv--small;
-    }
-
-    .p-notification__timestamp {
-      @extend %default-text;
-      @extend %muted-text;
-
-      color: $colors--theme--text-muted;
-    }
-
-    .p-notification__actions {
-      align-items: flex-start;
-      display: flex;
-
-      &:only-child {
-        margin-left: auto;
+      .p-notification__title {
+        flex-shrink: 0;
       }
     }
-
-    .p-notification__action {
-      @extend %default-text;
-      color: $colors--theme--link-default;
-
-      &:visited {
-        color: $colors--theme--link-visited;
-      }
-    }
-
-    .p-notification__action + .p-notification__action {
-      margin-left: $sph--large;
-    }
   }
-
-  @include vf-notifications-default;
-  @include vf-notifications-positive;
-  @include vf-notifications-caution;
-  @include vf-notifications-negative;
-  @include vf-notifications-information;
-}
-
-// Default notification styling
-@mixin vf-notifications-default {
-  .p-notification {
-    @extend %vf-notification;
-    @include vf-highlight-bar($colors--theme--border-information, left, true);
-    @include vf-icon-info-coloured-themed;
-  }
-}
-
-// Positive notification styling
-@mixin vf-notifications-positive {
-  .p-notification--positive {
-    @extend %vf-notification;
-    @include vf-highlight-bar($colors--theme--border-positive, left, true);
-    @include vf-icon-success-themed;
-  }
-}
-
-// Caution notification styling
-@mixin vf-notifications-caution {
-  .p-notification--caution {
-    @extend %vf-notification;
-    @include vf-highlight-bar($colors--theme--border-caution, left, true);
-    @include vf-icon-warning-themed;
-  }
-}
-
-// Negative notification styling
-@mixin vf-notifications-negative {
-  .p-notification--negative {
-    @extend %vf-notification;
-    @include vf-highlight-bar($colors--theme--border-negative, left, true);
-    @include vf-icon-error-themed;
-  }
-}
-
-// Information notification styling
-@mixin vf-notifications-information {
-  .p-notification--information {
-    @extend %vf-notification;
-    @include vf-highlight-bar($colors--theme--border-information, left, true);
-    @include vf-icon-info-coloured-themed;
-  }
+  // stylelint-enable max-nesting-depth
 }


### PR DESCRIPTION
Fixes #5546

Added a specific style rule for the close button inside borderless notifications to set its top position to 0. This resolves the misalignment issue where the close button was positioned incorrectly when the notification had no border and padding-top was 0.

## Done

[List of work items including drive-bys]

Fixes [list issues/bugs if needed]

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
