### PR TITLE
fix(navigation): dropdown min-width and boundary checking (#5758)

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -683,13 +683,16 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
     background-color: $colors--theme--background-default;
     display: none;
     margin: 0;
-    min-width: 100%;
     padding: 0;
     z-index: 5;
 
     @media (min-width: $breakpoint-navigation-threshold) {
+      // min-width matches the parent nav item width so the dropdown is never narrower than its trigger
+      min-width: 100%;
+      // max-width prevents dropdowns from becoming excessively wide on large screens
+      max-width: $text-max-width;
       position: absolute;
-      // padding applied to .p-navigation__link + line-heigh of the anchor text inside
+      // padding applied to .p-navigation__link + line-height of the anchor text inside
       top: $spv--large * 2 + map-get($settings-text-default, line-height);
     }
 
@@ -700,6 +703,15 @@ $navigation-height: calc(map-get($settings-text-p, line-height) + 2 * $spv--larg
 
   .p-navigation__dropdown--right {
     right: 0;
+  }
+
+  // Boundary checking: when JS detects a dropdown would overflow the right edge of the viewport,
+  // it adds this class to flip the dropdown so it aligns to the right of its trigger instead
+  .p-navigation__dropdown.is-right-overflow {
+    @media (min-width: $breakpoint-navigation-threshold) {
+      left: auto;
+      right: 0;
+    }
   }
 
   .p-navigation__item--dropdown-toggle {

--- a/templates/docs/examples/patterns/navigation/_script.js
+++ b/templates/docs/examples/patterns/navigation/_script.js
@@ -1,3 +1,16 @@
+function applyBoundaryChecking(dropdown) {
+  // Reset any previous boundary adjustment before measuring
+  dropdown.classList.remove('is-right-overflow');
+
+  var dropdownRect = dropdown.getBoundingClientRect();
+  var viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+
+  // If the dropdown's right edge exceeds the viewport, flip it to align to the right
+  if (dropdownRect.right > viewportWidth) {
+    dropdown.classList.add('is-right-overflow');
+  }
+}
+
 function toggleDropdown(toggle, open) {
   var parentElement = toggle.parentNode;
   var dropdown = document.getElementById(toggle.getAttribute('aria-controls'));
@@ -5,8 +18,11 @@ function toggleDropdown(toggle, open) {
 
   if (open) {
     parentElement.classList.add('is-active');
+    // Run boundary check after the dropdown becomes visible so we can measure it
+    applyBoundaryChecking(dropdown);
   } else {
     parentElement.classList.remove('is-active');
+    dropdown.classList.remove('is-right-overflow');
   }
 }
 


### PR DESCRIPTION

Resolves #5758

- Move min-width: 100% into the desktop media query where position: absolute is set, ensuring the dropdown is never narrower than its trigger element
- Add max-width: $text-max-width (40em) to prevent dropdowns from becoming excessively wide on large screens
- Add .is-right-overflow CSS class for boundary checking support
- Add applyBoundaryChecking() JS function that detects when a dropdown would overflow the right edge of the viewport and flips it to right-aligned

  ### How to test
1. Click "Design practice" - dropdown should match the parent width, not shrink to fit "User research"
2. Click "Brand" - short parent with short children, dropdown should still match "Brand" width
3. Click "Open design" near the right side - dropdown should stay within the viewport (boundary checking)

 
 
<img width="2092" height="554" alt="Screenshot 2026-02-26 011339" src="https://github.com/user-attachments/assets/01f61820-0612-4efb-a79f-3bc41c98e79e" />

