### PR TITLE
feat: add customizable padding to tiered lists

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -4,6 +4,10 @@
       url: /docs/base/tables#sortable-updated
       status: Updated
       notes: We've added the table sort button, which enables keyboard-accessible table sorting.
+    - component: Tiered list
+      url: /docs/patterns/tiered-list
+      status: Updated
+      notes: Added a new <code>padding</code> parameter to customize the bottom padding.
 - version: 4.40.0
   features:
     - component: Logo section

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -3,6 +3,7 @@
 #   desktop vs. 50/50 split between title/description
 # is_list_full_width_on_tablet: whether list title/description each have their
 #   own row on tablet vs. 50/50 split between title/description
+# padding: Type of padding to apply. Options are "deep", "shallow", "default". Default is "default".
 # Slots
 # title: top-level title element
 # description: top-level description element
@@ -10,6 +11,7 @@
 # list_item_description_[1-25]: description element of each child list item
 # cta: CTA block element
 {% macro vf_tiered_list(
+  padding="default",
   is_description_full_width_on_desktop=true,
   is_list_full_width_on_tablet=true) -%}
   {%- set title_content = caller('title') -%}
@@ -17,8 +19,17 @@
   {%- set has_description = description_content|trim|length > 0 -%}
   {%- set cta_content = caller('cta') -%}
   {%- set has_cta = cta_content|trim|length > 0 -%}
+  {%- set padding = padding | trim -%}
+  {%- if padding not in ["deep", "shallow", "default"] -%}
+    {%- set padding = "default" -%}
+  {%- endif -%}
+  {%- if padding == "default" -%}  
+    {%- set padding_classes = "p-section" -%}  
+  {%- else -%}  
+    {%- set padding_classes = "p-section--" + padding -%}  
+  {%- endif -%}
 
-  <div class="p-section u-fixed-width">
+  <div class="{{ padding_classes }} u-fixed-width">
     <hr class="p-rule">
     <div class="p-section--shallow">
       {% if has_description == true -%}

--- a/templates/docs/patterns/tiered-list/index.md
+++ b/templates/docs/patterns/tiered-list/index.md
@@ -155,6 +155,26 @@ The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. 
           Whether the list element should be full-width on tablet
         </td>
       </tr>
+      <tr>
+        <td>
+          <code>padding</code>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          One of:<br>
+          <code>'deep'</code>,<br>
+          <code>'shallow'</code>,<br>
+          <code>'default'</code>
+        </td>
+        <td>
+          <code>'default'</code>
+        </td>
+        <td>
+          Padding variant for the section
+        </td>
+      </tr>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
## Done

- Added `padding` param to tiered list

## QA

- Check out this [demo](https://cn-ubuntu-com-809.demos.haus/contact)
- Scroll to the bottom, and verify the tiered list works as expected with the given "deep" padding
- Review [release notes](https://vanilla-framework-5746.demos.haus/docs/whats-new)
- Review [docs](https://vanilla-framework-5746.demos.haus/docs/patterns/tiered-list#jinja-macro)

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Issue

Fixes [WD-33213](https://warthogs.atlassian.net/browse/WD-33213)

[WD-33213]: https://warthogs.atlassian.net/browse/WD-33213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ