### PR TITLE
docs: fix typo 'planing' to 'planning' in building-vanilla

### DIFF
--- a/templates/docs/building-vanilla.md
+++ b/templates/docs/building-vanilla.md
@@ -417,7 +417,7 @@ For more options on configuring `gulp-sass`, for example minification and autopr
 
 ## Git submodules
 
-Creating a submodule in the git repo does not add all the code to the project but includes a reference and path to include the framework. You may find this method useful if you're planing to host on Github Pages.
+Creating a submodule in the git repo does not add all the code to the project but includes a reference and path to include the framework. You may find this method useful if you're planning to host on Github Pages.
 
 Run this command at the root of your project (replacing vX.X.X with the [release](https://github.com/canonical/vanilla-framework/releases) you wish to use)
 


### PR DESCRIPTION
## Done

- Fixed typo: 'planing' -> 'planning' in the building-vanilla docs (Git submodules section)

Fixes N/A

## QA

- Open https://vanillaframework.io/docs/building-vanilla
- Confirm the word 'planning' is correctly spelled in the Git submodule section

### Check if PR is ready for release

N/A, documentation text fix only, no SCSS or macro code changes. This PR should be labelled 'Documentation 📝'.


## Screenshots

N/A