### PR TITLE
Fix: Reveal u-off-screen container when descendant receives focus (#5734)

### DIFF
--- a/scss/_base_placeholders.scss
+++ b/scss/_base_placeholders.scss
@@ -145,7 +145,7 @@
 
   // Utilities
   %u-off-screen {
-    &:not(:focus):not(:active) {
+    &:not(:focus):not(:focus-within):not(:active) {
       clip-path: inset(50%);
       height: 1px;
       overflow: hidden;


### PR DESCRIPTION
Fixes #5734

Summary of changes:
Added :focus-within to the %u-off-screen placeholder rule so visually hidden containers un-hide when keyboard focus moves into descendant interactive controls.