### PR TITLE
feat(WD-37057): add media (image, video) support to Tiered list pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.56.0",
+  "version": "4.57.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -3,7 +3,7 @@
     - component: Tiered list
       url: /docs/patterns/tiered-list
       status: Updated
-      notes: Updated positioning of CTA block within the tiered list pattern to be more consistent with other patterns. The CTA block is now positioned below the description element.
+      notes: Updated positioning of CTA block within the tiered list pattern to be more consistent with other patterns. The CTA block is now positioned below the description element. Added media (image, video) support to the tiered list pattern, with an option for full-width media that spans the entire width of the pattern and a default media option that is contained within the content column.
     - component: Equal heights
       url: /docs/patterns/equal-heights
       status: Updated

--- a/releases.yml
+++ b/releases.yml
@@ -8,6 +8,10 @@
       url: /docs/patterns/equal-heights
       status: Updated
       notes: Updated positioning of CTA block within the equal heights pattern to be more consistent with other patterns. The CTA block is now positioned below the description element.
+    - component: Tiered list
+      url: /docs/patterns/tiered-list
+      status: Updated
+      notes: Added media (image, video) support to the tiered list pattern, with an option for full-width media that spans the entire width of the pattern and a default media option that is contained within the content column. The media can be rendered at the top of section before the description, after the description, or after the CTA, with the option to hide on small or medium screens.
 - version: 4.53.0
   features:
     - component: Card pattern

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.57.0
+  features:
+    - component: Tiered list
+      url: /docs/patterns/tiered-list
+      status: Updated
+      notes: Added media (image, video) support to the tiered list pattern, with an option for full-width media that spans the entire width of the pattern as well as contained within the content column, before or after the description.
 - version: 4.56.0
   features:
     - component: Hero
@@ -29,15 +35,11 @@
     - component: Tiered list
       url: /docs/patterns/tiered-list
       status: Updated
-      notes: Updated positioning of CTA block within the tiered list pattern to be more consistent with other patterns. The CTA block is now positioned below the description element. Added media (image, video) support to the tiered list pattern, with an option for full-width media that spans the entire width of the pattern and a default media option that is contained within the content column.
+      notes: Updated positioning of CTA block within the tiered list pattern to be more consistent with other patterns. The CTA block is now positioned below the description element.
     - component: Equal heights
       url: /docs/patterns/equal-heights
       status: Updated
       notes: Updated positioning of CTA block within the equal heights pattern to be more consistent with other patterns. The CTA block is now positioned below the description element.
-    - component: Tiered list
-      url: /docs/patterns/tiered-list
-      status: Updated
-      notes: Added media (image, video) support to the tiered list pattern, with an option for full-width media that spans the entire width of the pattern and a default media option that is contained within the content column. The media can be rendered at the top of section before the description, after the description, or after the CTA, with the option to hide on small or medium screens.
 - version: 4.53.0
   features:
     - component: Card pattern

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -49,7 +49,7 @@
   {% endif %}
 
   {% set image_aspect_ratio = "16-9" %}
-  {% if is_media_full_width and not is_video %}
+  {% if is_media_full_width %}
     {% set image_aspect_ratio = "cinematic" %}
   {% endif %}
 
@@ -96,6 +96,18 @@
     {%- endif -%}
   {% endmacro %}
 
+  {% macro _description_with_media() %}
+    {#- Non-full-width media before description -#}
+    {%- if has_media and media_placement == "before_description" and not is_media_full_width -%}
+      {{- _wrapped_media() -}}
+    {%- endif -%}
+    {{ description_content }}
+    {#- Non-full-width media after description -#}
+    {%- if has_media and media_placement == "after_description" and not is_media_full_width -%}
+      {{- _wrapped_media() -}}
+    {%- endif -%}
+  {% endmacro %}
+
   {%- if title_content|trim|length == 0 -%}
     {%- set title_content = "<h2>Tiered List</h2>" -%}
   {%- endif -%}
@@ -122,15 +134,7 @@
 
           <div class="grid-row">
             <div class="grid-col-4 grid-col-start-large-5">
-            {#- Non-full-width media before description -#}
-            {% if has_media and media_placement == "before_description" and not is_media_full_width %}
-              {{- _wrapped_media() -}}
-            {% endif %}
-              {{ description_content }}
-            {#- Non-full-width media after description -#}
-            {% if has_media and media_placement == "after_description" and not is_media_full_width %}
-              {{- _wrapped_media() -}}
-            {% endif %}
+              {{- _description_with_media() -}}
             </div>
           </div>
         {%- else -%} {#- (50/50 desktop layout) -#}
@@ -140,15 +144,7 @@
             </div>
 
             <div class="grid-col">
-            {#- Non-full-width media before description -#}
-            {%- if has_media and media_placement == "before_description" and not is_media_full_width -%}
-              {{- _wrapped_media() -}}
-            {%- endif -%}
-              {{ description_content }}
-            {#- Non-full-width media after description -#}
-            {%- if has_media and media_placement == "after_description" and not is_media_full_width -%}
-              {{- _wrapped_media() -}}
-            {%- endif -%}
+              {{- _description_with_media() -}}
             </div>
           </div>
         {%- endif -%}
@@ -197,41 +193,21 @@
         {#- Check to see if title/description content exist, since we're
             iterating through 25 potential list items -#}
         {%- if has_title_content and has_description_content -%}
-          {%- if is_list_full_width_on_tablet == true %}
-            {#- Skip the first HR -#}
-            {%- if number != 1 %}
-              <div class="grid-row">
-                <div class="grid-col-6 grid-col-start-large-3">
-                  <hr class="is-muted">
-                </div>
-              </div>
-            {%- endif -%}
-
+          {#- Skip the first HR -#}
+          {%- if number != 1 %}
             <div class="grid-row">
-              <div class="grid-col-2 grid-col-start-large-3">{{ list_item_title_content }}</div>
-
-              <div class="grid-col-4">{{ list_item_description_content }}</div>
-            </div>
-          {%- else %}
-            {#- Skip the first HR -#}
-            {%- if number != 1 %}
-              <div class="grid-row">
-                <div class="grid-col-6 grid-col-start-large-3">
-                  <hr class="is-muted">
-                </div>
-              </div>
-            {%- endif -%}
-
-            <div class="grid-row">
-              <div class="grid-col-medium-2 grid-col-2 grid-col-start-large-3">
-                {{ list_item_title_content }}
-              </div>
-
-              <div class="grid-col-medium-2 grid-col-4">
-                {{ list_item_description_content }}
+              <div class="grid-col-6 grid-col-start-large-3">
+                <hr class="is-muted">
               </div>
             </div>
           {%- endif -%}
+
+          {%- set medium_class = "" if is_list_full_width_on_tablet else "grid-col-medium-2 " -%}
+          <div class="grid-row">
+            <div class="{{ medium_class }}grid-col-2 grid-col-start-large-3">{{ list_item_title_content }}</div>
+
+            <div class="{{ medium_class }}grid-col-4">{{ list_item_description_content }}</div>
+          </div>
         {%- endif -%}
       {% endfor %}
   </div>

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -6,6 +6,10 @@
 # padding: Type of padding to apply. Options are "deep", "shallow", "default". Default is "default".
 # top_rule_variant: Variant of the horizontal rule rendered at the top of the pattern.
 #   Options are "default", "muted", "highlighted", "none". Default is "default".
+# is_media_full_width: whether the media is full width
+# media_placement: where the image is placed relative to the description. Options are "after_description" or "before_description".
+# img_attrs: attributes for the image element, e.g. src, alt, class
+# video_attrs: attributes for the video element, e.g. src, class
 # Slots
 # title: top-level title element
 # description: top-level description element
@@ -17,7 +21,11 @@
   padding="default",
   is_description_full_width_on_desktop=true,
   is_list_full_width_on_tablet=true,
-  top_rule_variant="default") -%}
+  top_rule_variant="default",
+  is_media_full_width=false,
+  media_placement="after_description",
+  img_attrs={},
+  video_attrs={}) -%}
   {%- set title_content = caller('title') -%}
   {%- set description_content = caller('description') -%}
   {%- set has_description = description_content|trim|length > 0 -%}
@@ -32,9 +40,79 @@
   {%- else -%}  
     {%- set padding_classes = "p-section--" + padding -%}  
   {%- endif -%}
+  {%- set has_image = img_attrs['src']|trim|length > 0 -%}
+  {%- set has_video = video_attrs['src']|trim|length > 0 -%}
+  {%- set has_media = has_image or has_video -%}
+
+  {% if media_placement not in ["before_description", "after_description"] %}
+    {% set media_placement = "after_description" %}
+  {% endif %}
+
+  {% set image_aspect_ratio = "16-9" %}
+  {% if is_media_full_width and not is_video %}
+    {% set image_aspect_ratio = "cinematic" %}
+  {% endif %}
+
+  {% macro _wrapped_media() %}
+    {%- if has_media -%}
+      {%- if has_video -%}
+        <div class="p-section--shallow">
+          {#- u-embedded-media applies 16:9 aspect ratio via padding. -#}
+          <div class="u-embedded-media u-no-margin--bottom"> 
+            <iframe class="u-embedded-media__element {{ video_attrs['class'] }}"
+            {% for attr, value in video_attrs.items() %}
+              {% if attr != "class" %}
+                {{- attr }}="{{ value }}"
+              {% endif %}
+            {% endfor %}
+            ></iframe>
+          </div>
+        </div>
+      {%- elif has_image -%}
+        <div class="p-section--shallow">
+          <div class="p-image-container--{{ image_aspect_ratio }} is-cover">
+            <img
+              {#- Forward classes from the img_attrs. This is optional, on a per-pattern basis. #}
+              class="p-image-container__image {{ img_attrs['class'] }}"
+            {% for attr, value in img_attrs.items() %}
+              {% if attr != "class" %}
+                {{- attr }}="{{ value }}"
+              {% endif %}
+            {% endfor %}
+            >
+          </div>
+        </div>
+      {%- endif -%}
+    {%- endif -%}
+  {% endmacro %}
+
+  {% macro _full_width_media_row() %}
+    {%- if has_media and is_media_full_width -%}
+      <div class="grid-row">
+        <div class="grid-col">
+          {{- _wrapped_media() -}}
+        </div>
+      </div>
+    {%- endif -%}
+  {% endmacro %}
+
+  {%- if title_content|trim|length == 0 -%}
+    {%- set title_content = "<h2>Tiered List</h2>" -%}
+  {%- endif -%}
+
+  {%- if description_content|trim|length == 0 -%}
+    {%- set description_content = "<p>This is a tiered list.</p>" -%}
+  {%- endif -%}
+
+  {%- if cta_content|trim|length == 0 -%}
+    {%- set cta_content = "<p>No CTA provided.</p>" -%}
+  {%- endif -%}
 
   <div class="{{ padding_classes }} u-fixed-width">
     {{ vf_section_top_rule(top_rule_variant) }}
+    {% if has_media and is_media_full_width and media_placement == "before_description" %}
+      {{- _full_width_media_row() -}}
+    {% endif %}
     <div class="p-section--shallow">
       {% if has_description == true -%}
         {%- if is_description_full_width_on_desktop == true -%}
@@ -44,17 +122,33 @@
 
           <div class="grid-row">
             <div class="grid-col-4 grid-col-start-large-5">
+            {#- Non-full-width media before description -#}
+            {% if has_media and media_placement == "before_description" and not is_media_full_width %}
+              {{- _wrapped_media() -}}
+            {% endif %}
               {{ description_content }}
+            {#- Non-full-width media after description -#}
+            {% if has_media and media_placement == "after_description" and not is_media_full_width %}
+              {{- _wrapped_media() -}}
+            {% endif %}
             </div>
           </div>
-        {%- else -%}
+        {%- else -%} {#- (50/50 desktop layout) -#}
           <div class="grid-row--50-50-on-large">
             <div class="grid-col">
               {{ title_content }}
             </div>
 
             <div class="grid-col">
+            {#- Non-full-width media before description -#}
+            {%- if has_media and media_placement == "before_description" and not is_media_full_width -%}
+              {{- _wrapped_media() -}}
+            {%- endif -%}
               {{ description_content }}
+            {#- Non-full-width media after description -#}
+            {%- if has_media and media_placement == "after_description" and not is_media_full_width -%}
+              {{- _wrapped_media() -}}
+            {%- endif -%}
             </div>
           </div>
         {%- endif -%}
@@ -67,11 +161,27 @@
             </div>
           </div>
         {%- endif %}
-      {%- else -%}
-        <div class="u-fixed-width">
-          {{ title_content }}
+      {%- else -%} {#- No description (has_description is false) -#}
+        <div class="grid-row">
+          {#- No description; the non-full-width media goes directly adjacent to the title -#}
+          <div class="{% if not has_media or is_media_full_width %}grid-col{% else %}grid-col-4{% endif %}">
+            <div class="p-section--shallow">
+              {{ title_content }}
+            </div>
+          </div>
+          {% if has_media and not is_media_full_width %}
+            <div class="grid-col-4 grid-col-start-large-5">
+              {{- _wrapped_media() -}}
+            </div>
+          {% endif %}
         </div>
       {%- endif %}
+
+    {#- Always render full-width media in its own row, after the main title/description/no-description blocks -#}
+    {% if has_media and is_media_full_width and media_placement == "after_description" %}
+      {{- _full_width_media_row() -}}
+    {% endif %}
+
     </div>
 
     {#-

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -10,6 +10,7 @@
 # media_placement: where the image is placed relative to the description. Options are "after_description" or "before_description".
 # img_attrs: attributes for the image element, e.g. src, alt, class
 # video_attrs: attributes for the video element, e.g. src, class
+# media_aspect_ratio: aspect ratio of the media. Options are "3-2" or "16-9". Default is "3-2". If is_media_full_width is true, this will be set to "cinematic". Only applies to images, not videos. Videos always have a 16:9 aspect ratio.
 # Slots
 # title: top-level title element
 # description: top-level description element
@@ -25,7 +26,9 @@
   is_media_full_width=false,
   media_placement="after_description",
   img_attrs={},
-  video_attrs={}) -%}
+  video_attrs={},
+  media_aspect_ratio="3-2"
+  ) -%}
   {%- set title_content = caller('title') -%}
   {%- set description_content = caller('description') -%}
   {%- set has_description = description_content|trim|length > 0 -%}
@@ -48,9 +51,11 @@
     {% set media_placement = "after_description" %}
   {% endif %}
 
-  {% set image_aspect_ratio = "16-9" %}
+  {% if media_aspect_ratio not in ["3-2", "16-9"] %}
+    {% set media_aspect_ratio = "3-2" %}
+  {% endif %}
   {% if is_media_full_width %}
-    {% set image_aspect_ratio = "cinematic" %}
+    {% set media_aspect_ratio = "cinematic" %}
   {% endif %}
 
   {% macro _wrapped_media() %}
@@ -70,7 +75,7 @@
         </div>
       {%- elif has_image -%}
         <div class="p-section--shallow">
-          <div class="p-image-container--{{ image_aspect_ratio }} is-cover">
+          <div class="p-image-container--{{ media_aspect_ratio }} is-cover">
             <img
               {#- Forward classes from the img_attrs. This is optional, on a per-pattern basis. #}
               class="p-image-container__image {{ img_attrs['class'] }}"
@@ -151,9 +156,7 @@
         {% if has_cta == true -%}
           <div class="grid-row">
             <div class="grid-col-4 grid-col-start-large-5">
-              <p>
-                {{ cta_content }}
-              </p>
+              {{ cta_content }}
             </div>
           </div>
         {%- endif %}

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -7,7 +7,7 @@
 # top_rule_variant: Variant of the horizontal rule rendered at the top of the pattern.
 #   Options are "default", "muted", "highlighted", "none". Default is "default".
 # is_media_full_width: whether the media is full width
-# media_placement: where the image is placed relative to the description. Options are "after_description" or "before_description".
+# media_placement: where the media is placed. Options are "before_description", "after_description", or "after_cta". Default is "after_cta".
 # img_attrs: attributes for the image element, e.g. src, alt, class
 # video_attrs: attributes for the video element, e.g. src, class
 # media_aspect_ratio: aspect ratio of the media. Options are "3-2" or "16-9". Default is "3-2". If is_media_full_width is true, this will be set to "cinematic". Only applies to images, not videos. Videos always have a 16:9 aspect ratio.
@@ -47,8 +47,8 @@
   {%- set has_video = video_attrs['src']|trim|length > 0 -%}
   {%- set has_media = has_image or has_video -%}
 
-  {% if media_placement not in ["before_description", "after_description"] %}
-    {% set media_placement = "after_description" %}
+  {% if media_placement not in ["before_description", "after_description", "after_cta"] %}
+    {% set media_placement = "after_cta" %}
   {% endif %}
 
   {% if media_aspect_ratio not in ["3-2", "16-9"] %}
@@ -107,9 +107,20 @@
       {{- _wrapped_media() -}}
     {%- endif -%}
     {{ description_content }}
-    {#- Non-full-width media after description -#}
+    {#- Non-full-width media after description (before CTA) -#}
     {%- if has_media and media_placement == "after_description" and not is_media_full_width -%}
       {{- _wrapped_media() -}}
+    {%- endif -%}
+  {% endmacro %}
+
+  {#- Non-full-width "after_cta" media renders in its own row after the CTA. -#}
+  {% macro _after_cta_media_row() %}
+    {%- if has_media and media_placement == "after_cta" and not is_media_full_width -%}
+      <div class="grid-row">
+        <div class="grid-col-4 grid-col-start-large-5">
+          {{- _wrapped_media() -}}
+        </div>
+      </div>
     {%- endif -%}
   {% endmacro %}
 
@@ -160,6 +171,7 @@
             </div>
           </div>
         {%- endif %}
+        {{- _after_cta_media_row() -}}
       {%- else -%} {#- No description (has_description is false) -#}
         <div class="grid-row">
           {#- No description; the non-full-width media goes directly adjacent to the title -#}
@@ -177,7 +189,7 @@
       {%- endif %}
 
     {#- Always render full-width media in its own row, after the main title/description/no-description blocks -#}
-    {% if has_media and is_media_full_width and media_placement == "after_description" %}
+    {% if has_media and is_media_full_width and media_placement != "before_description" %}
       {{- _full_width_media_row() -}}
     {% endif %}
 

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -11,6 +11,8 @@
 # img_attrs: attributes for the image element, e.g. src, alt, class
 # video_attrs: attributes for the video element, e.g. src, class
 # media_aspect_ratio: aspect ratio of the media. Options are "3-2" or "16-9". Default is "3-2". If is_media_full_width is true, this will be set to "cinematic". Only applies to images, not videos. Videos always have a 16:9 aspect ratio.
+# hide_medium: whether to hide media on medium screens. Default is false.
+# hide_small: whether to hide media on small screens. Default is false.
 # Slots
 # title: top-level title element
 # description: top-level description element
@@ -27,7 +29,9 @@
   media_placement="after_description",
   img_attrs={},
   video_attrs={},
-  media_aspect_ratio="3-2"
+  media_aspect_ratio="3-2",
+  hide_medium=false,
+  hide_small=false
   ) -%}
   {%- set title_content = caller('title') -%}
   {%- set description_content = caller('description') -%}
@@ -59,9 +63,10 @@
   {% endif %}
 
   {% macro _wrapped_media() %}
+    {%- set hide_classes = (" u-hide--medium" if hide_medium else "") + (" u-hide--small" if hide_small else "") -%}
     {%- if has_media -%}
       {%- if has_video -%}
-        <div class="p-section--shallow">
+        <div class="p-section--shallow{{ hide_classes }}">
           {#- u-embedded-media applies 16:9 aspect ratio via padding. -#}
           <div class="u-embedded-media u-no-margin--bottom"> 
             <iframe class="u-embedded-media__element {{ video_attrs['class'] }}"
@@ -74,7 +79,7 @@
           </div>
         </div>
       {%- elif has_image -%}
-        <div class="p-section--shallow">
+        <div class="p-section--shallow{{ hide_classes }}">
           <div class="p-image-container--{{ media_aspect_ratio }} is-cover">
             <img
               {#- Forward classes from the img_attrs. This is optional, on a per-pattern basis. #}

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -63,10 +63,11 @@
   {% endif %}
 
   {% macro _wrapped_media() %}
+    {%- set section_classes = ("p-section--shallow" if (media_placement == "before_description") or (media_placement == "after_description" and not is_media_full_width)) -%}
     {%- set hide_classes = (" u-hide--medium" if hide_medium else "") + (" u-hide--small" if hide_small else "") -%}
     {%- if has_media -%}
       {%- if has_video -%}
-        <div class="p-section--shallow{{ hide_classes }}">
+        <div class="{{ section_classes }}{{ hide_classes }}">
           {#- u-embedded-media applies 16:9 aspect ratio via padding. -#}
           <div class="u-embedded-media u-no-margin--bottom"> 
             <iframe class="u-embedded-media__element {{ video_attrs['class'] }}"
@@ -79,7 +80,7 @@
           </div>
         </div>
       {%- elif has_image -%}
-        <div class="p-section--shallow{{ hide_classes }}">
+        <div class="{{ section_classes }}{{ hide_classes }}">
           <div class="p-image-container--{{ media_aspect_ratio }} is-cover">
             <img
               {#- Forward classes from the img_attrs. This is optional, on a per-pattern basis. #}

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -9,7 +9,12 @@
 # is_media_full_width: whether the media is full width
 # media_placement: where the media is placed. Options are "before_description", "after_description", or "after_cta". Default is "after_cta".
 # img_attrs: attributes for the image element, e.g. src, alt, class
-# video_attrs: attributes for the video element, e.g. src, class
+# video_attrs: attributes for the video element.
+#   Pass "src" (e.g. a YouTube embed URL) to render a standard iframe embed, e.g. {"src": "...", "title": "...", "class": "..."}.
+#   Pass "video_id" (and ideally "video_title") to render a lite-youtube embed instead,
+#   e.g. {"video_id": "rPJEZ_tr_1w", "video_title": "Scaling Android development with Anbox Cloud"}.
+#   Any other keys are forwarded as attributes onto the rendered element.
+#   Consumers using lite-youtube must load the lite-youtube script themselves.
 # media_aspect_ratio: aspect ratio of the media. Options are "3-2" or "16-9". Default is "3-2". If is_media_full_width is true, this will be set to "cinematic". Only applies to images, not videos. Videos always have a 16:9 aspect ratio.
 # hide_media_on_small_medium_breakpoints: whether to hide media on medium and small screens. Default is false.
 # is_media_highlighted: Whether to apply the "is-highlighted" class to the media container (default is false) (only applies to image media type).
@@ -48,7 +53,9 @@
     {%- set padding_classes = "p-section--" + padding -%}  
   {%- endif -%}
   {%- set has_image = img_attrs['src']|trim|length > 0 -%}
-  {%- set has_video = video_attrs['src']|trim|length > 0 -%}
+  {%- set lite_youtube_video_id = video_attrs['video_id']|trim -%}
+  {%- set has_lite_youtube = lite_youtube_video_id|length > 0 -%}
+  {%- set has_video = has_lite_youtube or video_attrs['src']|trim|length > 0 -%}
   {%- set has_media = has_image or has_video -%}
 
   {% if media_placement not in ["before_description", "after_description", "after_cta"] %}
@@ -70,6 +77,23 @@
         <div class="{{ section_classes }} {{ hide_classes }}">
           {#- u-embedded-media applies 16:9 aspect ratio via padding. -#}
           <div class="u-embedded-media u-no-margin--bottom"> 
+            {%- if has_lite_youtube -%}
+              {%- set lite_youtube_video_title = video_attrs['video_title']|trim -%}
+              <lite-youtube class="u-embedded-media__element {{ video_attrs['class'] }}"
+              videoid="{{ lite_youtube_video_id }}"
+              videotitle="{{ lite_youtube_video_title }}"
+              {% if 'posterquality' not in video_attrs %}posterquality="maxresdefault"{% endif %}
+            {% for attr, value in video_attrs.items() %}
+              {% if attr not in ["class", "video_id", "video_title"] %}
+                {{- attr }}="{{ value }}"
+              {% endif %}
+            {% endfor %}
+              >
+                <a href="https://www.youtube.com/watch?v={{ lite_youtube_video_id }}" title="Play Video">
+                  <span class="lyt-visually-hidden">{{ lite_youtube_video_title }}</span>
+                </a>
+              </lite-youtube>
+            {%- else -%}
             <iframe class="u-embedded-media__element {{ video_attrs['class'] }}"
             {% for attr, value in video_attrs.items() %}
               {% if attr != "class" %}
@@ -77,6 +101,7 @@
               {% endif %}
             {% endfor %}
             ></iframe>
+            {%- endif -%}
           </div>
         </div>
       {%- elif has_image -%}

--- a/templates/_macros/vf_tiered-list.jinja
+++ b/templates/_macros/vf_tiered-list.jinja
@@ -11,8 +11,8 @@
 # img_attrs: attributes for the image element, e.g. src, alt, class
 # video_attrs: attributes for the video element, e.g. src, class
 # media_aspect_ratio: aspect ratio of the media. Options are "3-2" or "16-9". Default is "3-2". If is_media_full_width is true, this will be set to "cinematic". Only applies to images, not videos. Videos always have a 16:9 aspect ratio.
-# hide_medium: whether to hide media on medium screens. Default is false.
-# hide_small: whether to hide media on small screens. Default is false.
+# hide_media_on_small_medium_breakpoints: whether to hide media on medium and small screens. Default is false.
+# is_media_highlighted: Whether to apply the "is-highlighted" class to the media container (default is false) (only applies to image media type).
 # Slots
 # title: top-level title element
 # description: top-level description element
@@ -30,8 +30,8 @@
   img_attrs={},
   video_attrs={},
   media_aspect_ratio="3-2",
-  hide_medium=false,
-  hide_small=false
+  hide_media_on_small_medium_breakpoints=false,
+  is_media_highlighted=false
   ) -%}
   {%- set title_content = caller('title') -%}
   {%- set description_content = caller('description') -%}
@@ -64,10 +64,10 @@
 
   {% macro _wrapped_media() %}
     {%- set section_classes = ("p-section--shallow" if (media_placement == "before_description") or (media_placement == "after_description" and not is_media_full_width)) -%}
-    {%- set hide_classes = (" u-hide--medium" if hide_medium else "") + (" u-hide--small" if hide_small else "") -%}
+    {%- set hide_classes = ("u-hide--medium u-hide--small" if hide_media_on_small_medium_breakpoints else "") -%}
     {%- if has_media -%}
       {%- if has_video -%}
-        <div class="{{ section_classes }}{{ hide_classes }}">
+        <div class="{{ section_classes }} {{ hide_classes }}">
           {#- u-embedded-media applies 16:9 aspect ratio via padding. -#}
           <div class="u-embedded-media u-no-margin--bottom"> 
             <iframe class="u-embedded-media__element {{ video_attrs['class'] }}"
@@ -80,8 +80,8 @@
           </div>
         </div>
       {%- elif has_image -%}
-        <div class="{{ section_classes }}{{ hide_classes }}">
-          <div class="p-image-container--{{ media_aspect_ratio }} is-cover">
+        <div class="{{ section_classes }} {{ hide_classes }}">
+          <div class="p-image-container--{{ media_aspect_ratio }} is-cover{%- if is_media_highlighted %} is-highlighted{% endif -%}">
             <img
               {#- Forward classes from the img_attrs. This is optional, on a per-pattern basis. #}
               class="p-image-container__image {{ img_attrs['class'] }}"
@@ -218,16 +218,16 @@
           {%- if number != 1 %}
             <div class="grid-row">
               <div class="grid-col-6 grid-col-start-large-3">
-                <hr class="is-muted">
+                <hr class="p-rule--muted">
               </div>
             </div>
           {%- endif -%}
 
-          {%- set medium_class = "" if is_list_full_width_on_tablet else "grid-col-medium-2 " -%}
+          {%- set medium_class = "" if is_list_full_width_on_tablet else "grid-col-medium-2" -%}
           <div class="grid-row">
-            <div class="{{ medium_class }}grid-col-2 grid-col-start-large-3">{{ list_item_title_content }}</div>
+            <div class="{{ medium_class }} grid-col-2 grid-col-start-large-3">{{ list_item_title_content }}</div>
 
-            <div class="{{ medium_class }}grid-col-4">{{ list_item_description_content }}</div>
+            <div class="{{ medium_class }} grid-col-4">{{ list_item_description_content }}</div>
           </div>
         {%- endif -%}
       {% endfor %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-description.html
@@ -6,7 +6,11 @@
 {% block standalone_css %}patterns_all{% endblock %}
 
 {% block content %}
-{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true) -%}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, media_placement="before_description", img_attrs={
+  "width": "2384",
+  "height": "1257",
+  "src": "https://assets.ubuntu.com/v1/a299c914-GettyImages-DataCenter.jpeg"
+}) -%}
   {%- if slot == 'title' -%}
     <h2>H2 - up to two lines; ideally one.</h2>
   {%- endif -%}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-image-after-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-image-after-description.html
@@ -1,0 +1,88 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on desktop with full width image after description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, media_placement="after_description", img_attrs={
+  "width": "2384",
+  "height": "1257",
+  "src": "https://assets.ubuntu.com/v1/a299c914-GettyImages-DataCenter.jpeg"
+}, is_media_full_width=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-image-before-description.html
@@ -1,0 +1,88 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on desktop with full width image before description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, media_placement="before_description", img_attrs={
+  "width": "2384",
+  "height": "1257",
+  "src": "https://assets.ubuntu.com/v1/a299c914-GettyImages-DataCenter.jpeg"
+}, is_media_full_width=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-lite-youtube-video.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-lite-youtube-video.html
@@ -1,0 +1,64 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on desktop with full width lite-youtube video{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, media_placement="before_description", video_attrs={
+  "video_id": "rPJEZ_tr_1w",
+  "video_title": "Scaling Android development with Anbox Cloud"
+}, is_media_full_width=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}
+
+{% block script %}
+<script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"
+        integrity="sha384-krUlgvxdz2iSLnbpvxj8zLWWUCa3QxzwLbW3EXmbzXCoAQ+ANH1cWJYRMc/TErh+"
+        crossorigin="anonymous"></script>
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-media-hidden-on-small-medium-breakpoints.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-media-hidden-on-small-medium-breakpoints.html
@@ -1,12 +1,16 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 on desktop with media in list items{% endblock %}
+{% block title %}Tiered list / 50/50 on desktop with media hidden on small and medium breakpoints{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 
 {% block content %}
-{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=false) -%}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, media_placement="before_description", img_attrs={
+  "width": "2384",
+  "height": "1257",
+  "src": "https://assets.ubuntu.com/v1/a299c914-GettyImages-DataCenter.jpeg"
+}, is_media_full_width=true, hide_small=true, hide_medium=true) -%}
   {%- if slot == 'title' -%}
     <h2>H2 - up to two lines; ideally one.</h2>
   {%- endif -%}
@@ -26,9 +30,6 @@
     <p>Resell the full range of Canonical’s portfolio of private and public
     cloud products: OpenStack, Kubernetes, IoT, support, security and
     compliance for Ubuntu.</p>
-    <div class="p-image-container p-section--shallow">
-      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/a299c914-GettyImages-DataCenter.jpeg" alt="Data centre" width="2384" height="1257">
-    </div>
   {%- endif -%}
 
   {%- if slot == 'list_item_title_2' -%}
@@ -39,9 +40,6 @@
     <p>Canonical can help train your field sales and presales teams and
     provide you with sales collateral and permission to use the Canonical
     and Ubuntu trademarks in your own materials.</p>
-    <div class="u-embedded-media"> 
-      <iframe title="Title of the media object" class="u-embedded-media__element" src="https://www.youtube.com/embed/TShKZLeZzWE" allowfullscreen></iframe>
-    </div>
   {%- endif -%}
 
   {%- if slot == 'list_item_title_3' -%}
@@ -51,12 +49,40 @@
   {%- if slot == 'list_item_description_3' -%}
     <p>We host a partner portal with product and solutions collaterals, agreed
     pricing, incentives and a deal registration system.</p>
-    <div class="p-cta-block">
-      <a href="#" class="p-cta-block__link">Learn more about the partner portal&nbsp;&rsaquo;</a>
-    </div>
-    <div class="p-image-container p-section--shallow">
-      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/a299c914-GettyImages-DataCenter.jpeg" alt="Data centre" width="2384" height="1257">
-    </div>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
   {%- endif -%}
 {%- endcall -%}
 {% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-media-hidden-on-small-medium-breakpoints.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-media-hidden-on-small-medium-breakpoints.html
@@ -10,7 +10,7 @@
   "width": "2384",
   "height": "1257",
   "src": "https://assets.ubuntu.com/v1/a299c914-GettyImages-DataCenter.jpeg"
-}, is_media_full_width=true, hide_small=true, hide_medium=true) -%}
+}, is_media_full_width=true, hide_media_on_small_medium_breakpoints=true) -%}
   {%- if slot == 'title' -%}
     <h2>H2 - up to two lines; ideally one.</h2>
   {%- endif -%}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-video-after-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-video-after-description.html
@@ -1,0 +1,86 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on desktop with full width video after description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, media_placement="after_description", video_attrs={
+  "src": "https://www.youtube.com/embed/PZdJiH0bUxY?si=zepeZVY1SXWr-KJo"
+}, is_media_full_width=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-video-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-video-before-description.html
@@ -1,0 +1,86 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on desktop with full width video before description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, media_placement="before_description", video_attrs={
+  "src": "https://www.youtube.com/embed/PZdJiH0bUxY?si=zepeZVY1SXWr-KJo"
+}, is_media_full_width=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-image-after-cta.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-image-after-cta.html
@@ -1,12 +1,16 @@
 {% extends "_layouts/examples.html" %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block title %}Tiered list / 50/50 on desktop with media in list items{% endblock %}
+{% block title %}Tiered list / 50/50 on desktop with image after CTA{% endblock %}
 
 {% block standalone_css %}patterns_all{% endblock %}
 
 {% block content %}
-{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=false) -%}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, media_placement="after_cta", img_attrs={
+  "width": "2384",
+  "height": "1257",
+  "src": "https://assets.ubuntu.com/v1/a299c914-GettyImages-DataCenter.jpeg"
+}) -%}
   {%- if slot == 'title' -%}
     <h2>H2 - up to two lines; ideally one.</h2>
   {%- endif -%}
@@ -26,9 +30,6 @@
     <p>Resell the full range of Canonical’s portfolio of private and public
     cloud products: OpenStack, Kubernetes, IoT, support, security and
     compliance for Ubuntu.</p>
-    <div class="p-image-container p-section--shallow">
-      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/a299c914-GettyImages-DataCenter.jpeg" alt="Data centre" width="2384" height="1257">
-    </div>
   {%- endif -%}
 
   {%- if slot == 'list_item_title_2' -%}
@@ -39,9 +40,6 @@
     <p>Canonical can help train your field sales and presales teams and
     provide you with sales collateral and permission to use the Canonical
     and Ubuntu trademarks in your own materials.</p>
-    <div class="u-embedded-media"> 
-      <iframe title="Title of the media object" class="u-embedded-media__element" src="https://www.youtube.com/embed/TShKZLeZzWE" allowfullscreen></iframe>
-    </div>
   {%- endif -%}
 
   {%- if slot == 'list_item_title_3' -%}
@@ -51,12 +49,40 @@
   {%- if slot == 'list_item_description_3' -%}
     <p>We host a partner portal with product and solutions collaterals, agreed
     pricing, incentives and a deal registration system.</p>
-    <div class="p-cta-block">
-      <a href="#" class="p-cta-block__link">Learn more about the partner portal&nbsp;&rsaquo;</a>
-    </div>
-    <div class="p-image-container p-section--shallow">
-      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/a299c914-GettyImages-DataCenter.jpeg" alt="Data centre" width="2384" height="1257">
-    </div>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
   {%- endif -%}
 {%- endcall -%}
 {% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-image-after-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-image-after-description.html
@@ -1,0 +1,88 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on desktop with image after description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, media_placement="after_description", img_attrs={
+  "width": "2384",
+  "height": "1257",
+  "src": "https://assets.ubuntu.com/v1/a299c914-GettyImages-DataCenter.jpeg"
+}) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-image-before-description.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-image-before-description.html
@@ -1,0 +1,88 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on desktop with image before description{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true, media_placement="before_description", img_attrs={
+  "width": "2384",
+  "height": "1257",
+  "src": "https://assets.ubuntu.com/v1/a299c914-GettyImages-DataCenter.jpeg"
+}) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_4' -%}
+    <h3 class="p-heading--5">Training and certification</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_4' -%}
+    <p>Gain access to technology that is the foundation for digital
+    transformation and expand your business through marketing support and
+    alignment with a trusted brand</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_5' -%}
+    <h3 class="p-heading--5">Technical enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_5' -%}
+    <p>We provide in-depth technical training for your customer engineering
+    teams with access to technical resources for your labs and customer
+    engagements.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_6' -%}
+    <h3 class="p-heading--5">Go to market with Canonical</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_6' -%}
+    <p>Working with our dedicated partner team, get new joint marketing
+    opportunities and lead generation.</p>
+  {%- endif -%}
+
+  {%- if slot == 'cta' -%}
+    <a href="#" class="p-button">Learn more</a>
+    <a href="#">Contact us &rsaquo;</a>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-media-in-list-items.html
+++ b/templates/docs/examples/patterns/tiered-list/50-50-desktop-with-media-in-list-items.html
@@ -1,0 +1,62 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}Tiered list / 50/50 on desktop with media in list items{% endblock %}
+
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% block content %}
+{%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true) -%}
+  {%- if slot == 'title' -%}
+    <h2>H2 - up to two lines; ideally one.</h2>
+  {%- endif -%}
+
+  {%- if slot == 'description' -%}
+    <p>A <a href="#">private cloud</a> provides organisations with on-demand
+    compute, storage and other resources that can be accessed over the network
+    and that are reserved exclusively for them - either in their own data centre
+    or via a 3rd party.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+    <h3 class="p-heading--5">Rich portfolio of products</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+    <p>Resell the full range of Canonical’s portfolio of private and public
+    cloud products: OpenStack, Kubernetes, IoT, support, security and
+    compliance for Ubuntu.</p>
+    <div class="p-image-container p-section--shallow">
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/a299c914-GettyImages-DataCenter.jpeg" alt="Data centre" width="2384" height="1257">
+    </div>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+    <h3 class="p-heading--5">Sales enablement</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+    <p>Canonical can help train your field sales and presales teams and
+    provide you with sales collateral and permission to use the Canonical
+    and Ubuntu trademarks in your own materials.</p>
+    <div class="u-embedded-media"> 
+      <iframe title="Title of the media object" class="u-embedded-media__element" src="https://www.youtube.com/embed/TShKZLeZzWE" allowfullscreen></iframe>
+    </div>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+    <h3 class="p-heading--5">Access to Canonical partner portal</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+    <p>We host a partner portal with product and solutions collaterals, agreed
+    pricing, incentives and a deal registration system.</p>
+    <div class="p-cta-block">
+      <a href="#" class="p-cta-block__link">Learn more about the partner portal&nbsp;&rsaquo;</a>
+    </div>
+    <div class="p-image-container p-section--shallow">
+      <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/a299c914-GettyImages-DataCenter.jpeg" alt="Data centre" width="2384" height="1257">
+    </div>
+  {%- endif -%}
+{%- endcall -%}
+{% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/combined.html
+++ b/templates/docs/examples/patterns/tiered-list/combined.html
@@ -15,5 +15,12 @@
 <section>{% include 'docs/examples/patterns/tiered-list/full-width-without-description.html' %}</section>
 <section>{% include 'docs/examples/patterns/tiered-list/full-width-with-description.html' %}</section>
 <section>{% include 'docs/examples/patterns/tiered-list/full-width-with-description-without-cta.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-image-after-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-video-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-video-after-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-image-before-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-image-after-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-media-in-list-items.html' %}</section>
 {% endwith %}
 {% endblock %}

--- a/templates/docs/examples/patterns/tiered-list/combined.html
+++ b/templates/docs/examples/patterns/tiered-list/combined.html
@@ -21,6 +21,8 @@
 <section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-video-after-description.html' %}</section>
 <section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-image-before-description.html' %}</section>
 <section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-image-after-description.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-image-after-cta.html' %}</section>
+<section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-media-hidden-on-small-medium-breakpoints.html' %}</section>
 <section>{% include 'docs/examples/patterns/tiered-list/50-50-desktop-with-media-in-list-items.html' %}</section>
 {% endwith %}
 {% endblock %}

--- a/templates/docs/patterns/tiered-list/index.md
+++ b/templates/docs/patterns/tiered-list/index.md
@@ -27,6 +27,7 @@ The tiered list pattern is composed of the following elements:
 | --------------------- | ----------------------------------------------------------------------------------- |
 | Title (**required**)  | <code>h2</code> title text                                                          |
 | Description           | <code>p</code> description text with optional [CTA block](/docs/patterns/cta-block) |
+| Media (optional)      | Image or video to show near description                                             |
 | List item title       | Title text/content                                                                  |
 | List item description | Description text/content with optional [CTA block](/docs/patterns/cta-block)        |
 | Call to action block  | [CTA block](/docs/patterns/cta-block) beneath the list                              |
@@ -110,6 +111,100 @@ By default the pattern renders a standard horizontal rule at its top. Use the
 `none` to remove it.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/muted-top-rule/" class="js-example" data-lang="jinja">
+View example of the tiered list pattern
+</a></div>
+
+## With media {{ status('new') }}
+
+You can embed an [image](#image) or a [video](#video) near the description.
+
+### Image
+
+You can embed a [default width](#default-width-image) or [full width](#full-width-image) image near the description.
+The image may be positioned before or after the description, depending on the variant you choose.
+The aspect ratio of the image depends on the variant you choose, and it will be wrapped in an [image container](/docs/patterns/images#image-container-with-aspect-ratio) to ensure it maintains the correct aspect ratio.
+
+**Always apply the `p-image-container__image` class to your image** to ensure the image is styled correctly.
+
+```json
+"img_attrs": {
+  "src": "image-url",
+  "alt": "alt-text",
+  "width": "image width",
+  "height": "image height",
+  "class": "additional image classes"
+}
+```
+
+#### Default width image
+
+This variant features a default width image positioned before description.
+
+When using the default width image, the image will use half of the page width on large screens.
+We recommend following these guidelines when using the default width image:
+
+- Use an image with a width sufficient to fill the page width on all screens.
+- Use an image with an aspect ratio of approximately 16:9 to avoid using too much vertical space.
+  - The Jinja macro will wrap your image in
+    a [16:9 image container](/docs/patterns/images#image-container-with-aspect-ratio) and make your
+    image [fill its contents](/docs/patterns/images#cover-image). Use an image with approximately a 16:9 aspect ratio,
+    otherwise some of your image contents may be cropped at some screen sizes.
+
+The following example demonstrates a good usage of the default width image variant:
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/50-50-desktop-with-image-before-description" class="js-example" data-lang="jinja">
+View example of the tiered list pattern
+</a></div>
+
+#### Full width image
+
+This variant features a full width image positioned before the title and description.
+
+When using the full width image, the image will use the full width of the page on all screens.
+We recommend following these guidelines when using the full width image:
+
+- Use an image with a width sufficient to fill the page width on all screens.
+- Use an image with an aspect ratio of approximately 2.4:1 to avoid using too much vertical space.
+  - The Jinja macro will wrap your image in
+    a [2.4:1 ("cinematic") image container](/docs/patterns/images#image-container-with-aspect-ratio) and make your
+    image [fill its contents](/docs/patterns/images#cover-image). Use an image with approximately a 2.4:1 aspect
+    ratio, otherwise some of your image contents may be cropped at some screen sizes.
+
+The following example demonstrates a good usage of the full width image variant:
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-image-before-description" class="js-example" data-lang="jinja">
+View example of the tiered list pattern
+</a></div>
+
+### Variable media placement
+
+By default, the media is displayed after the description, but you can choose whether it should be displayed before or after the description.
+To do this, set the `media_placement` parameter in the Jinja macro to either `before_description` or `after_description`.
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/50-50-desktop-with-image-after-description" class="js-example" data-lang="jinja">
+View example of the tiered list pattern
+</a></div>
+
+### Video
+
+You may also use this variant to embed a video. Videos are positioned exactly the same as images, but they always have a
+16:9 aspect ratio.
+
+When embedding a video with the Jinja macro, follow the following guidelines:
+
+- Use the `video_attrs` param instead of the `img_attrs` param.
+- Apply the `u-embedded-media__element` class, which is provided by the [embedded media utility](/docs/utilities/embedded-media).
+
+```json
+"video_attrs": {
+  "src": "video url",
+  "title": "title of the video iframe",
+  "allowfullscreen": "boolean - whether to allow full screen",
+  "class": "additional classes"
+}
+```
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-video-before-description" class="js-example" data-lang="jinja">
 View example of the tiered list pattern
 </a></div>
 
@@ -204,6 +299,76 @@ The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. 
         </td>
         <td>
           Variant of the <a href="/docs/patterns/rule">horizontal rule</a> rendered at the top of the pattern
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>img_attrs</code>
+        </td>
+        <td>
+          No
+        </td>
+        <td><code>object</code></td>
+        <td><code>{}</code></td>
+        <td>
+          Attributes of the image to display near the description.<br/>
+          Must have the class <code><a href="/docs/patterns/images">p-image-container__image</a></code>.<br/>
+          If the <code>video</code> slot is used, this slot will be ignored.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>video_attrs</code>
+        </td>
+        <td>
+          No
+        </td>
+        <td><code>object</code></td>
+        <td><code>{}</code></td>
+        <td>
+          Video to display near the description.<br/>
+          Must have the class <code><a href="/docs/utilities/embedded-media">u-embedded-media__element</a></code>.<br/>
+          Takes precedence over the <code>image</code> slot, so if both are used, the <code>video</code> will be displayed instead of the <code>image</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>is_media_full_width</code>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>
+          Whether the media should be full-width and displayed in its own row.<br/>
+          If the media is a full-width image, a <a href="/docs/patterns/images#image-container-with-aspect-ratio">cinematic (2.4:1 aspect ratio) image container</a> will wrap your image.<br/>
+          If the media is a default-width image, a <a href="/docs/patterns/images#image-container-with-aspect-ratio">16:9 image container</a> will wrap your image.<br/>
+          If you use the <code>video</code> slot, this parameter will affect the positioning of the video, but will not change its aspect ratio. Videos are always 16:9.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>media_placement</code>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          One of <code>'before_description'</code> or <code>'after_description'</code>
+        </td>
+        <td>
+          <code>'after_description'</code>
+        </td>
+        <td>
+          Whether the media should be full-width and displayed in its own row.<br/>
+          If the media is a full-width image, a <a href="/docs/patterns/images#image-container-with-aspect-ratio">cinematic (2.4:1 aspect ratio) image container</a> will wrap your image.<br/>
+          If the media is a default-width image, a <a href="/docs/patterns/images#image-container-with-aspect-ratio">16:9 image container</a> will wrap your image.<br/>
+          If you use the <code>video</code> slot, this parameter will affect the positioning of the video, but will not change its aspect ratio. Videos are always 16:9.
         </td>
       </tr>
     </tbody>

--- a/templates/docs/patterns/tiered-list/index.md
+++ b/templates/docs/patterns/tiered-list/index.md
@@ -381,6 +381,40 @@ The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. 
           Aspect ratio to apply to media. Only applies to images, and is set to `cinematic` when `is_media_full_width` is true. Videos have `16-9` ratio always.
         </td>
       </tr>
+      <tr>
+        <td>
+          <code>hide_medium</code>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>'false'</code>
+        </td>
+        <td>
+          Whether to hide media on medium screens
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>hide_small</code>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>'false'</code>
+        </td>
+        <td>
+          Whether to hide media on small screens
+        </td>
+      </tr>
     </tbody>
   </table>
 </div>

--- a/templates/docs/patterns/tiered-list/index.md
+++ b/templates/docs/patterns/tiered-list/index.md
@@ -170,8 +170,8 @@ View example of the tiered list pattern
 
 ### Variable media placement
 
-By default, the media is displayed after the description, but you can choose whether it should be displayed before or after the description.
-To do this, set the `media_placement` parameter in the Jinja macro to either `before_description` or `after_description`.
+By default, the media is displayed after the CTA, but you can choose where it should be displayed relative to the description and CTA.
+To do this, set the `media_placement` parameter in the Jinja macro to `before_description`, `after_description`, or `after_cta`.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/50-50-desktop-with-image-after-description" class="js-example" data-lang="jinja">
 View example of the tiered list pattern
@@ -351,16 +351,17 @@ The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. 
           No
         </td>
         <td>
-          One of <code>'before_description'</code> or <code>'after_description'</code>
+          One of <code>'before_description'</code>, <code>'after_description'</code>, or <code>'after_cta'</code>
         </td>
         <td>
-          <code>'after_description'</code>
+          <code>'after_cta'</code>
         </td>
         <td>
           Whether the media should be full-width and displayed in its own row.<br/>
           If the media is a full-width image, a <a href="/docs/patterns/images#image-container-with-aspect-ratio">cinematic (2.4:1 aspect ratio) image container</a> will wrap your image.<br/>
           If the media is a default-width image, a <a href="/docs/patterns/images#image-container-with-aspect-ratio">16:9 image container</a> will wrap your image.<br/>
           If you use the <code>video</code> slot, this parameter will affect the positioning of the video, but will not change its aspect ratio. Videos are always 16:9.
+          `after_description` and `after_cta` will have same effect for full-width media, i.e., media row will be rendered after description + cta combined.
         </td>
       </tr>
       <tr>

--- a/templates/docs/patterns/tiered-list/index.md
+++ b/templates/docs/patterns/tiered-list/index.md
@@ -144,11 +144,7 @@ When using the default width image, the image will use half of the page width on
 We recommend following these guidelines when using the default width image:
 
 - Use an image with a width sufficient to fill the page width on all screens.
-- Use an image with an aspect ratio of approximately 16:9 to avoid using too much vertical space.
-  - The Jinja macro will wrap your image in
-    a [16:9 image container](/docs/patterns/images#image-container-with-aspect-ratio) and make your
-    image [fill its contents](/docs/patterns/images#cover-image). Use an image with approximately a 16:9 aspect ratio,
-    otherwise some of your image contents may be cropped at some screen sizes.
+- By default, the images have `3-2` aspect ratio. You can also set it to `16-9` by using `media_aspect_ratio` attribute.
 
 The following example demonstrates a good usage of the default width image variant:
 
@@ -164,11 +160,7 @@ When using the full width image, the image will use the full width of the page o
 We recommend following these guidelines when using the full width image:
 
 - Use an image with a width sufficient to fill the page width on all screens.
-- Use an image with an aspect ratio of approximately 2.4:1 to avoid using too much vertical space.
-  - The Jinja macro will wrap your image in
-    a [2.4:1 ("cinematic") image container](/docs/patterns/images#image-container-with-aspect-ratio) and make your
-    image [fill its contents](/docs/patterns/images#cover-image). Use an image with approximately a 2.4:1 aspect
-    ratio, otherwise some of your image contents may be cropped at some screen sizes.
+- `cinematic` aspect ratio will be automatically applied.
 
 The following example demonstrates a good usage of the full width image variant:
 
@@ -369,6 +361,23 @@ The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. 
           If the media is a full-width image, a <a href="/docs/patterns/images#image-container-with-aspect-ratio">cinematic (2.4:1 aspect ratio) image container</a> will wrap your image.<br/>
           If the media is a default-width image, a <a href="/docs/patterns/images#image-container-with-aspect-ratio">16:9 image container</a> will wrap your image.<br/>
           If you use the <code>video</code> slot, this parameter will affect the positioning of the video, but will not change its aspect ratio. Videos are always 16:9.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>media_aspect_ratio</code>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          One of <code>'3-2'</code> or <code>'16-9'</code>
+        </td>
+        <td>
+          <code>'3-2'</code>
+        </td>
+        <td>
+          Aspect ratio to apply to media. Only applies to images, and is set to `cinematic` when `is_media_full_width` is true. Videos have `16-9` ratio always.
         </td>
       </tr>
     </tbody>

--- a/templates/docs/patterns/tiered-list/index.md
+++ b/templates/docs/patterns/tiered-list/index.md
@@ -200,6 +200,31 @@ When embedding a video with the Jinja macro, follow the following guidelines:
 View example of the tiered list pattern
 </a></div>
 
+#### Lite YouTube video
+
+To embed a YouTube video with the [lite-youtube](https://github.com/justinribeiro/lite-youtube) custom element instead of a standard iframe,
+pass `video_id` (and ideally `video_title`) in `video_attrs` instead of `src`:
+
+```json
+"video_attrs": {
+  "video_id": "id of the YouTube video",
+  "video_title": "title of the video, used for accessibility",
+  "class": "additional classes"
+}
+```
+
+Any other keys are forwarded as attributes onto the `lite-youtube` element. `posterquality` defaults to `maxresdefault`.
+
+The `lite-youtube` script is not bundled with Vanilla, so it must be loaded on the page for the video to be playable:
+
+```html
+<script type="module" src="https://cdn.jsdelivr.net/npm/@justinribeiro/lite-youtube@1.9.0/lite-youtube.min.js"></script>
+```
+
+<div class="embedded-example"><a href="/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-lite-youtube-video" class="js-example" data-lang="jinja">
+View example of the tiered list pattern
+</a></div>
+
 ## Jinja Macro
 
 The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. The API for the macro is shown below.
@@ -319,8 +344,8 @@ The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. 
         <td><code>{}</code></td>
         <td>
           Video to display near the description.<br/>
-          Must have the class <code><a href="/docs/utilities/embedded-media">u-embedded-media__element</a></code>.<br/>
-          Takes precedence over the <code>image</code> slot, so if both are used, the <code>video</code> will be displayed instead of the <code>image</code>.
+          Pass <code>src</code> to render an iframe embed.<br/>
+          Pass <code>video_id</code> (and ideally <code>video_title</code>) instead to render a <code>lite-youtube</code> embed.<br/>
         </td>
       </tr>
       <tr>

--- a/templates/docs/patterns/tiered-list/index.md
+++ b/templates/docs/patterns/tiered-list/index.md
@@ -25,7 +25,7 @@ The tiered list pattern is composed of the following elements:
 
 | Element               | Description                                                                         |
 | --------------------- | ----------------------------------------------------------------------------------- |
-| Title (**required**)  | <code>h2</code> title text                                                          |
+| Title                 | <code>h2</code> title text                                                          |
 | Description           | <code>p</code> description text with optional [CTA block](/docs/patterns/cta-block) |
 | Media (optional)      | Image or video to show near description                                             |
 | List item title       | Title text/content                                                                  |
@@ -124,8 +124,6 @@ You can embed a [default width](#default-width-image) or [full width](#full-widt
 The image may be positioned before or after the description, depending on the variant you choose.
 The aspect ratio of the image depends on the variant you choose, and it will be wrapped in an [image container](/docs/patterns/images#image-container-with-aspect-ratio) to ensure it maintains the correct aspect ratio.
 
-**Always apply the `p-image-container__image` class to your image** to ensure the image is styled correctly.
-
 ```json
 "img_attrs": {
   "src": "image-url",
@@ -135,6 +133,8 @@ The aspect ratio of the image depends on the variant you choose, and it will be 
   "class": "additional image classes"
 }
 ```
+
+**`img_attrs`**: Dictionary of image attributes (src, alt, class, etc.). The `p-image-container__image` class is automatically applied. See [attribute forwarding docs](/docs/building-vanilla#attribute-forwarding) for more info.
 
 #### Default width image
 
@@ -383,7 +383,7 @@ The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. 
       </tr>
       <tr>
         <td>
-          <code>hide_medium</code>
+          <code>hide_media_on_small_medium_breakpoints</code>
         </td>
         <td>
           No
@@ -395,12 +395,12 @@ The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. 
           <code>'false'</code>
         </td>
         <td>
-          Whether to hide media on medium screens
+          Whether to hide media on medium and small screens
         </td>
       </tr>
       <tr>
         <td>
-          <code>hide_small</code>
+          <code>is_media_highlighted</code>
         </td>
         <td>
           No
@@ -412,7 +412,7 @@ The `vf_tiered_list` Jinja macro can be used to generate a tiered list pattern. 
           <code>'false'</code>
         </td>
         <td>
-          Whether to hide media on small screens
+          Whether to apply the "is-highlighted" class to the media container. Only applies to images
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
## Done

- Updated Tiered list pattern to include media support
- Includes full width (before/after description) media support
- Include content-width (before/after description) media support

Fixes [WD-37057](https://warthogs.atlassian.net/browse/WD-37057)
Implements [figma](https://www.figma.com/design/ffN7Dx2T63Fz7au5gxKw4j/Tiered-List-Images?node-id=2004-769&p=f&m=dev)

## QA

- Review [release notes](https://vanilla-framework-5817.demos.haus/docs/whats-new)
- Review [Tiered list docs](https://vanilla-framework-5817.demos.haus/docs/patterns/tiered-list#with-media-new)
- Review following specific new examples
  - [full width image before description](https://vanilla-framework-5817.demos.haus/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-image-before-description)
  - [full width image after description](https://vanilla-framework-5817.demos.haus/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-image-after-description)
  - [Default width image before description](https://vanilla-framework-5817.demos.haus/docs/examples/patterns/tiered-list/50-50-desktop-with-image-before-description)
  - [Default width image after description](https://vanilla-framework-5817.demos.haus/docs/examples/patterns/tiered-list/50-50-desktop-with-image-after-description)
   - [Default width image after cta](https://vanilla-framework-5817.demos.haus/docs/examples/patterns/tiered-list/50-50-desktop-with-image-after-cta)
  - [full width video before description](https://vanilla-framework-5817.demos.haus/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-video-before-description)
  - [full width video after description](https://vanilla-framework-5817.demos.haus/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-video-after-description)
  - [full width video with lite-youtube package](https://vanilla-framework-5817.demos.haus/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-lite-youtube-video)
  - [Media within list items](https://vanilla-framework-5817.demos.haus/docs/examples/patterns/tiered-list/50-50-desktop-with-media-in-list-items)
  - [full width media hidden on small and medium breakpoints](https://vanilla-framework-5817.demos.haus/docs/examples/patterns/tiered-list/50-50-desktop-with-full-width-media-hidden-on-small-medium-breakpoints)
 - Review [combined examples](https://vanilla-framework-5817.demos.haus/docs/examples/patterns/tiered-list/combined)

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [ ] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


[WD-37057]: https://warthogs.atlassian.net/browse/WD-37057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ