### PR TITLE
Fix: Logo links should have visible tab focus (#5732)

### DIFF
--- a/scss/_patterns_logo-section.scss
+++ b/scss/_patterns_logo-section.scss
@@ -29,6 +29,17 @@
       }
     }
 
+    // === ADDED: focus styles for linked logos (#5732) ===
+    .p-logo-section__link {
+      display: inline-block;
+
+      &:focus,
+      &:focus-visible {
+        outline: 1px solid $colors--theme--text-default;
+        outline-offset: 2px;
+      }
+    }
+
     .p-logo-section__logo {
       display: block;
       height: $logo-section-item-size-small;


### PR DESCRIPTION
Fixes #5732

Summary of changes:
Added :focus and :focus-visible ring outlines to .p-logo-section__link elements to ensure visible tab focus during keyboard navigation.