### PR TITLE
build(deps): add flask as explicit dep for rockcraft pack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ canonicalwebteam.search==2.1.2
 canonicalwebteam.image-template==1.9.0
 mistune==0.8.4
 pyyaml==6.0.2
+flask


### PR DESCRIPTION
## Done

- Adds `flask` (unpinned) to `requirements.txt` so the `flask-framework` rockcraft extension can pack the rock during deploy.
- The extension requires `flask` to be a **direct** dependency — having it transitively via `canonicalwebteam.flask-base==3.1.1` isn't enough.
- Left unpinned so `flask-base` continues to own the version constraint; pinning here would risk resolver conflicts when `flask-base` is bumped.

### Context
PE [confirmed](https://chat.canonical.com/canonical/pl/jk631uisyb8w8b3s4oddjcuu1o) pip's resolver can't be made to treat the transitive flask as "explicit" for the extension's check. The two options are (a) list flask in `requirements.txt`, or (b) `pip freeze > requirements.txt` in CI before pack. Option (b) isn't viable here because [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml) delegates the pack step to `canonical/webteam-devops/.github/workflows/deploy.yaml@main`, which we don't control from this repo.


## QA

- Open [demo](https://vanilla-framework-5801.demos.haus/docs)
- See that nothing is broken
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
