### PR TITLE
fix: keep the pull quote closing mark next to the text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-framework",
-  "version": "4.59.0",
+  "version": "4.59.1",
   "author": {
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"

--- a/scss/_patterns_pull-quotes.scss
+++ b/scss/_patterns_pull-quotes.scss
@@ -58,9 +58,17 @@
     &:last-of-type::after {
       @include vf-quote-mark;
 
-      bottom: 0.55em;
+      // Kept in the inline flow so the mark always follows the last
+      // character: positioned absolutely, it takes the static position of
+      // the next line when the paragraph ends with a line break and lands
+      // over the text. The zero line height and the negative margin keep it
+      // out of line box sizing and wrapping.
+      bottom: 0.35em;
       content: '\201E';
+      line-height: 0;
       margin-left: 0.25em;
+      margin-right: -0.75em;
+      position: relative;
     }
   }
 
@@ -86,6 +94,10 @@
       &::before,
       &::after {
         font-size: 1.5em;
+      }
+
+      &::after {
+        bottom: 0.475em;
       }
     }
   }

--- a/tests/parker.js
+++ b/tests/parker.js
@@ -12,7 +12,7 @@ function generateMetrics(file, metricsArray) {
     {
       name: 'Stylesheet size',
       benchmark: 150000,
-      threshold: 559133,
+      threshold: 559175,
       result: results['total-stylesheet-size'],
     },
     {


### PR DESCRIPTION
## Done

- Keep the pull quote closing mark in the inline flow instead of positioning it absolutely. Positioned absolutely, the mark takes the static position of the next line whenever the quote paragraph ends with a line break, then `bottom` pulls it back up over the start of the last line. Kept inline, with a zero line height and a negative margin so it has no line box or wrapping footprint, it always follows the last character
- Give the small variant its own vertical offset, so every size renders exactly where it did
- Raise the parker stylesheet size threshold by the 42 bytes this adds
- Bump version to 4.59.1

Fixes #5711

## QA

- Open the standalone examples `default`, `small` and `large`: they are pixel identical to `main` at 375, 768, 1024 and 1280px wide
- Open `default-image` at 768px wide and `variants` at 375px wide on `main`: the closing mark is drawn over the first word of the last line ("my deployment.", "to use."). On this branch the mark follows the last word, and the last line breaks where the text actually fits. Those are the only visual differences Percy should report, together with sub pixel anti aliasing on the marks of the multi quote examples
- Paste the markup from #5711 into a page and end the quote paragraph with `<br>`, as WordPress does when the paragraph ends with a newline: on `main` the mark lands over the first word of the last line in Chrome, Firefox and Safari; on this branch it stays after the text

About the report itself: the closing quote rendered twice on ubuntu.com because the article's text also contained a typographic closing quote, which the pattern does not (and cannot) remove; the article has since been reworked and no longer uses the pattern. The overlap seen in Chrome is the positioning defect fixed here, and it reproduces in the framework's own examples without any WordPress involvement.

Verified in headless Chromium 151, Firefox 153 and WebKit (Playwright 1.55) against a local build.

### Check if PR is ready for release

- [ ] `Bug 🐛` label (I cannot set labels on this repository)
- [x] Version bumped to 4.59.1: bugfix only, no CSS class or macro API changes (same bump as #5836, whichever lands second will need the trivial rebase)
- [x] No class name or macro change, so no `releases.yml` entry
