### PR TITLE
fix(docs): correct broken anchor links in README and contributor guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,8 @@ Please provide as much information possible detailing what you're currently expe
 
 - [Pre release tasks](/guides/release-process.md#pre-release-tasks)
 - [Releasing](/guides/release-process.md#releasing)
-- [Deploying vanillaframework.io](/guides/release-process.md#deploy-vanillaframeworkio)
-- [Releasing React Components](/guides/release-process.md#react-components)
+- [Deploying vanillaframework.io](/guides/release-process.md#deploying-vanillaframeworkio)
+- [Releasing React Components](/guides/release-process.md#releasing-react-components)
 - [Promotion](/guides/release-process.md#promotion)
 
 ## Licenses

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Vanilla Framework is an extensible CSS framework, built using [Sass](http://sass
 
 - [Using Vanilla](#using-vanilla)
   - [Hotlinking](#hotlinking)
-  - [Including Vanilla in your project via NPM](#including-vanilla-in-your-project-via-npm)
+  - [Including Vanilla in your project via NPM or yarn](#including-vanilla-in-your-project-via-npm-or-yarn)
 - [Developing Vanilla](#developing-vanilla)
 - [Community](#community)
 

--- a/guides/release-process.md
+++ b/guides/release-process.md
@@ -8,7 +8,7 @@
   - [Releasing to NPM](#releasing-to-npm)
   - [Releasing to assets server](#releasing-to-assets-server)
 - [Deploying vanillaframework.io](#deploying-vanillaframeworkio)
-- [Releasing React Components](#react-components)
+- [Releasing React Components](#releasing-react-components)
 - [Promotion](#promotion)
 
 ## Pre release tasks


### PR DESCRIPTION
Four table-of-contents links in the repo's own documentation point at anchors that don't exist, so clicking them on GitHub silently does nothing.

- `README.md` links to `#including-vanilla-in-your-project-via-npm`, but the heading is "Including Vanilla in your project via NPM or yarn", which slugifies to `#including-vanilla-in-your-project-via-npm-or-yarn`. I updated the link text to match the heading as well.
- `guides/release-process.md`'s own contents list links to `#react-components`; the heading "Releasing React Components" slugifies to `#releasing-react-components`.
- `CONTRIBUTING.md` links to `#deploy-vanillaframeworkio` and `#react-components` in `guides/release-process.md`; those headings are `#deploying-vanillaframeworkio` and `#releasing-react-components`.

Docs only, no Sass or template changes. `prettier -c` passes on all three files.

Related but deliberately left out: `guides/hacking.md`'s contents list links to `#via-dotrun` and `#via-docker`, but "Running the project" is a single section with no such subheadings. That needs a maintainer's call on whether to add the headings or drop the entries, and #5701 is already editing that file. Happy to follow up separately.