### PR TITLE
Card pattern title height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.57.0",
+  "version": "4.58.0",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,4 +1,5 @@
 - version: 4.58.0
+  features:
     - component: Card
       url: /docs/patterns/content-card
       status: Updated

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,8 @@
+- version: 4.58.0
+    - component: Card
+      url: /docs/patterns/content-card
+      status: Updated
+      notes: Enforced equal height on the title/description section for image-on-top cards in in the same row  
 - version: 4.57.0
   features:
     - component: Tiered list

--- a/releases.yml
+++ b/releases.yml
@@ -3,7 +3,7 @@
     - component: Card
       url: /docs/patterns/content-card
       status: Updated
-      notes: Enforced equal height on the title/description section for image-on-top cards in in the same row  
+      notes: Enforced equal height on the title/description section for image-on-top cards in in the same row
 - version: 4.57.0
   features:
     - component: Tiered list

--- a/scss/_patterns_content-card.scss
+++ b/scss/_patterns_content-card.scss
@@ -697,9 +697,8 @@ $card-height-8col: 22rem;
 
     @include mq-min($breakpoint-large) {
       &.p-content-card--image-top.p-content-card--cols-6 {
-        /* Preserve content-driven row height at the large breakpoint. */
         height: auto;
-        min-height: 0;
+        min-height: $card-height-vertical;
       }
 
       &.p-content-card--image-top.p-content-card--cols-8.has-image {

--- a/scss/_patterns_content-card.scss
+++ b/scss/_patterns_content-card.scss
@@ -650,6 +650,7 @@ $card-height-8col: 22rem;
     @include mq-min($breakpoint-small) {
       &.p-content-card--image-top.p-content-card--cols-4,
       &.p-content-card--image-top.p-content-card--cols-6 {
+        flex: 1;
         flex-direction: column;
         height: auto;
         min-height: $card-height-vertical;
@@ -670,7 +671,16 @@ $card-height-8col: 22rem;
 
       &.p-content-card--image-top.p-content-card--cols-4 .p-content-card__body,
       &.p-content-card--image-top.p-content-card--cols-6 .p-content-card__body {
+        flex: 1;
         padding: 0 $sp-medium;
+      }
+
+      &.p-content-card--image-top.p-content-card--cols-4 .p-content-card__primary-content,
+      &.p-content-card--image-top.p-content-card--cols-6 .p-content-card__primary-content,
+      &.p-content-card--image-top.p-content-card--cols-4 .p-content-card__hover-content,
+      &.p-content-card--image-top.p-content-card--cols-6 .p-content-card__hover-content {
+        /* Size both layers from the tallest content and stretch them to match. */
+        align-self: stretch;
       }
 
       &.p-content-card--image-top.p-content-card--cols-4 .p-content-card__footer-outer,
@@ -687,8 +697,9 @@ $card-height-8col: 22rem;
 
     @include mq-min($breakpoint-large) {
       &.p-content-card--image-top.p-content-card--cols-6 {
+        /* Preserve content-driven row height at the large breakpoint. */
         height: auto;
-        min-height: $card-height-vertical;
+        min-height: 0;
       }
 
       &.p-content-card--image-top.p-content-card--cols-8.has-image {

--- a/scss/_patterns_content-card.scss
+++ b/scss/_patterns_content-card.scss
@@ -652,6 +652,7 @@ $card-height-8col: 22rem;
       &.p-content-card--image-top.p-content-card--cols-6 {
         flex: 1;
         flex-direction: column;
+        gap: 0;
         height: auto;
         min-height: $card-height-vertical;
         padding: 0;
@@ -672,7 +673,7 @@ $card-height-8col: 22rem;
       &.p-content-card--image-top.p-content-card--cols-4 .p-content-card__body,
       &.p-content-card--image-top.p-content-card--cols-6 .p-content-card__body {
         flex: 1;
-        padding: 0 $sp-medium;
+        padding: 0 $sp-medium var(--spacing-vertical-small, $sp-small);
       }
 
       &.p-content-card--image-top.p-content-card--cols-4 .p-content-card__primary-content,
@@ -724,6 +725,10 @@ $card-height-8col: 22rem;
 
       &.p-content-card--image-top.p-content-card--cols-8.has-image .p-content-card__content {
         grid-column: unset;
+      }
+
+      &.p-content-card--image-top.p-content-card--cols-8.has-image .p-content-card__body {
+        padding: 0 $sp-medium;
       }
     }
   }

--- a/templates/docs/examples/patterns/content-card/2-column-no-image.html
+++ b/templates/docs/examples/patterns/content-card/2-column-no-image.html
@@ -8,7 +8,46 @@
 <div class="grid-row">
   {{ vf_card(
     columns="2",
-    link="https://www.ubuntu.com",
+    link="#",
+    heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
+    footer={
+      "resource_type": {
+        "icon": "topic",
+        "text": "Whitepaper"
+      },
+      "content_type": "Developers and community"
+    },
+    description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+  ) }}
+  {{ vf_card(
+    columns="2",
+    link="#",
+    heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
+    footer={
+      "resource_type": {
+        "icon": "topic",
+        "text": "Whitepaper"
+      },
+      "content_type": "Developers and community"
+    },
+    description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+  ) }}
+  {{ vf_card(
+    columns="2",
+    link="#",
+    heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
+    footer={
+      "resource_type": {
+        "icon": "topic",
+        "text": "Whitepaper"
+      },
+      "content_type": "Developers and community"
+    },
+    description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+  ) }}
+  {{ vf_card(
+    columns="2",
+    link="#",
     heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
     footer={
       "resource_type": {

--- a/templates/docs/examples/patterns/content-card/2-column.html
+++ b/templates/docs/examples/patterns/content-card/2-column.html
@@ -9,7 +9,64 @@
   {{ vf_card(
     columns="2",
     heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
-    link="https://www.ubuntu.com",
+    link="#",
+    image={
+      "src": "https://assets.ubuntu.com/v1/010995f2-an_canonical_announces_ubuntu_pro_for_wsl_dark.png",
+      "alt": "Ubuntu Pro WSL Dark"
+    },
+    author="Canonical",
+    date="10 July 2025",
+    footer={
+      "resource_type": {
+        "icon": "topic",
+        "text": "Whitepaper"
+      },
+      "content_type": "Developers and community"
+    },
+    description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+  ) }}
+  {{ vf_card(
+    columns="2",
+    heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
+    link="#",
+    image={
+      "src": "https://assets.ubuntu.com/v1/010995f2-an_canonical_announces_ubuntu_pro_for_wsl_dark.png",
+      "alt": "Ubuntu Pro WSL Dark"
+    },
+    author="Canonical",
+    date="10 July 2025",
+    footer={
+      "resource_type": {
+        "icon": "topic",
+        "text": "Whitepaper"
+      },
+      "content_type": "Developers and community"
+    },
+    description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+  ) }}
+  {{ vf_card(
+    columns="2",
+    heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
+    link="#",
+    image={
+      "src": "https://assets.ubuntu.com/v1/010995f2-an_canonical_announces_ubuntu_pro_for_wsl_dark.png",
+      "alt": "Ubuntu Pro WSL Dark"
+    },
+    author="Canonical",
+    date="10 July 2025",
+    footer={
+      "resource_type": {
+        "icon": "topic",
+        "text": "Whitepaper"
+      },
+      "content_type": "Developers and community"
+    },
+    description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+  ) }}
+  {{ vf_card(
+    columns="2",
+    heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
+    link="#",
     image={
       "src": "https://assets.ubuntu.com/v1/010995f2-an_canonical_announces_ubuntu_pro_for_wsl_dark.png",
       "alt": "Ubuntu Pro WSL Dark"

--- a/templates/docs/examples/patterns/content-card/4-column-image-top.html
+++ b/templates/docs/examples/patterns/content-card/4-column-image-top.html
@@ -8,8 +8,26 @@
 <div class="grid-row">
   {{ vf_card(
     columns="4",
-    link="https://www.ubuntu.com",
-    heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
+    link="#",
+    heading="Canonical announces Charmed Feast",
+    image={
+      "src": "https://assets.ubuntu.com/v1/010995f2-an_canonical_announces_ubuntu_pro_for_wsl_dark.png",
+      "alt": "Ubuntu Pro WSL Dark"
+    },
+    footer={
+      "resource_type": {
+        "icon": "topic",
+        "text": "Whitepaper"
+      },
+      "content_type": "Developers and community"
+    },
+    description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+    stacked_image=True
+  ) }}
+  {{ vf_card(
+    columns="4",
+    link="#",
+    heading="Canonical announces Charmed Feast",
     image={
       "src": "https://assets.ubuntu.com/v1/010995f2-an_canonical_announces_ubuntu_pro_for_wsl_dark.png",
       "alt": "Ubuntu Pro WSL Dark"

--- a/templates/docs/examples/patterns/content-card/4-column-multiple-chips.html
+++ b/templates/docs/examples/patterns/content-card/4-column-multiple-chips.html
@@ -8,7 +8,23 @@
 <div class="grid-row">
   {{ vf_card(
     columns="4",
-    link="https://www.ubuntu.com",
+    link="#",
+    heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
+    image={
+      "src": "https://assets.ubuntu.com/v1/010995f2-an_canonical_announces_ubuntu_pro_for_wsl_dark.png",
+      "alt": "Ubuntu Pro WSL Dark"
+    },
+    footer={
+      "resource_type": {
+        "icon": "topic",
+        "text": "Whitepaper"
+      },
+      "content_type": ["Developers", "Community", "Cloud"]
+    }
+  ) }}
+  {{ vf_card(
+    columns="4",
+    link="#",
     heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
     image={
       "src": "https://assets.ubuntu.com/v1/010995f2-an_canonical_announces_ubuntu_pro_for_wsl_dark.png",

--- a/templates/docs/examples/patterns/content-card/4-column-no-image.html
+++ b/templates/docs/examples/patterns/content-card/4-column-no-image.html
@@ -8,7 +8,20 @@
 <div class="grid-row">
   {{ vf_card(
     columns="4",
-    link="https://www.ubuntu.com",
+    link="#",
+    heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
+    footer={
+      "resource_type": {
+        "icon": "topic",
+        "text": "Whitepaper"
+      },
+      "content_type": "Developers and community"
+    },
+    description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+  ) }}
+  {{ vf_card(
+    columns="4",
+    link="#",
     heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
     footer={
       "resource_type": {

--- a/templates/docs/examples/patterns/content-card/4-column.html
+++ b/templates/docs/examples/patterns/content-card/4-column.html
@@ -8,7 +8,24 @@
 <div class="grid-row">
   {{ vf_card(
     columns="4",
-    link="https://www.ubuntu.com",
+    link="#",
+    heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
+    image={
+      "src": "https://assets.ubuntu.com/v1/010995f2-an_canonical_announces_ubuntu_pro_for_wsl_dark.png",
+      "alt": "Ubuntu Pro WSL Dark"
+    },
+    footer={
+      "resource_type": {
+        "icon": "topic",
+        "text": "Whitepaper"
+      },
+      "content_type": "Developers and community"
+    },
+    description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+  ) }}
+  {{ vf_card(
+    columns="4",
+    link="#",
     heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
     image={
       "src": "https://assets.ubuntu.com/v1/010995f2-an_canonical_announces_ubuntu_pro_for_wsl_dark.png",

--- a/templates/docs/examples/patterns/content-card/6-column.html
+++ b/templates/docs/examples/patterns/content-card/6-column.html
@@ -8,7 +8,7 @@
 <div class="grid-row">
   {{ vf_card(
     columns="6",
-    link="https://www.ubuntu.com",
+    link="#",
     heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
     image={
       "src": "https://assets.ubuntu.com/v1/010995f2-an_canonical_announces_ubuntu_pro_for_wsl_dark.png",

--- a/templates/docs/examples/patterns/content-card/8-column.html
+++ b/templates/docs/examples/patterns/content-card/8-column.html
@@ -8,7 +8,7 @@
 <div class="grid-row">
   {{ vf_card(
     columns="8",
-    link="https://www.ubuntu.com",
+    link="#",
     heading="Canonical announces Charmed Feast: A production-grade feature store for your open source MLOps stack",
     image={
       "src": "https://assets.ubuntu.com/v1/010995f2-an_canonical_announces_ubuntu_pro_for_wsl_dark.png",

--- a/templates/docs/patterns/content-card/index.md
+++ b/templates/docs/patterns/content-card/index.md
@@ -10,8 +10,6 @@ context:
 
 The **Card** pattern is a rich, responsive, highly structured card variant designed to display heavily contextual items like articles, webinars, announcements, or whitepapers. It supports custom column spans and fluidly adjusts its layout between vertical and horizontal orientations depending on the space available.
 
-Responsive by design, the larger horizontal variants are built to adapt to screen real estate: **6-column cards collapse down to 4 columns and eventually 2 columns** on smaller screens, while **4-column cards collapse down to 2 columns**. The **8-column card** spans the full grid width with a 50/50 desktop split and collapses to a vertical stack on smaller screens.
-
 The Card pattern is composed of the following elements:
 
 | Element                | Description                                                                    |

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -12,7 +12,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Stylesheet size',
       benchmark: 150000,
-      threshold: 558424,
+      threshold: 559001,
       result: results['total-stylesheet-size'],
     },
     {


### PR DESCRIPTION
## Done

- enforce equal height of title sections for cards on the same row

fly-by:
- remove active links from examples
- add more cards to examples to demo responsiveness
- remove description about responsiveness (this can be assumed for all patterns)

## QA

- Open [demo](https://vanilla-framework-5832.demos.haus/docs/patterns/content-card#4-column-card-with-image-top)
- See that the cards for '4-Column Card with Image Top' have equal height `p-content-card__body` sections despite differing lengths of hover text.
- Using dev tools change the title length, description length - the body height should remain the same across both cards, based on the tallest content.

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]
