### PR TITLE
[Component amendment] Deprecate p-rule--highlight, add p-rule--highlighted (#5627)

### DIFF
--- a/scss/_patterns_rule.scss
+++ b/scss/_patterns_rule.scss
@@ -3,6 +3,8 @@
 @mixin vf-p-rule {
   .p-rule,
   .p-rule--muted,
+  .p-rule--highlighted,
+  // Deprecated: .p-rule--highlight will be removed in a future release
   .p-rule--highlight {
     @extend %hr;
 
@@ -15,6 +17,8 @@
     background-color: $colors--theme--border-low-contrast;
   }
 
+  .p-rule--highlighted,
+  // Deprecated: .p-rule--highlight will be removed in a future release
   .p-rule--highlight {
     @include vf-highlight-bar($colors--theme--text-default);
 


### PR DESCRIPTION
Fixes #5627

Summary of changes:
Added .p-rule--highlighted as the primary class name alongside .p-rule--highlight, adding deprecation comments for the legacy selector.