### PR TITLE
Fix spacing between muted rule and border/image on 8-col content card

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.58.0",
+  "version": "4.58.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/releases.yml
+++ b/releases.yml
@@ -1,3 +1,9 @@
+- version: 4.58.1
+  features:
+    - component: Content card
+      url: /docs/patterns/content-card
+      status: Updated
+      notes: Added spacing between the muted rule and the card border/image for the 8-column layout on large screens, and removed redundant CSS from the image-top variant
 - version: 4.58.0
   features:
     - component: Card

--- a/scss/_patterns_content-card.scss
+++ b/scss/_patterns_content-card.scss
@@ -459,6 +459,14 @@ $card-height-8col: 22rem;
       .p-content-card--cols-8 & {
         width: 100%;
       }
+
+      @include mq-min($breakpoint-large) {
+        .p-content-card--cols-8 & .p-rule--muted {
+          margin-left: $sp-medium;
+          margin-right: $sp-medium;
+          width: calc(100% - #{$sp-medium} * 2);
+        }
+      }
     }
 
     &__footer-outer {
@@ -565,7 +573,6 @@ $card-height-8col: 22rem;
           grid-row: 1 / -1;
           height: 100%;
           padding: 0.5rem;
-          padding-bottom: 0;
           width: 100%;
         }
       }
@@ -710,21 +717,13 @@ $card-height-8col: 22rem;
       }
 
       &.p-content-card--image-top.p-content-card--cols-8.has-image .p-content-card__image-wrapper {
-        grid-column: unset;
-        grid-row: unset;
         height: auto;
         padding: 0;
-        padding-bottom: var(--spacing-vertical-large, $sp-medium);
-        width: 100%;
       }
 
       &.p-content-card--image-top.p-content-card--cols-8.has-image .p-content-card__image {
         aspect-ratio: 16/9;
         height: auto;
-      }
-
-      &.p-content-card--image-top.p-content-card--cols-8.has-image .p-content-card__content {
-        grid-column: unset;
       }
 
       &.p-content-card--image-top.p-content-card--cols-8.has-image .p-content-card__body {

--- a/scss/_patterns_content-card.scss
+++ b/scss/_patterns_content-card.scss
@@ -464,7 +464,7 @@ $card-height-8col: 22rem;
         .p-content-card--cols-8 & .p-rule--muted {
           margin-left: $sp-medium;
           margin-right: $sp-medium;
-          width: calc(100% - #{$sp-medium} * 2);
+          width: auto;
         }
       }
     }


### PR DESCRIPTION
## Done

- Added a 1rem gap between the `.p-rule--muted` footer divider and the card border/image for the 8-column 
- Bumped Vanilla version to `4.58.1` and updated `releases.yml`

Fixes WD-38501

## QA

- Open [demo](https://vanilla-framework-5835.demos.haus/docs/patterns/content-card)
- Go to the Content card docs page and view the 8-column example
- Resize to a large screen (`>= 1281px` / desktop breakpoint) and confirm the muted `<hr>` above the footer now has visible spacing (1rem) from both the card border and the image, instead of touching them
- Review updated documentation:
  - [Content card docs](/docs/patterns/content-card)

### Check if PR is ready for release

If this PR contains Vanilla SCSS or macro code changes, it should contain the following changes to make sure it's ready for the release:

- [x] PR should have one of the following labels to automatically categorise it in release notes:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] Vanilla version in `package.json` should be updated relative to the [most recent release](https://github.com/canonical/vanilla-framework/releases/latest), following semver convention
  - if existing APIs (CSS classes & macro APIs) are not changed it can be a bugfix release (x.x.**X**)
  - if existing APIs (CSS classes & macro APIs) are changed/added/removed it should be a minor version (x.**X**.0)
  - see the [wiki for more details](https://github.com/canonical/vanilla-framework/wiki/Release-process#pre-release-tasks)
- [x] Any changes to component class names (new patterns, variants, removed or added features) or macros should be listed on the [what's new page](https://github.com/canonical/vanilla-framework/blob/main/releases.yml).


## Screenshots

[if relevant, include a screenshot or screen capture]