### PR TITLE
fix(docs): Fix version number in CDN link being malformatted

### DIFF
--- a/templates/docs/index.html
+++ b/templates/docs/index.html
@@ -30,7 +30,7 @@
 
 <h2>Hotlink</h2>
 <p>You can add Vanilla directly to your markup:</p>
-<pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla_framework_version_{{ version | replace(".", "_") }}_min.css" /&gt;</code></pre>
+<pre><code>&lt;link rel="stylesheet" href="https://assets.ubuntu.com/v1/vanilla_framework_version_{{ version }}.min.css" /&gt;</code></pre>
 
 <h2>Download</h2>
 <p>Download the latest version of Vanilla from GitHub.</p>

--- a/templates/static/js/example.js
+++ b/templates/static/js/example.js
@@ -67,7 +67,7 @@
       // if it's a demo, use local build.css for better QA, otherwise use latest published Vanilla
       /demos\.haus$/.test(window.location.host)
         ? `${window.location.origin}/static/build/css/build.css`
-        : 'https://assets.ubuntu.com/v1/vanilla_framework_version_' + VANILLA_VERSION.replaceAll('.', '_') + '_min.css',
+        : 'https://assets.ubuntu.com/v1/vanilla_framework_version_' + VANILLA_VERSION + '.min.css',
       // link to example stylesheet (to set margin on body)
       'https://assets.ubuntu.com/v1/4653d9ba-example.css',
     ],


### PR DESCRIPTION
## Done

Changes formatting of the Vanilla URL in CDN links to use dots inside the version number instead of underscores

Fixes https://github.com/canonical/vanilla-framework/issues/5793
Fixes https://warthogs.atlassian.net/browse/WD-36205
Fixes https://chat.canonical.com/canonical/pl/dwo4wuwarib3dm86bjxuik11pw

## QA

- Open [demo](https://chat.canonical.com/canonical/pl/dwo4wuwarib3dm86bjxuik11pw)
- Open the getting started page
- Verify the CDN url (when the version is replaced with 4.50.0 instead of 4.51.0) does not 404

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

