### PR TITLE
Fix: Tooltip text overlapping issue (#5757)

### DIFF
--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -35,8 +35,8 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
     @extend %small-text;
 
     background-color: $colors--theme--background-alt;
-    opacity: 1; // FIX #5757: Ensure full background opacity over overlapping text
-    isolation: isolate; // FIX #5757: Create isolated stacking context for pseudo-elements
+    opacity: 1; 
+    isolation: isolate; 
     border: 0;
     color: $colors--theme--text-default;
     display: none;

--- a/scss/_patterns_tooltips.scss
+++ b/scss/_patterns_tooltips.scss
@@ -35,6 +35,8 @@ $tooltip-overlay-top-border-radius: 0% 0% 100% 100%;
     @extend %small-text;
 
     background-color: $colors--theme--background-alt;
+    opacity: 1; // FIX #5757: Ensure full background opacity over overlapping text
+    isolation: isolate; // FIX #5757: Create isolated stacking context for pseudo-elements
     border: 0;
     color: $colors--theme--text-default;
     display: none;


### PR DESCRIPTION
Fixes #5757

Summary of changes:
Enforced opacity: 1 and isolation: isolate on .p-tooltip__message to ensure tooltips form an isolated stacking context and maintain full background opacity over overlapping content.