### PR TITLE
fix: fix table sorting for numeric and alphanumeric values

### DIFF
--- a/templates/docs/examples/patterns/tables/_script-sorting.js
+++ b/templates/docs/examples/patterns/tables/_script-sorting.js
@@ -45,18 +45,17 @@ function sortTable(header, table) {
       return a.getAttribute('data-index') - b.getAttribute('data-index');
     });
   } else {
-    // Sort based on a cell contents
+    // Enables natural alphanumeric sorting (e.g., "2 GiB" comes before "3 GiB") 
+    var collator = new Intl.Collator(undefined, ({numeric: true, sensitivity: "base"}))
+
     newRows.sort(function (rowA, rowB) {
       // Trim the cell contents.
       var contentA = rowA.cells[col].textContent.trim();
       var contentB = rowB.cells[col].textContent.trim();
 
+      // Compares the strings naturally and applies the sorting direction (ascending/descending)
       // Based on the direction, do the sort.
-      //
-      // This example only sorts based on alphabetical order, to sort based on
-      // number value a more specific implementation would be needed, to provide
-      // number parsing and comparison function between text strings and numbers.
-      return contentA < contentB ? direction : -direction;
+      return collator.compare(contentA, contentB) * direction;
     });
   }
   // Append each row into the table, replacing the current elements.


### PR DESCRIPTION
## Done

- The sorting logic has been changed in `templates/docs/examples/patterns/tables/_script-sorting.js`

Fixes [list issues/bugs if needed]

Fixed #5742 

## QA 
- Demo

*Numeric Values*

<img width="1833" height="749" alt="sorting-table-cores" src="https://github.com/user-attachments/assets/e944d0e2-4346-440d-81b0-d5eeaf65477d" />

*Alphanumeric Values*

<img width="1833" height="749" alt="sorting-table-ram" src="https://github.com/user-attachments/assets/e16b4139-1359-4518-b1cc-32dfff230aff" />

- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Bug 🐛`.
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
