### PR TITLE
docs(CI): Update Charmhub token expiration date

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
       VAULT_APPROLE_SECRET_ID: ${{ secrets.VAULT_APPROLE_SECRET_ID }}
       # See https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/commands/login/ to create a Charmhub token
       # Default TTL is 30 hours, the command below creates one that is valid for 6 months
-      # Current token was set 11 July 2025, needs update by 10 January 2026
+      # Current token was set 13 January 2026, needs update by 13 July 2026
       # Use `charmcraft login --ttl 15638400 --export path/to/save-token-file` to create the token file.
       # Then, copy its contents to the secret.
       CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}


### PR DESCRIPTION
Charmhub push actions have been [failing](https://github.com/canonical/vanilla-framework/actions/runs/20963235619/job/60247083167) due to expired charmhub token. This is used to push charms to charmhub as a prerequisite for docs site deployment to PS6. 

## Done

I have updated the charmhub token repo secret (see [passing deploy job](https://github.com/canonical/vanilla-framework/actions/runs/20964020376/job/60250208563)). This PR updates the documentation adjacent to the token's usage with the new token refresh date.