### PR TITLE
docs: add component class mixing guidelines

### DIFF
--- a/templates/docs/building-vanilla.md
+++ b/templates/docs/building-vanilla.md
@@ -498,3 +498,41 @@ Example HTML:
 ```html
 <script type="module" src="/static/js/modules/vanilla-framework/js/tabs.js"></script>
 ```
+
+## Component Class Mixing
+
+When using Vanilla, **component class names should not be mixed on the same element**. Each element should only have classes from one component, along with any applicable `is-<theme>` modifiers.
+
+### Recommended usage
+
+Wrap components in their own container elements:
+
+```html
+<!-- ✓ Recommended: Each component in its own container -->
+<div class="row--50-50">
+  <div class="col">
+    <div class="p-section">
+      <p>Content here</p>
+    </div>
+  </div>
+</div>
+```
+
+### Avoid
+
+Do not combine classes from different components on the same element:
+
+```html
+<!-- ✗ Avoid: Mixing col and p-section on the same element -->
+<div class="row--50-50">
+  <div class="col p-section">
+    <p>Content here</p>
+  </div>
+</div>
+```
+
+### Why this matters
+
+- **Predictable styling**: Each component's styles are designed to work independently. Mixing classes can lead to unexpected interactions.
+- **Maintainability**: When components are properly separated, updating or debugging styles becomes easier.
+- **Consistency**: Following this convention ensures your project looks and behaves consistently with other projects using Vanilla.


### PR DESCRIPTION
Closes #5413

This PR adds documentation explaining that component class names should not be mixed on the same element. 

## Changes
- Added a new "Component Class Mixing" section to the "Building with Vanilla" documentation
- Included recommended usage examples showing proper component nesting
- Provided rationale for why this convention matters (predictability, maintainability, consistency)

## Context
As noted in #5413, Vanilla has an unspoken style rule that component class names should not be mixed. This PR formalizes that convention in the documentation to help users avoid unexpected styling issues.