### PR TITLE
fix: style the baseline grid toggle on standalone examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.59.0",
+  "version": "4.59.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_switch.scss
+++ b/scss/_patterns_switch.scss
@@ -19,7 +19,9 @@ $knob-size: $sp-unit * 2;
     }
 
     &:disabled + .p-switch__slider {
-      @extend %vf-disabled-element;
+      // Optional: the placeholder only exists when base form styles are
+      // compiled alongside, which standalone contexts don't do.
+      @extend %vf-disabled-element !optional;
     }
 
     &:checked + .p-switch__slider {

--- a/scss/docs/example.scss
+++ b/scss/docs/example.scss
@@ -4,6 +4,7 @@
 @include vf-u-baseline-grid;
 @include vf-b-button;
 @include vf-p-segmented-control;
+@include vf-p-switch;
 @include vf-p-forms-inline;
 
 // stylelint-disable selector-max-type -- examples can use type selectors


### PR DESCRIPTION
## Done

- Compile the switch styles into the standalone examples stylesheet, following the triage suggestion to include them the same way as the theme switch segmented control, so the baseline grid toggle renders as a proper switch
- Make the switch pattern's disabled-state `@extend` optional, so the pattern also compiles in contexts that do not compile the base form styles alongside; the missing `%vf-disabled-element` placeholder is what failed CI on the previous attempt (#5684)
- Bump version to 4.59.1

Fixes #5286

## QA

- Open a standalone example that does not import the switch on its own, for example `/docs/examples/standalone/patterns/buttons/combined?theme=light`
- Verify the "Toggle baseline grid" control at the bottom renders as a styled switch instead of a bare checkbox, and still toggles the baseline grid
- Verify a standalone example that does import the switch styles is unchanged
- The compiled library CSS is unaffected: after a full `yarn build-scss`, `build/css/docs/example.css` is the only output file whose content changes. Every build that compiles the base form styles still defines the placeholder, so the extend behaves exactly as before there

### Check if PR is ready for release

- [ ] `Bug 🐛` label (I cannot set labels on this repository)
- [x] Version bumped to 4.59.1: bugfix only, no CSS class or macro API changes
- [x] No component class name or macro changes, so no `releases.yml` entry needed
