### PR TITLE
docs: add proper example for code snippet multi-dropdown

### DIFF
--- a/templates/docs/examples/patterns/code-snippet/_dropdown-multiple.html
+++ b/templates/docs/examples/patterns/code-snippet/_dropdown-multiple.html
@@ -3,23 +3,23 @@
     <h5 class="p-code-snippet__title">Installing Thunderbird as a snap</h5>
 
     <div class="p-code-snippet__dropdowns">
-      <select class="p-code-snippet__dropdown" name="track-select-1" id="track-select-1">
+      <select class="p-code-snippet__dropdown" name="track-select-1" id="track-select-1" aria-label="Track">
         <option value="latest-track-1">latest</option>
         <option value="esr-track-1">esr</option>
         <option value="monthly-track-1">monthly</option>
       </select>
 
-      <select class="p-code-snippet__dropdown" name="latest-track-1" id="latest-track-1">
+      <select class="p-code-snippet__dropdown" name="latest-track-1" id="latest-track-1" aria-label="Channel">
         <option value="latest-stable-1">stable</option>
         <option value="latest-candidate-1">candidate</option>
       </select>
 
-      <select class="p-code-snippet__dropdown u-hide" name="esr-track-1" id="esr-track-1" aria-hidden="true">
+      <select class="p-code-snippet__dropdown u-hide" name="esr-track-1" id="esr-track-1" aria-hidden="true" aria-label="Channel">
         <option value="esr-stable-1">stable</option>
         <option value="esr-candidate-1">candidate</option>
       </select>
 
-      <select class="p-code-snippet__dropdown u-hide" name="monthly-track-1" id="monthly-track-1" aria-hidden="true">
+      <select class="p-code-snippet__dropdown u-hide" name="monthly-track-1" id="monthly-track-1" aria-hidden="true" aria-label="Channel">
         <option value="monthly-beta-1">beta</option>
         <option value="monthly-candidate-1">candidate</option>
       </select>
@@ -42,23 +42,23 @@
 <div class="p-code-snippet">
   <div class="p-code-snippet__header">
     <div class="p-code-snippet__dropdowns">
-      <select class="p-code-snippet__dropdown" name="track-select-2" id="track-select-2">
+      <select class="p-code-snippet__dropdown" name="track-select-2" id="track-select-2" aria-label="Track">
         <option value="latest-track-2">latest</option>
         <option value="esr-track-2">esr</option>
         <option value="monthly-track-2">monthly</option>
       </select>
 
-      <select class="p-code-snippet__dropdown" name="latest-track-2" id="latest-track-2">
+      <select class="p-code-snippet__dropdown" name="latest-track-2" id="latest-track-2" aria-label="Channel">
         <option value="latest-stable-2">stable</option>
         <option value="latest-candidate-2">candidate</option>
       </select>
 
-      <select class="p-code-snippet__dropdown u-hide" name="esr-track-2" id="esr-track-2" aria-hidden="true">
+      <select class="p-code-snippet__dropdown u-hide" name="esr-track-2" id="esr-track-2" aria-hidden="true" aria-label="Channel">
         <option value="esr-stable-2">stable</option>
         <option value="esr-candidate-2">candidate</option>
       </select>
 
-      <select class="p-code-snippet__dropdown u-hide" name="monthly-track-2" id="monthly-track-2" aria-hidden="true">
+      <select class="p-code-snippet__dropdown u-hide" name="monthly-track-2" id="monthly-track-2" aria-hidden="true" aria-label="Channel">
         <option value="monthly-beta-2">beta</option>
         <option value="monthly-candidate-2">candidate</option>
       </select>
@@ -83,18 +83,18 @@
     <h5 class="p-code-snippet__title">Installing Thunderbird as a snap on different tracks via the command line</h5>
 
     <div class="p-code-snippet__dropdowns">
-      <select class="p-code-snippet__dropdown" name="track-select-3" id="track-select-3">
+      <select class="p-code-snippet__dropdown" name="track-select-3" id="track-select-3" aria-label="Track">
         <option value="latest-track-3">latest</option>
         <option value="esr-track-3">esr</option>
       </select>
 
-      <select class="p-code-snippet__dropdown" name="latest-track-3" id="latest-track-3">
+      <select class="p-code-snippet__dropdown" name="latest-track-3" id="latest-track-3" aria-label="Channel">
         <option value="latest-stable-3">stable</option>
         <option value="latest-beta-3">beta</option>
         <option value="latest-candidate-3">candidate</option>
       </select>
 
-      <select class="p-code-snippet__dropdown u-hide" name="esr-track-3" id="esr-track-3" aria-hidden="true">
+      <select class="p-code-snippet__dropdown u-hide" name="esr-track-3" id="esr-track-3" aria-hidden="true" aria-label="Channel">
         <option value="esr-edge-3">edge</option>
       </select>
     </div>

--- a/templates/docs/examples/patterns/code-snippet/_dropdown-multiple.html
+++ b/templates/docs/examples/patterns/code-snippet/_dropdown-multiple.html
@@ -3,72 +3,110 @@
     <h5 class="p-code-snippet__title">Installing Thunderbird as a snap</h5>
 
     <div class="p-code-snippet__dropdowns">
-      <select class="p-code-snippet__dropdown" name="menu1-select" id="menu1-select">
-        <option value="">amd64</option>
-        <option value="">i386</option>
+      <select class="p-code-snippet__dropdown" name="track-select-1" id="track-select-1">
+        <option value="latest-track-1">latest</option>
+        <option value="esr-track-1">esr</option>
+        <option value="monthly-track-1">monthly</option>
       </select>
 
-      <select class="p-code-snippet__dropdown" name="menu2-select" id="menu2-select">
-        <option value="stable-panel">stable</option>
-        <option value="beta-panel">beta</option>
-        <option value="edge-panel">edge</option>
+      <select class="p-code-snippet__dropdown" name="latest-track-1" id="latest-track-1">
+        <option value="latest-stable-1">stable</option>
+        <option value="latest-candidate-1">candidate</option>
+      </select>
+
+      <select class="p-code-snippet__dropdown u-hide" name="esr-track-1" id="esr-track-1" aria-hidden="true">
+        <option value="esr-stable-1">stable</option>
+        <option value="esr-candidate-1">candidate</option>
+      </select>
+
+      <select class="p-code-snippet__dropdown u-hide" name="monthly-track-1" id="monthly-track-1" aria-hidden="true">
+        <option value="monthly-beta-1">beta</option>
+        <option value="monthly-candidate-1">candidate</option>
       </select>
     </div>
   </div>
 
-  <pre id="stable-panel" class="p-code-snippet__block--icon"><code>sudo snap install thunderbird</code></pre>
+  <pre id="latest-stable-1" class="p-code-snippet__block--icon"><code>sudo snap install thunderbird --channel=latest/stable</code></pre>
 
-  <pre id="beta-panel" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --beta</code></pre>
+  <pre id="latest-candidate-1" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --channel=latest/candidate</code></pre>
 
-  <pre id="edge-panel" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --edge</code></pre>
+  <pre id="esr-stable-1" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --channel=esr/stable</code></pre>
+
+  <pre id="esr-candidate-1" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --channel=esr/candidate</code></pre>
+
+  <pre id="monthly-beta-1" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --channel=monthly/beta</code></pre>
+
+  <pre id="monthly-candidate-1" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --channel=monthly/candidate</code></pre>
 </div>
 
 <div class="p-code-snippet">
   <div class="p-code-snippet__header">
     <div class="p-code-snippet__dropdowns">
-      <select class="p-code-snippet__dropdown" name="menu1-select" id="menu1-select">
-        <option value="">amd64</option>
-        <option value="">i386</option>
+      <select class="p-code-snippet__dropdown" name="track-select-2" id="track-select-2">
+        <option value="latest-track-2">latest</option>
+        <option value="esr-track-2">esr</option>
+        <option value="monthly-track-2">monthly</option>
       </select>
 
-      <select class="p-code-snippet__dropdown" name="menu2-select" id="menu2-select">
-        <option value="headerless-stable-panel">stable</option>
-        <option value="headerless-beta-panel">beta</option>
-        <option value="headerless-edge-panel">edge</option>
+      <select class="p-code-snippet__dropdown" name="latest-track-2" id="latest-track-2">
+        <option value="latest-stable-2">stable</option>
+        <option value="latest-candidate-2">candidate</option>
+      </select>
+
+      <select class="p-code-snippet__dropdown u-hide" name="esr-track-2" id="esr-track-2" aria-hidden="true">
+        <option value="esr-stable-2">stable</option>
+        <option value="esr-candidate-2">candidate</option>
+      </select>
+
+      <select class="p-code-snippet__dropdown u-hide" name="monthly-track-2" id="monthly-track-2" aria-hidden="true">
+        <option value="monthly-beta-2">beta</option>
+        <option value="monthly-candidate-2">candidate</option>
       </select>
     </div>
   </div>
 
-  <pre id="headerless-stable-panel" class="p-code-snippet__block--icon"><code>sudo snap install thunderbird</code></pre>
+  <pre id="latest-stable-2" class="p-code-snippet__block--icon"><code>sudo snap install thunderbird --channel=latest/stable</code></pre>
 
-  <pre id="headerless-beta-panel" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --beta</code></pre>
+  <pre id="latest-candidate-2" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --channel=latest/candidate</code></pre>
 
-  <pre id="headerless-edge-panel" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --edge</code></pre>
+  <pre id="esr-stable-2" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --channel=esr/stable</code></pre>
+
+  <pre id="esr-candidate-2" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --channel=esr/candidate</code></pre>
+
+  <pre id="monthly-beta-2" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --channel=monthly/beta</code></pre>
+
+  <pre id="monthly-candidate-2" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --channel=monthly/candidate</code></pre>
 </div>
 
 <div class="p-code-snippet">
   <div class="p-code-snippet__header is-stacked">
-    <h5 class="p-code-snippet__title">Installing Thunderbird as a snap on different architectures via the command line</h5>
+    <h5 class="p-code-snippet__title">Installing Thunderbird as a snap on different tracks via the command line</h5>
 
     <div class="p-code-snippet__dropdowns">
-      <select class="p-code-snippet__dropdown" name="menu3-select" id="menu3-select">
-        <option value="">amd64</option>
-        <option value="">i386</option>
+      <select class="p-code-snippet__dropdown" name="track-select-3" id="track-select-3">
+        <option value="latest-track-3">latest</option>
+        <option value="esr-track-3">esr</option>
       </select>
 
-      <select class="p-code-snippet__dropdown" name="menu4-select" id="menu4-select">
-        <option value="stacked-stable-panel">stable</option>
-        <option value="stacked-beta-panel">beta</option>
-        <option value="stacked-edge-panel">edge</option>
+      <select class="p-code-snippet__dropdown" name="latest-track-3" id="latest-track-3">
+        <option value="latest-stable-3">stable</option>
+        <option value="latest-beta-3">beta</option>
+        <option value="latest-candidate-3">candidate</option>
+      </select>
+
+      <select class="p-code-snippet__dropdown u-hide" name="esr-track-3" id="esr-track-3" aria-hidden="true">
+        <option value="esr-edge-3">edge</option>
       </select>
     </div>
   </div>
 
-  <pre id="stacked-stable-panel" class="p-code-snippet__block--icon"><code>sudo snap install thunderbird</code></pre>
+  <pre id="latest-stable-3" class="p-code-snippet__block--icon"><code>sudo snap install thunderbird --channel=latest/stable</code></pre>
 
-  <pre id="stacked-beta-panel" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --beta</code></pre>
+  <pre id="latest-candidate-3" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --channel=latest/candidate</code></pre>
 
-  <pre id="stacked-edge-panel" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --edge</code></pre>
+  <pre id="latest-beta-3" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --channel=latest/beta</code></pre>
+
+  <pre id="esr-edge-3" class="p-code-snippet__block--icon u-hide" aria-hidden="true"><code>sudo snap install thunderbird --channel=esr/edge</code></pre>
 </div>
 
 <script>

--- a/templates/docs/examples/patterns/code-snippet/_script.js
+++ b/templates/docs/examples/patterns/code-snippet/_script.js
@@ -7,7 +7,37 @@ function attachDropdownEvents(dropdown) {
     var targetElement = document.getElementById(e.target.value);
 
     if (targetElement) {
-      toggleElement(targetElement, dropdown.options);
+      // Check if target is another dropdown (cascading dropdowns)
+      if (targetElement.tagName === 'SELECT') {
+        // Find the container with all dropdowns
+        var container = dropdown.closest('.p-code-snippet__dropdowns');
+
+        // Hide all panels from all code snippet dropdowns in this group
+        var allChannelDropdowns = container.querySelectorAll('.p-code-snippet__dropdown');
+        allChannelDropdowns.forEach(function (channelDropdown) {
+          for (var i = 0; i < channelDropdown.options.length; i++) {
+            var panel = document.getElementById(channelDropdown.options[i].value);
+            if (panel && panel.tagName !== 'SELECT') {
+              panel.classList.add('u-hide');
+              panel.setAttribute('aria-hidden', true);
+            }
+          }
+        });
+
+        // Toggle between channel dropdowns
+        toggleElement(targetElement, dropdown.options);
+
+        // Show the panel for the newly visible dropdown's selected option
+        var panelId = targetElement.value;
+        var panelElement = document.getElementById(panelId);
+        if (panelElement && panelElement.tagName !== 'SELECT') {
+          panelElement.classList.remove('u-hide');
+          panelElement.setAttribute('aria-hidden', false);
+        }
+      } else {
+        // Target is a code panel
+        toggleElement(targetElement, dropdown.options);
+      }
     }
   });
 }
@@ -21,8 +51,10 @@ function attachDropdownEvents(dropdown) {
 function toggleElement(targetElement, options) {
   for (var i = 0; i < options.length; i++) {
     var element = document.getElementById(options[i].value);
-    element.classList.add('u-hide');
-    element.setAttribute('aria-hidden', true);
+    if (element) {
+      element.classList.add('u-hide');
+      element.setAttribute('aria-hidden', true);
+    }
   }
 
   targetElement.classList.remove('u-hide');


### PR DESCRIPTION
## Done

- Added a working example for multi-dropdown code snippet

Fixes https://github.com/canonical/vanilla-framework/issues/5761

## QA

- Open [demo](https://vanilla-framework-5762.demos.haus/)
- Review updated documentation:
  - Verify that the examples for code snippet with multiple dropdowns work.

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

<img width="1332" height="349" alt="Screenshot 2026-02-26 at 11 16 15 PM" src="https://github.com/user-attachments/assets/acf6a8cf-813e-472e-b767-fce69767359e" />


