### PR TITLE
chore: skip Percy on Blocked PRs even with the Percy label

### DIFF
--- a/.github/workflows/pr-percy-prepare-label.yml
+++ b/.github/workflows/pr-percy-prepare-label.yml
@@ -13,7 +13,14 @@ on:
 jobs:
   copy_artifact:
     name: Copy changed files to GHA artifact
-    if: "(github.event.action == 'synchronize' && contains(toJson(github.event.pull_request.labels.*.name), 'Review: Percy needed')) || (github.event.action == 'labeled' && github.event.label.name == 'Review: Percy needed')"
+    # Never run on PRs marked "Blocked ⛔" (matched as a substring), even if the Percy label is present.
+    # This stops abandoned/blocked PRs (e.g. a stale renovate PR that keeps rebasing) from burning full Percy builds.
+    if: >-
+      !contains(toJson(github.event.pull_request.labels.*.name), 'Blocked')
+      && (
+        (github.event.action == 'synchronize' && contains(toJson(github.event.pull_request.labels.*.name), 'Review: Percy needed'))
+        || (github.event.action == 'labeled' && github.event.label.name == 'Review: Percy needed')
+      )
     uses: ./.github/workflows/percy-prepare.yml
     with:
       pr_number: ${{ github.event.number }}


### PR DESCRIPTION
## Done

- Guard the `Percy (labeled)` workflow so it **never runs when a PR carries the `Blocked ⛔` label**, even if `Review: Percy needed` is present.
- Matches `Blocked` as a substring (robust to the emoji/trailing space; no other label contains it).
- Applies to both trigger branches (`labeled` and `synchronize`), so neither adding the Percy label nor pushing/rebasing a blocked PR will start a build.

**Why:** a Renovate PR was labelled `Review: Percy needed`, then hit a problem and was marked `Blocked ⛔` and abandoned. Renovate kept rebasing it ~2–4×/week, and each `synchronize` faithfully ran a full ~700-screenshot Percy build for months. The label was doing its job; it just outlived its purpose on a PR that could never merge.

**Effect:** healthy labelled PRs (including legitimate Renovate version-bump visual checks) are unaffected and still re-check on each rebase. `Blocked ⛔` now acts as a pause/resume switch.

CI-only change — no SCSS/macro changes, so no version bump or release-notes entry needed.

Fixes — ticket [WD-37050](https://warthogs.atlassian.net/browse/WD-37050)
https://warthogs.atlassian.net/browse/WD-37066

## QA

- On a PR **with** `Review: Percy needed` **and** `Blocked ⛔`: push a commit → confirm the `Percy (labeled)` workflow does **not** trigger.
- On a PR with only `Review: Percy needed` (no `Blocked ⛔`): push a commit → confirm Percy still runs as before.
- Remove `Blocked ⛔`, push again → Percy resumes.

### Check if PR is ready for release

N/A — no Vanilla SCSS or macro code changes (CI workflow only).

## Screenshots

N/A

[WD-37050]: https://warthogs.atlassian.net/browse/WD-37050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ