### PR TITLE
fix: stop the modal docs page from scrolling to the embedded example

### DIFF
--- a/templates/docs/examples/patterns/modal/_script.js
+++ b/templates/docs/examples/patterns/modal/_script.js
@@ -28,7 +28,10 @@
   function attemptFocus(child) {
     if (child.focus) {
       ignoreFocusChanges = true;
-      child.focus();
+      // Focusing without scrolling: when the example is embedded in the
+      // documentation page, Firefox would otherwise scroll that page down
+      // to the focused element.
+      child.focus({preventScroll: true});
       ignoreFocusChanges = false;
       return document.activeElement === child;
     }


### PR DESCRIPTION
## Done

- Focus elements inside the modal example with `preventScroll`, so the documentation page no longer scrolls down to the "With footer" example on load. The standalone examples keep focusing the open modal on load, which is the accessibility behaviour that must stay (WCAG SC 2.4.3), and the focus trap and Escape handling are unchanged

Fixes #5119

## QA

- Open `/docs/patterns/modal` in Firefox: the page stays at the top instead of scrolling to the close button of the "With footer" example
- Open `/docs/examples/patterns/modal/footer/` directly: the close button of the open modal is focused on load, as before
- Press Tab repeatedly inside that example: focus cycles between the three modal buttons and never leaves the modal; Escape closes it and returns focus to the "Show modal" button
- Same checks in Chrome, where the scroll never happened, behave as before

Verified in headless Firefox 153 and Chromium 151 against a local build: before the change the documentation page loads scrolled 1166px down with the iframe's close button focused, after it the page loads at 0px with the same element focused inside the example.

`preventScroll` is ignored by browsers that predate it, which simply leaves them with today's behaviour.

### Check if PR is ready for release

- [ ] `Bug 🐛` label (I cannot set labels on this repository)
- [x] No Vanilla SCSS or macro change, so no version bump and no `releases.yml` entry: this only touches the documentation example script
