### PR TITLE
chore: updated patterns docs

### DIFF
--- a/templates/docs/patterns/blog/index.md
+++ b/templates/docs/patterns/blog/index.md
@@ -125,6 +125,10 @@ Each article can specify its own cover image. If no image is provided, a [fallba
 View example of the blog pattern with custom image
 </a></div>
 
+## Article Block
+
+Each blog unit (cover image, title, description, and citation metadata) is built using the <a href="https://github.com/canonical/vanilla-framework/blob/main/templates/_macros/shared/vf_article_block.jinja">article block</a>. This allows it to be easily looped over and reused in different contexts.
+
 ## Jinja Macro
 
 The `vf_blog` Jinja macro can be used to generate a blog pattern. The API for the macro is shown below.
@@ -430,7 +434,7 @@ Each article in the `articles` array accepts the following configuration:
       </tr>
       <tr>
         <td>
-          <code>citation</code>
+          <code>metadata</code>
         </td>
         <td>
           No
@@ -439,12 +443,12 @@ Each article in the `articles` array accepts the following configuration:
           <code>object</code>
         </td>
         <td>
-          Citation configuration for the article
+          Citation metadata configuration for the article
         </td>
       </tr>
       <tr>
         <td>
-          <code>citation.authors</code>
+          <code>metadata.authors</code>
         </td>
         <td>
           No
@@ -458,7 +462,7 @@ Each article in the `articles` array accepts the following configuration:
       </tr>
       <tr>
         <td>
-          <code>citation.authors[].text</code>
+          <code>metadata.authors[].text</code>
         </td>
         <td>
           Yes
@@ -472,7 +476,7 @@ Each article in the `articles` array accepts the following configuration:
       </tr>
       <tr>
         <td>
-          <code>citation.authors[].link_attrs</code>
+          <code>metadata.authors[].link_attrs</code>
         </td>
         <td>
           No
@@ -486,7 +490,7 @@ Each article in the `articles` array accepts the following configuration:
       </tr>
       <tr>
         <td>
-          <code>citation.date</code>
+          <code>metadata.date</code>
         </td>
         <td>
           No
@@ -500,7 +504,7 @@ Each article in the `articles` array accepts the following configuration:
       </tr>
       <tr>
         <td>
-          <code>citation.date.text</code>
+          <code>metadata.date.text</code>
         </td>
         <td>
           Yes
@@ -514,7 +518,7 @@ Each article in the `articles` array accepts the following configuration:
       </tr>
       <tr>
         <td>
-          <code>citation.date.attrs</code>
+          <code>metadata.date.attrs</code>
         </td>
         <td>
           No

--- a/templates/docs/patterns/resources/index.md
+++ b/templates/docs/patterns/resources/index.md
@@ -97,6 +97,10 @@ You can pass also multiple, comma separated authors
 View example of the resources pattern with multiple authors
 </a></div>
 
+## Article Block
+
+Each resource unit (cover image/logo, title, description, and citation metadata) is built using the <a href="https://github.com/canonical/vanilla-framework/blob/main/templates/_macros/shared/vf_article_block.jinja">article block</a>. This allows it to be easily looped over and reused in different contexts.
+
 ## Jinja Macro
 
 The `vf_resources` Jinja macro can be used to generate a resources pattern. The API for the macro is shown below.
@@ -470,7 +474,7 @@ The Resources block allows you to specify categories and resource items to appea
       </tr>
       <tr>
         <td>
-          <code>categories[].items[].citation</code>
+          <code>categories[].items[].metadata</code>
         </td>
         <td>
           No
@@ -479,12 +483,12 @@ The Resources block allows you to specify categories and resource items to appea
           <code>object</code>
         </td>
         <td>
-          Citation configuration for the article
+          Citation metadata configuration for the article
         </td>
       </tr>
       <tr>
         <td>
-          <code>categories[].items[].citation.authors</code>
+          <code>categories[].items[].metadata.authors</code>
         </td>
         <td>
           No
@@ -498,7 +502,7 @@ The Resources block allows you to specify categories and resource items to appea
       </tr>
       <tr>
         <td>
-          <code>categories[].items[].citation.authors[].text</code>
+          <code>categories[].items[].metadata.authors[].text</code>
         </td>
         <td>
           Yes
@@ -512,7 +516,7 @@ The Resources block allows you to specify categories and resource items to appea
       </tr>
       <tr>
         <td>
-          <code>categories[].items[].citation.authors[].link</code>
+          <code>categories[].items[].metadata.authors[].link</code>
         </td>
         <td>
           No
@@ -526,7 +530,7 @@ The Resources block allows you to specify categories and resource items to appea
       </tr>
       <tr>
         <td>
-          <code>categories[].items[].citation.date</code>
+          <code>categories[].items[].metadata.date</code>
         </td>
         <td>
           No
@@ -540,7 +544,7 @@ The Resources block allows you to specify categories and resource items to appea
       </tr>
       <tr>
         <td>
-          <code>categories[].items[].citation.date.text</code>
+          <code>categories[].items[].metadata.date.text</code>
         </td>
         <td>
           Yes
@@ -554,7 +558,7 @@ The Resources block allows you to specify categories and resource items to appea
       </tr>
       <tr>
         <td>
-          <code>categories[].items[].citation.date.attrs</code>
+          <code>categories[].items[].metadata.date.attrs</code>
         </td>
         <td>
           No


### PR DESCRIPTION
## Done

- Updated documentation for blogs and resources patterns

Fixes [WD-36125](https://warthogs.atlassian.net/browse/WD-36125) [WD-35345](https://warthogs.atlassian.net/browse/WD-35345)

## QA

- Checkout this pull request
- Run the project using `dotrun`
- Check docs for [blogs](http://localhost:8010/docs/patterns/blogs) and [resources](http://localhost:8010/docs/patterns/resources)
- Verify the documentation is updated as per tickets attached

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


[WD-36125]: https://warthogs.atlassian.net/browse/WD-36125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-35345]: https://warthogs.atlassian.net/browse/WD-35345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ