### PR TITLE
fix: restrict textarea resize to vertical and enable auto-grow

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -11,7 +11,7 @@
     - component: Multi-line text field
       url: /docs/base/forms#multi-line-text-field
       status: Updated
-      notes: Textarea now auto-grows in height as the user types and is restricted to vertical resizing only.
+      notes: Textarea now auto-grows in height as the user types and is restricted to vertical resizing only. Default min and max height can be customised via $textarea-min-height and $textarea-max-height variables.
 - version: 4.46.0
   features:
     - component: CTA section

--- a/releases.yml
+++ b/releases.yml
@@ -8,6 +8,10 @@
       url: /docs/patterns/icons
       status: New
       notes: Added icon for circle of friends.
+    - component: Multi-line text field
+      url: /docs/base/forms#multi-line-text-field
+      status: Updated
+      notes: Textarea now auto-grows in height as the user types and is restricted to vertical resizing only.
 - version: 4.46.0
   features:
     - component: CTA section

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -215,7 +215,9 @@
 
     field-sizing: content;
     margin-bottom: $input-margin-bottom;
-    overflow: hidden;
+    max-height: $textarea-max-height;
+    min-height: $textarea-min-height;
+    overflow: auto;
     resize: vertical;
     vertical-align: top;
   }

--- a/scss/_base_forms.scss
+++ b/scss/_base_forms.scss
@@ -213,8 +213,10 @@
   textarea {
     @extend %vf-input-elements;
 
+    field-sizing: content;
     margin-bottom: $input-margin-bottom;
-    overflow: auto;
+    overflow: hidden;
+    resize: vertical;
     vertical-align: top;
   }
 

--- a/scss/_settings_spacing.scss
+++ b/scss/_settings_spacing.scss
@@ -370,6 +370,10 @@ $input-margin-bottom: $sp-unit * 4 - $spv-nudge * 2;
 $input-border-thickness: 1.5px;
 $input-vertical-padding: calc($spv-nudge - $input-border-thickness);
 
+// textarea variables
+$textarea-min-height: calc(map-get($settings-text-default, line-height) * 3) !default;
+$textarea-max-height: none !default;
+
 // tick element variables
 $form-tick-box-size: 1rem;
 $form-tick-height: 0.375rem;

--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -22,9 +22,9 @@ View example of a single-line text field
 
 Vanilla also styles HTML’s other single-line field types: `password`, `datetime`, `datetime-local`, `date`, `month`, `time`, `week`, `number`, `email`, `url`, `search` and `tel`. For the `search` type, see <a href="../patterns/search-box">Search box</a>.
 
-## Multi-line text field
+## Multi-line text field {{ status('updated') }}
 
-`<textarea>` is a multi-line text field.
+`<textarea>` is a multi-line text field. The textarea grows automatically in height as the user types. Horizontal resizing is disabled; the user can only resize the textarea vertically. The `rows` attribute sets the minimum height of the textarea.
 
 <div class="embedded-example"><a href="/docs/examples/base/forms/textarea/" class="js-example">
 View example of a textarea

--- a/templates/docs/base/forms.md
+++ b/templates/docs/base/forms.md
@@ -24,7 +24,7 @@ Vanilla also styles HTML’s other single-line field types: `password`, `datetim
 
 ## Multi-line text field {{ status('updated') }}
 
-`<textarea>` is a multi-line text field. The textarea grows automatically in height as the user types. Horizontal resizing is disabled; the user can only resize the textarea vertically. The `rows` attribute sets the minimum height of the textarea.
+`<textarea>` is a multi-line text field. The textarea grows automatically in height as the user types. Horizontal resizing is disabled; the user can only resize the textarea vertically.
 
 <div class="embedded-example"><a href="/docs/examples/base/forms/textarea/" class="js-example">
 View example of a textarea


### PR DESCRIPTION
## Done
* Restricted textarea resize to vertical only (`resize: vertical`)
* Enabled auto-grow in height as the user types (`field-sizing: content`)
* Added configurable `$textarea-min-height` (defaults to 3 lines) and `$textarea-max-height` (defaults to `none`) variables in `_settings_spacing.scss` with `!default` flag for user override
* Updated docs heading with `{{ status('updated') }}` label
* Added entry to `releases.yml`
* `field-sizing: content` has ~80% global browser support as of March 2026 ([[caniuse](https://caniuse.com/mdn-css_properties_field-sizing)]). Unsupported browsers fall back gracefully, the textarea remains functional with fixed sizing and vertical-only resize still applies.

## QA
* Verify textarea only resizes vertically, the horizontal drag handle should be gone
* Verify textarea grows in height automatically as text is typed
* Verify textarea starts at a 3-row minimum height
* Tested locally using `dotrun` on WSL with the docs site at `localhost:8101`

## Screenshots

### Resizing:
#### Before:
<img width="1918" height="298" alt="Resizing_before" src="https://github.com/user-attachments/assets/46ba888a-d2e7-4602-8e86-89519e6f5e99" />

#### After:
<img width="1919" height="336" alt="Resizing_after" src="https://github.com/user-attachments/assets/757c7688-2504-49ce-9b55-31ba83286473" />

### Auto-grow:
#### Before:
<img width="1919" height="304" alt="Auto-grow_before" src="https://github.com/user-attachments/assets/d0a4fa97-8428-4e0a-bb8b-4580388a5217" />

#### After:
<img width="1919" height="410" alt="Auto-grow_after" src="https://github.com/user-attachments/assets/951e9da5-1f7c-44e9-99ef-707282a9e4a9" />


---

Fixes #5713