### PR TITLE
fix(accordion): indent wrapped text past chevron icon (#4562)

### DIFF
--- a/scss/_patterns_accordion.scss
+++ b/scss/_patterns_accordion.scss
@@ -25,6 +25,8 @@
     font-size: inherit;
     justify-content: flex-start;
     margin-bottom: 0;
+    // padding-left creates consistent indentation for ALL lines of wrapped text
+    padding-left: $icon-size + $sph--large;
     padding-right: $sph--large;
     position: relative;
     text-align: left;
@@ -37,7 +39,9 @@
       @include vf-transition($property: transform, $duration: fast);
 
       content: '';
-      margin-right: $sph--large;
+      // position the chevron absolutely in the padding area so it doesn't push text inline
+      left: 0;
+      position: absolute;
     }
 
     // aria-selected controls the open and closed state for the accordion tab


### PR DESCRIPTION
- Add padding-left to .p-accordion__tab so all lines of text are consistently indented past the chevron icon area
- Position the ::before chevron absolutely (left: 0) instead of using margin-right, which only indented the first line of text

Resolves #4562
 

## Screenshots
 
<img width="839" height="807" alt="image" src="https://github.com/user-attachments/assets/4d538c33-fbf4-4884-bd02-b7e004eae340" />
