### PR TITLE
feat(basic-section): container_class for the image config

### DIFF
--- a/templates/_macros/vf_basic-section.jinja
+++ b/templates/_macros/vf_basic-section.jinja
@@ -45,6 +45,7 @@
 # - caption_html: The HTML content for the caption of the image (optional). Will be wrapped in <figcaption>, and the image and caption will be wrapped in a <figure>.
 # - is_highlighted: Whether to apply the "is-highlighted" class to the image container (default is true).
 # - is_cover: Whether to apply the "is-cover" class to the image container (default is false).
+# - container_class: Utility classes applied to the image container, e.g. hide utilities to hide the whole container on specific screen sizes (optional).
 # - attrs: A dictionary of attributes to apply to the image
 {% macro _basic_section_image(image_config={}) %}
   {%- set aspect_ratio = image_config.get("aspect_ratio", "") | trim -%}
@@ -57,11 +58,12 @@
 
   {%- set is_highlighted = image_config.get("is_highlighted", true) -%}
   {%- set is_cover = image_config.get("is_cover", false) -%}
+  {%- set container_class = image_config.get("container_class", "") | trim -%}
 
   {%- if has_caption -%}
   <figure>
   {%- endif -%}
-  <div class="p-image-container{%- if aspect_ratio | length > 0 -%}--{{- aspect_ratio -}}{%- endif %}{%- if is_highlighted %} is-highlighted{% endif -%}{%- if is_cover %} is-cover{% endif -%}">
+  <div class="p-image-container{%- if aspect_ratio | length > 0 -%}--{{- aspect_ratio -}}{%- endif %}{%- if is_highlighted %} is-highlighted{% endif -%}{%- if is_cover %} is-cover{% endif -%}{%- if container_class | length > 0 %} {{ container_class }}{%- endif -%}">
     <img class="p-image-container__image {{ image_config.get("attrs", {}).get("class", "") -}}"
       {%- for attr, value in image_config.get("attrs", {}).items() -%}
         {% if attr != "class" %}

--- a/templates/docs/patterns/basic-section/index.md
+++ b/templates/docs/patterns/basic-section/index.md
@@ -153,6 +153,7 @@ ratios</a> and a [caption](/docs/patterns/images#image-with-caption).
     "caption_html": "Optional caption with HTML",
     "is_highlighted": "Optional boolean to enable/disable background highlighting. Default is true",
     "is_cover": "Optional boolean to add 'is-cover' class to image container. Default is false",
+    "container_class": "Optional utility classes to apply to the image container",
     "attrs": {
       "src": "image-url",
       "alt": "alt-text"
@@ -167,6 +168,7 @@ ratios</a> and a [caption](/docs/patterns/images#image-with-caption).
   container</a>.
 - **`is_cover`**: Optional boolean which defaults to false. Wraps image in a <a href="/docs/patterns/images#cover-image">cover image
   container</a>.
+- **`container_class`**: Optional string of utility classes applied to the image container. Use the <a href="/docs/utilities/hide">hide utilities</a> to hide the whole container (and its reserved space) on specific screen sizes, rather than hiding only the image.
 - **`attrs`**: Dictionary of image attributes (src, alt, class, etc.). The `p-image-container__image` class is automatically applied. See [attribute forwarding docs](/docs/building-vanilla#attribute-forwarding) for more info.
 
 #### Videos


### PR DESCRIPTION
Fixes #5830.

The image config of a basic section could only forward attributes to the img element, so applying the hide utilities left the container's reserved space on the page. Downstream sites (canonical.com/juju, ubuntu.com/ceph/install, ubuntu.com/certified) currently work around it with the deprecated CTA section slots or by breaking out of the framework entirely, as listed in the issue.

This adds a `container_class` key to the image config: a free-form string of utility classes appended to the `p-image-container` classes, alongside the existing `is-highlighted` and `is-cover` booleans. Intended use is the hide utilities, for example:

```jinja
{
  "type": "image",
  "item": {
    "attrs": {"src": "hero.png", "alt": ""},
    "container_class": "u-hide--small u-hide--medium"
  }
}
```

Docs updated (config block + key description, pointing at the hide utilities). Renders verified for the default, the new key, and the combined aspect-ratio / no-highlight / container_class cases:

```html
<div class="p-image-container--16-9 u-hide">
  <img class="p-image-container__image " src="a.png" alt="a" />
</div>
```

Happy to adjust the key name if you would rather see a different shape (a `container_attrs` dictionary, for instance).
