### PR TITLE
chore: update Node.js version to 20 in publish-on-release workflow

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 20
       - name: Read Vanilla version from package.json
         run: |
           node -p "require('./package.json').version" > VANILLA_VERSION


### PR DESCRIPTION
## Summary
- Bumps the `build` job's Node.js version from 18 to 20 in `publish-on-release.yml`, aligning it with `pr.yml` which already uses Node 20. Node 18 reached EOL in April 2025.

## Test plan
- [ ] Confirm the release workflow still builds successfully on Node 20