### PR TITLE
Move release permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.38.0.experimental.1",
+  "version": "4.38.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"


### PR DESCRIPTION
Reverts #5715

This is removing more debugging code from @bartaz and myself as we have been configuring the project to use OIDC trusted publishing so that maintainers don't need to manually refresh tokens.