### PR TITLE
feat(Tiered List): make top rule customisable with variant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.51.1",
+  "version": "4.52.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.51.0",
+  "version": "4.51.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.51.1
+  features:
+    - component: Tiered list
+      url: /docs/patterns/tiered-list#top-rule-variant
+      status: Updated
+      notes: Added a <code>top_rule_variant</code> parameter to customise the horizontal rule at the top of the pattern, supporting <code>muted</code>, <code>highlighted</code>, and <code>none</code> variants in addition to the default.
 - version: 4.51.0
   features:
     - component: Rich vertical list

--- a/releases.yml
+++ b/releases.yml
@@ -1,4 +1,4 @@
-- version: 4.51.1
+- version: 4.52.0
   features:
     - component: Tiered list
       url: /docs/patterns/tiered-list#top-rule-variant

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -4,16 +4,20 @@
 # is_list_full_width_on_tablet: whether list title/description each have their
 #   own row on tablet vs. 50/50 split between title/description
 # padding: Type of padding to apply. Options are "deep", "shallow", "default". Default is "default".
+# top_rule_variant: Variant of the horizontal rule rendered at the top of the pattern.
+#   Options are "default", "muted", "highlighted", "none". Default is "default".
 # Slots
 # title: top-level title element
 # description: top-level description element
 # list_item_title_[1-25]: title element of each child list item
 # list_item_description_[1-25]: description element of each child list item
 # cta: CTA block element
+{% from "_macros/shared/vf_section_top_rule.jinja" import vf_section_top_rule %}
 {% macro vf_tiered_list(
   padding="default",
   is_description_full_width_on_desktop=true,
-  is_list_full_width_on_tablet=true) -%}
+  is_list_full_width_on_tablet=true,
+  top_rule_variant="default") -%}
   {%- set title_content = caller('title') -%}
   {%- set description_content = caller('description') -%}
   {%- set has_description = description_content|trim|length > 0 -%}
@@ -30,7 +34,7 @@
   {%- endif -%}
 
   <div class="{{ padding_classes }} u-fixed-width">
-    <hr class="p-rule">
+    {{ vf_section_top_rule(top_rule_variant) }}
     <div class="p-section--shallow">
       {% if has_description == true -%}
         {%- if is_description_full_width_on_desktop == true -%}

--- a/templates/docs/examples/patterns/tiered-list/muted-top-rule.html
+++ b/templates/docs/examples/patterns/tiered-list/muted-top-rule.html
@@ -1,0 +1,55 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / Muted top rule{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=true, is_list_full_width_on_tablet=true, top_rule_variant="muted") -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/patterns/tiered-list/index.md
+++ b/templates/docs/patterns/tiered-list/index.md
@@ -203,7 +203,7 @@ The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. 
           <code>'default'</code>
         </td>
         <td>
-          Variant of the horizontal rule rendered at the top of the pattern
+          Variant of the <a href="/docs/patterns/rule">horizontal rule</a> rendered at the top of the pattern
         </td>
       </tr>
     </tbody>

--- a/templates/docs/patterns/tiered-list/index.md
+++ b/templates/docs/patterns/tiered-list/index.md
@@ -103,6 +103,16 @@ View example of the tiered list pattern
 View example of the tiered list pattern
 </a></div>
 
+## Top rule variant
+
+By default the pattern renders a standard horizontal rule at its top. Use the
+`top_rule_variant` parameter to render a `muted` or `highlighted` rule, or
+`none` to remove it.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/muted-top-rule/" class="js-example" data-lang="jinja">
+View example of the tiered list pattern
+</a></div>
+
 ## Jinja Macro
 
 The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. The API for the macro is shown below.
@@ -173,6 +183,27 @@ The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. 
         </td>
         <td>
           Padding variant for the section
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>top_rule_variant</code>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          One of:<br>
+          <code>'default'</code>,<br>
+          <code>'muted'</code>,<br>
+          <code>'highlighted'</code>,<br>
+          <code>'none'</code>
+        </td>
+        <td>
+          <code>'default'</code>
+        </td>
+        <td>
+          Variant of the horizontal rule rendered at the top of the pattern
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
## Done

- Added a `top_rule_variant` parameter to the `vf_tiered_list` macro, delegating rendering of the top horizontal rule to the shared `vf_section_top_rule` helper (the same mechanism `vf_divided_section` uses).
  - Supports `default`, `muted`, `highlighted` and `none`.
  - Default output is byte-equivalent to the previous `<hr class="p-rule">` (the helper emits a self-closing `/>`, identical for a void element), so **existing usages are unaffected**.
- Added a `muted-top-rule` example demonstrating the variant.
- Documented the new parameter (param table row + "Top rule variant" section) on the Tiered list docs page.
- Bumped Vanilla to `4.52.0` (minor) and added a `releases.yml` entry.

## QA

- Open [demo](https://vanilla-framework-5811.demos.haus/docs/patterns/tiered-list)
- Visit `/docs/patterns/tiered-list` and confirm the new "Top rule variant" section and `top_rule_variant` parameter row appear.
- Open the [muted top rule example](/docs/examples/patterns/tiered-list/muted-top-rule/) and confirm the top rule renders muted (`p-rule--muted`).
- Confirm the existing tiered-list examples (e.g. [full-width with description](/docs/examples/patterns/tiered-list/full-width-with-description/)) are visually unchanged.
- Verified locally: all 713 example templates render successfully through the Flask app, including all 11 existing tiered-list examples and the new one.
- Review updated documentation:
  - `templates/docs/patterns/tiered-list/index.md`

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - Patch bump `4.51.0` → `4.52.0`: the change is additive and existing macro/CSS APIs are unchanged.
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).

## Screenshots

## Ticket
https://warthogs.atlassian.net/browse/WD-37065

[if relevant, include a screenshot or screen capture]
