### PR TITLE
fix a11y bug of aria-expanded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.46.0",
+  "version": "4.47.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.47.0
+  features:
+    - component: Search and filter bar
+      url: /docs/patterns/search-and-filter
+      status: Updated
+      notes: Changed the <code>aria-expanded</code>> attribute to <code>data-expanded</code> to comply with a11y standards. This change may require updates to any custom JavaScript that interacts with the search and filter bar's expanded state.
 - version: 4.46.0
   features:
     - component: CTA section

--- a/scss/_patterns_search-and-filter.scss
+++ b/scss/_patterns_search-and-filter.scss
@@ -42,7 +42,7 @@
       }
 
       &[data-empty='false'],
-      &[aria-expanded='false'] {
+      &[data-expanded='false'] {
         height: $input-height;
       }
 
@@ -59,7 +59,7 @@
         top: 0.3rem;
       }
 
-      &[aria-expanded='true'] {
+      &[data-expanded='true'] {
         height: auto;
         max-height: 100%;
 

--- a/templates/docs/examples/patterns/search-and-filter/_default-script.js
+++ b/templates/docs/examples/patterns/search-and-filter/_default-script.js
@@ -9,10 +9,10 @@ function togglePanel(container, panel, collapse) {
   if (panel && container) {
     if (collapse) {
       panel.setAttribute('aria-hidden', 'true');
-      container.setAttribute('aria-expanded', 'false');
+      container.setAttribute('data-expanded', 'false');
     } else {
       panel.setAttribute('aria-hidden', 'false');
-      container.setAttribute('aria-expanded', 'true');
+      container.setAttribute('data-expanded', 'true');
     }
   }
 }

--- a/templates/docs/examples/patterns/search-and-filter/_overflow-script.js
+++ b/templates/docs/examples/patterns/search-and-filter/_overflow-script.js
@@ -7,6 +7,6 @@
   overflowCount.addEventListener('click', function (event) {
     searchBox.dataset.overflowing = 'true';
     panel.setAttribute('aria-hidden', 'false');
-    container.setAttribute('aria-expanded', 'true');
+    container.setAttribute('data-expanded', 'true');
   });
 });

--- a/templates/docs/examples/patterns/search-and-filter/_search-prompt-script.js
+++ b/templates/docs/examples/patterns/search-and-filter/_search-prompt-script.js
@@ -51,12 +51,12 @@ function createChip(value) {
     input.addEventListener('blur', function (event) {
       var targetPanel = searchAndFilterComponent.querySelector('.p-search-and-filter__panel');
       targetPanel.setAttribute('aria-hidden', 'true');
-      container.setAttribute('aria-expanded', 'false');
+      container.setAttribute('data-expanded', 'false');
     });
 
     input.addEventListener('focus', function (event) {
       var targetPanel = searchAndFilterComponent.querySelector('.p-search-and-filter__panel');
       targetPanel.setAttribute('aria-hidden', 'false');
-      container.setAttribute('aria-expanded', 'true');
+      container.setAttribute('data-expanded', 'true');
     });
   });

--- a/templates/docs/examples/patterns/search-and-filter/chip-overflow.html
+++ b/templates/docs/examples/patterns/search-and-filter/chip-overflow.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="p-search-and-filter">
-  <div class="p-search-and-filter__search-container" aria-expanded="false" data-active="true" data-empty="false">
+  <div class="p-search-and-filter__search-container" data-expanded="false" data-active="true" data-empty="false">
     <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
       <button class="p-chip__dismiss">Dismiss</button>

--- a/templates/docs/examples/patterns/search-and-filter/default.html
+++ b/templates/docs/examples/patterns/search-and-filter/default.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="p-search-and-filter">
-  <div class="p-search-and-filter__search-container" aria-expanded="false" data-active="true" data-empty="true">
+  <div class="p-search-and-filter__search-container" data-expanded="false" data-active="true" data-empty="true">
     <form class="p-search-and-filter__box" data-overflowing="false">
       <label class="u-off-screen" for="search">Search and filter</label>
       <input autocomplete="off" class="p-search-and-filter__input" id="search" name="search" placeholder="Search and filter" type="search" value="">

--- a/templates/docs/examples/patterns/search-and-filter/expanded.html
+++ b/templates/docs/examples/patterns/search-and-filter/expanded.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="p-search-and-filter">
-  <div class="p-search-and-filter__search-container" aria-expanded="true" data-active="true" data-empty="true">
+  <div class="p-search-and-filter__search-container" data-expanded="true" data-active="true" data-empty="true">
     <form class="p-search-and-filter__box" data-overflowing="false">
       <label class="u-off-screen" for="search">Search and filter</label>
       <input autocomplete="off" class="p-search-and-filter__input" id="search" name="search" placeholder="Search and filter" type="search" value="">

--- a/templates/docs/examples/patterns/search-and-filter/with-chips.html
+++ b/templates/docs/examples/patterns/search-and-filter/with-chips.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="p-search-and-filter">
-  <div class="p-search-and-filter__search-container" aria-expanded="false" data-active="true" data-empty="false">
+  <div class="p-search-and-filter__search-container" data-expanded="false" data-active="true" data-empty="false">
     <span class="p-chip">
       <span class="p-chip__lead">CLOUD</span><span class="p-chip__value">Google</span>
       <button class="p-chip__dismiss">Dismiss</button>

--- a/templates/docs/examples/patterns/search-and-filter/with-search-prompt.html
+++ b/templates/docs/examples/patterns/search-and-filter/with-search-prompt.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="p-search-and-filter">
   <button class="p-search-and-filter__clear"><i class="p-icon--close"></i></button>
-  <div class="p-search-and-filter__search-container" aria-expanded="false" data-active="true" data-empty="false">
+  <div class="p-search-and-filter__search-container" data-expanded="false" data-active="true" data-empty="false">
     <form class="p-search-and-filter__box" data-overflowing="false">
       <label class="u-off-screen" for="search">Search and filter</label>
       <input autocomplete="off" class="p-search-and-filter__input" id="search" name="search" placeholder="Search and filter" type="search" value="vanilla">


### PR DESCRIPTION
## Done

- Changed the aria-expanded attribute used in searchAndFilter components to data-expanded
- This is because aria-expanded was wrongly used for historical reasons
- It should have been used on the button that triggers the opening of the search bar, not on the search bar itself.

This is **closely related to [this](https://github.com/canonical/react-components/pull/1330) ** PR.

## QA

- Open [demo](insert-demo-url)
- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

This is the dummy app I used in testing:
```
{% extends "_layouts/examples.html" %}
{% block title %}Sandbox / Search and filter chip overflow{% endblock %}

{% block standalone_css %}patterns_search-and-filter{% endblock %}

{% block content %}
<div style="max-width: 760px; padding: 24px;">
  <h2 style="margin-top: 0;">Search bar with preselected chips</h2>
  <p class="u-text--muted">Click <code>+N</code> to expand and reveal all selected chips.</p>

  <div class="p-search-and-filter" id="search-filter-demo">
    <div class="p-search-and-filter__search-container" data-expanded="false" data-active="true" data-empty="false">
	  <span class="p-chip"><span class="p-chip__lead">OWNER</span><span class="p-chip__value">me</span><button class="p-chip__dismiss" type="button">Dismiss</button></span>
	  <span class="p-chip"><span class="p-chip__lead">STATUS</span><span class="p-chip__value">open</span><button class="p-chip__dismiss" type="button">Dismiss</button></span>
	  <span class="p-chip"><span class="p-chip__lead">TAG</span><span class="p-chip__value">frontend</span><button class="p-chip__dismiss" type="button">Dismiss</button></span>
	  <span class="p-chip"><span class="p-chip__lead">TAG</span><span class="p-chip__value">ui</span><button class="p-chip__dismiss" type="button">Dismiss</button></span>
	  <span class="p-chip"><span class="p-chip__lead">TAG</span><span class="p-chip__value">accessibility</span><button class="p-chip__dismiss" type="button">Dismiss</button></span>
	  <span class="p-chip"><span class="p-chip__lead">PRIORITY</span><span class="p-chip__value">high</span><button class="p-chip__dismiss" type="button">Dismiss</button></span>
	  <span class="p-chip"><span class="p-chip__lead">ENV</span><span class="p-chip__value">prod</span><button class="p-chip__dismiss" type="button">Dismiss</button></span>
	  <span class="p-chip"><span class="p-chip__lead">REGION</span><span class="p-chip__value">eu</span><button class="p-chip__dismiss" type="button">Dismiss</button></span>
	  <span class="p-chip"><span class="p-chip__lead">TYPE</span><span class="p-chip__value">bug</span><button class="p-chip__dismiss" type="button">Dismiss</button></span>
	  <span class="p-chip"><span class="p-chip__lead">TEAM</span><span class="p-chip__value">design-systems</span><button class="p-chip__dismiss" type="button">Dismiss</button></span>
	  <span class="p-chip"><span class="p-chip__lead">COMPONENT</span><span class="p-chip__value">search</span><button class="p-chip__dismiss" type="button">Dismiss</button></span>
	  <span class="p-chip"><span class="p-chip__lead">COMPONENT</span><span class="p-chip__value">filter</span><button class="p-chip__dismiss" type="button">Dismiss</button></span>

	  <span class="p-search-and-filter__selected-count" role="button" tabindex="0">+6</span>

	  <form class="p-search-and-filter__box" data-overflowing="false">
		<label class="u-off-screen" for="search-demo">Search and filter</label>
		<input autocomplete="off" class="p-search-and-filter__input" id="search-demo" name="search" placeholder="Search and filter" type="search" value="">
		<button alt="search" class="p-search-and-filter__search-button" type="submit">Search</button>
	  </form>
	</div>
	<div class="p-search-and-filter__panel" aria-hidden="true"></div>
  </div>
</div>

<script>
  (function () {
	var pattern = document.getElementById("search-filter-demo");
	var selectedCount = pattern.querySelector(".p-search-and-filter__selected-count");
	var searchContainer = pattern.querySelector(".p-search-and-filter__search-container");
	var searchBox = pattern.querySelector(".p-search-and-filter__box");
	var panel = pattern.querySelector(".p-search-and-filter__panel");

	function expandSelectedChips() {
	  searchContainer.dataset.expanded = "true";
	  searchBox.dataset.overflowing = "true";
	  panel.setAttribute("aria-hidden", "false");
	}

	selectedCount.addEventListener("click", expandSelectedChips);
	selectedCount.addEventListener("keydown", function (event) {
	  if (event.key === "Enter" || event.key === " ") {
		event.preventDefault();
		expandSelectedChips();
	  }
	});
  })();
</script>
{% endblock %}


```

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


