### PR TITLE
fix: invert calendar and clock icons in dark mode

### DIFF
--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -233,5 +233,15 @@
       content: '* ';
     }
   }
+
+  // Calendar and clock icons in date/time inputs
+  [type='date']::-webkit-calendar-picker-indicator,
+  [type='time']::-webkit-calendar-picker-indicator {
+    filter: none;
+
+    .is-dark & {
+      filter: invert(1);
+    }
+  }
   // stylelint-enable selector-max-type
 }


### PR DESCRIPTION
## Summary

Fixes #5696

Calendar and clock icons in `type="date"` and `type="time"` inputs were barely visible in dark mode due to their default black color. This PR applies `filter: invert(1)` to these icons when inside `.is-dark` containers, making them white and clearly visible against dark backgrounds.

## Changes

- Added CSS rules targeting `::-webkit-calendar-picker-indicator` pseudo-elements
- Applied `filter: none` in light mode (default behavior)
- Applied `filter: invert(1)` in dark mode (inside `.is-dark` containers)
- Modified: `scss/_base_forms.scss`

## Implementation Details

This fix is based on the solution implemented in lxd-ui (PR #1620) and adapted to vanilla-framework's dark mode pattern using `.is-dark` class.

```scss
[type='date']::-webkit-calendar-picker-indicator,
[type='time']::-webkit-calendar-picker-indicator {
  filter: none;

  .is-dark & {
    filter: invert(1);
  }
}
```

## Testing

- ✅ Linting passed (stylelint, prettier)
- ✅ Build successful (SCSS compilation)
- ✅ Manual testing confirmed icons are visible in both light and dark modes
- ✅ All existing tests pass

## Expected Behavior

**Light Mode:** Calendar/clock icons remain black (default browser behavior)  
**Dark Mode:** Calendar/clock icons are inverted to white for visibility

## Screenshots

See original issue screenshots: https://github.com/canonical/vanilla-framework/issues/5696