### PR TITLE
feat: hero pattern amendment with chip

### DIFF
--- a/templates/_macros/shared/vf_chip-block.jinja
+++ b/templates/_macros/shared/vf_chip-block.jinja
@@ -1,0 +1,38 @@
+{#- 
+Helper macro to render a chip block.
+    Params
+        - content: The inner HTML for the chip button.
+        - chip_type: "branded" | "default" (default is "branded")
+        - attrs: A dictionary of attributes to apply to the button or link.
+ #}
+
+ {% macro vf_chip_block(content="", chip_type="branded", attrs={}) %}
+    {%- set chip_element_tag = "span" -%}
+
+    {%- if chip_type == "default" %}
+        {%- set chip_element_tag = "button" -%}
+    {%- endif -%}
+
+    {%- set chip_class = "" -%}
+    {%- if chip_type == "branded" -%}
+        {%- set chip_class = "p-chip--branded" -%}
+    {%- elif chip_type == "default" -%}
+        {%- set chip_class = "p-chip" -%}
+    {%- endif -%}
+
+    
+    <{{ chip_element_tag }} class="{{ chip_class }} {{ attrs.get('class', '') }}"
+    {%- for attr, value in attrs.items() -%}
+        {% if attr != "class" %}
+            {{ attr }}="{{ value }}"
+        {%- endif -%}
+    {%- endfor -%}
+    >
+        {%- if chip_type == "branded" -%}
+            <i class="p-icon--circle-of-friends"></i>
+            <span class="p-chip__value">{{- content | safe -}}</span>
+        {%- elif chip_type == "default" -%}
+            <span class="p-chip__value">{{- content | safe -}}</span>
+        {%- endif -%}
+    </{{ chip_element_tag }}>
+{% endmacro %}

--- a/templates/_macros/vf_hero.jinja
+++ b/templates/_macros/vf_hero.jinja
@@ -1,5 +1,6 @@
 {% from "_macros/shared/vf_cta-block.jinja" import vf_cta_block %}
 {% from "_macros/vf_basic-section.jinja" import vf_basic_section_blocks %}
+{% from "_macros/shared/vf_chip-block.jinja" import vf_chip_block %}
 
 # Params
 # title_text: Hero title text (required)
@@ -9,7 +10,7 @@
 #   If false, the layout is stacked on tablet.
 #   If true, the layout is split on tablet.
 # display_blank_signpost_image_space: whether to indent the content for 25/75 layout on large screens.
-# blocks: list of content blocks for the hero section. Includes description, cta, image, and signpost_image blocks.
+# blocks: list of content blocks for the hero section. Includes description, cta, image, chip and signpost_image blocks.
 # Slots
 # description (deprecated): paragraph-style content below the title and subtitle
 # cta (deprecated): call-to-action block below the description
@@ -27,6 +28,7 @@
   {%- set cta_block = blocks | selectattr("type", "equalto", "cta-block") | list | first | default(None) -%}
   {%- set image_block = blocks | selectattr("type", "equalto", "image") | list | first | default(None) -%}
   {%- set signpost_image_block = blocks | selectattr("type", "equalto", "signpost_image") | list | first | default(None) -%}
+  {%- set chip_block = blocks | selectattr("type", "equalto", "chip-block") | list | first | default(None) -%}
 
   {% set has_subtitle = subtitle_text|trim|length > 0 %}
   {% set description_content = caller('description') %}
@@ -37,6 +39,7 @@
   {% set has_image = image_block or image_content|trim|length > 0 %}
   {% set signpost_image_content = caller('signpost_image') %}
   {% set has_signpost_image = signpost_image_block or signpost_image_content|trim|length > 0 or display_blank_signpost_image_space %}
+  {% set has_chip = chip_block %}
 
   {#- User can pass layout as "X-Y" or "X/Y" -#}
   {% set layout = layout | trim | replace('/', '-') %}
@@ -129,6 +132,15 @@
     {% endif %}
   {%- endmacro %}
 
+  {%- macro _hero_chip_block() -%}
+  <div class="p-section--shallow">
+    {%- if has_chip -%}
+      {%- set chip_data = chip_block.get("item", {}) -%}
+        {{- vf_chip_block(content=chip_data.get("content",""),chip_type=chip_data.get("chip_type","branded"),attrs=chip_data.get("attrs",{})) -}}
+    {%- endif -%}
+  </div>
+  {%- endmacro -%}
+  
   {%- macro _hero_image_block() -%}
     {%- if image_block -%}
       {{- vf_basic_section_blocks(items=[image_block], override_last_item_padding=true) -}}
@@ -164,6 +176,7 @@
       {%- if is_fallback -%}
         <div class="{{ col_classes[0] }}">
           {{- _hero_description_block() -}}
+          {{- _hero_chip_block() -}}
           {{ _hero_cta_block() -}}
         </div>
         {% if has_image -%}
@@ -182,6 +195,7 @@
             </div>
           {% endif %}
           {{- _hero_description_block() -}}
+          {{- _hero_chip_block() -}}
           {{- _hero_cta_block() -}}
         </div>
         {{ _hero_image_block() }}
@@ -196,6 +210,7 @@
             {{ _hero_subtitle_block() -}}
           </div>
           {{- _hero_description_block() -}}
+          {{- _hero_chip_block() -}}
           {{- _hero_cta_block() -}}
         </div>
         {% if has_image %}
@@ -209,6 +224,7 @@
             {{ _hero_subtitle_block() -}}
           </div>
           {{- _hero_description_block() -}}
+          {{- _hero_chip_block() -}}
           {{- _hero_cta_block() -}}
         </div>
         {% if has_image -%}

--- a/templates/docs/examples/patterns/hero/combined.html
+++ b/templates/docs/examples/patterns/hero/combined.html
@@ -24,5 +24,7 @@
 <section>{% include 'docs/examples/patterns/hero/hero-75-25.html' %}</section>
 <section>{% include 'docs/examples/patterns/hero/hero-fallback.html' %}</section>
 <section>{% include 'docs/examples/patterns/hero/hero-50-50-no-image.html' %}</section>
+<section>{% include 'docs/examples/patterns/hero/hero-with-chip.html' %}</section>
+<section>{% include 'docs/examples/patterns/hero/hero-with-chip-default.html' %}</section>
 {% endwith %}
 {% endblock %}

--- a/templates/docs/examples/patterns/hero/hero-with-chip-default.html
+++ b/templates/docs/examples/patterns/hero/hero-with-chip-default.html
@@ -1,0 +1,69 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+
+{% block title %}Hero / With Ordinary Chip{% endblock %}
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% set is_paper = true %}
+{% block content %}
+
+{% call(slot) vf_hero(
+  title_text='H1 - ideally one line, up to two',
+  subtitle_text='H2 placeholder - aim for one line, 2 is acceptable, more - use a paragraph',
+  layout='50/50',
+  blocks=[
+    {
+      "type": "description",
+      "padding": "shallow",
+      "item": {
+        "type": "text",
+        "content": "Generally, the height of the right hand side of a 50/50 split should contain more content than the left
+        hand side."
+      }
+    },
+    {
+        "type":"chip-block",
+        "padding":"shallow",
+        "item":{
+            "chip_type":"default",
+            "content":"Click below to learn more",
+            "attrs":{
+                "class":"p-chip--positive"
+            }
+        }
+    },
+    {
+      "type": "cta-block",
+      "padding": "shallow",
+      "item": {
+        "primary": {
+          "content_html": "Learn more",
+          "attrs": {
+            "href": "#"
+          }
+        },
+        "link": {
+          "content_html": "Contact us ›",
+          "attrs": {
+            "href": "#"
+          }
+        }
+      }
+    },
+    {
+      "type": "image",
+      "item": {
+        "aspect_ratio": "3-2",
+        "is_highlighted": false,
+        "is_cover": true,
+        "attrs": {
+          "src": "https://assets.ubuntu.com/v1/cf1e2ddb-datacenter-wide-crop.jpeg",
+          "alt": "alt-text"
+        }
+      }
+    },
+  ]
+) -%}
+{% endcall -%}
+
+{% endblock %}

--- a/templates/docs/examples/patterns/hero/hero-with-chip.html
+++ b/templates/docs/examples/patterns/hero/hero-with-chip.html
@@ -1,0 +1,66 @@
+{% extends "_layouts/examples.html" %}
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+
+{% block title %}Hero / With Chip{% endblock %}
+{% block standalone_css %}patterns_all{% endblock %}
+
+{% set is_paper = true %}
+{% block content %}
+
+{% call(slot) vf_hero(
+  title_text='H1 - ideally one line, up to two',
+  subtitle_text='H2 placeholder - aim for one line, 2 is acceptable, more - use a paragraph',
+  layout='50/50',
+  blocks=[
+    {
+      "type": "description",
+      "padding": "shallow",
+      "item": {
+        "type": "text",
+        "content": "Generally, the height of the right hand side of a 50/50 split should contain more content than the left
+        hand side."
+      }
+    },
+    {
+        "type":"chip-block",
+        "padding":"shallow",
+        "item":{
+            "chip_type":"branded",
+            "content":"Available with Ubunto Pro",
+        }
+    },
+    {
+      "type": "cta-block",
+      "padding": "shallow",
+      "item": {
+        "primary": {
+          "content_html": "Learn more",
+          "attrs": {
+            "href": "#"
+          }
+        },
+        "link": {
+          "content_html": "Contact us ›",
+          "attrs": {
+            "href": "#"
+          }
+        }
+      }
+    },
+    {
+      "type": "image",
+      "item": {
+        "aspect_ratio": "3-2",
+        "is_highlighted": false,
+        "is_cover": true,
+        "attrs": {
+          "src": "https://assets.ubuntu.com/v1/cf1e2ddb-datacenter-wide-crop.jpeg",
+          "alt": "alt-text"
+        }
+      }
+    },
+  ]
+) -%}
+{% endcall -%}
+
+{% endblock %}

--- a/templates/docs/patterns/hero/index.md
+++ b/templates/docs/patterns/hero/index.md
@@ -16,6 +16,7 @@ Depending on the size and composition of your content, you can choose from a var
 - [50/50 with no image](#5050-with-no-image)
 - [25/75 Signpost](#2575-signpost)
 - [75/25](#7525)
+- [With Chip](#with-chip)
 - [Fallback](#fallback)
 
 The hero pattern is composed of the following elements:
@@ -100,8 +101,26 @@ If you find that the image is too tall on small screens, you can use <code>.u-hi
 small screens.
 
 <div class="embedded-example"><a href="/docs/examples/patterns/hero/hero-75-25" class="js-example" data-lang="jinja">
-View example of the hero pattern in 50/50 split
+
 </a></div>
+
+## With Chip
+
+You can also add a chip with any layout. The default variant for the chip is branded.
+
+
+### With Chip Branded 
+
+<div class="embedded-example"><a href="/docs/examples/patterns/hero/hero-with-chip" class="js-example" data-lang="jinja">
+View example of the hero pattern with chip
+</a></div>
+
+### With Ordinary Chip
+
+<div class="embedded-example"><a href="/docs/examples/patterns/hero/hero-with-chip-default" class="js-example" data-lang="jinja">
+View example of the hero pattern with default chip variant
+</a></div>
+
 
 ## Fallback
 


### PR DESCRIPTION
## Done

- This PR adds a chip block to the hero pattern.
- There are two chip variants, branded and ordinary.
- The default variant for the chip is branded as mentioned in #5822 

Fixes #5822 


## QA
- Demo
<img width="1351" height="730" alt="Screenshot 2026-07-20 at 3 23 39 PM" src="https://github.com/user-attachments/assets/f2fc6c33-7d92-48c9-9ed2-9f7a91bfb326" />

<img width="1340" height="836" alt="Screenshot 2026-07-20 at 3 23 23 PM" src="https://github.com/user-attachments/assets/8539b977-2cfb-4606-8147-a216e9a17af0" />


- [Add QA steps]
- Review updated documentation:
  - [List any updated documentation for review]

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`
- [ ] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [ ] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
