### PR TITLE
Fix: Center alignment for chevron icons (#5567)

### DIFF
--- a/scss/_patterns_icons.scss
+++ b/scss/_patterns_icons.scss
@@ -152,6 +152,7 @@
   .p-icon--chevron-down,
   .p-icon--chevron-left {
     @extend %icon;
+    background-position: center center;
   }
 }
 


### PR DESCRIPTION
Fixes #5567

Summary of changes:
Added background-position: center center to .p-icon--chevron-* class variants to ensure chevron icons render strictly centered inside their bounding boxes.