### PR TITLE
Add worked modal accessibility regression example

### DIFF
--- a/templates/docs/patterns/modal/accessibility.md
+++ b/templates/docs/patterns/modal/accessibility.md
@@ -28,5 +28,4 @@ JavaScript needs to be used to ensure:
 - [Modal Dialog Example](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)
 - [WAI-ARIA practices: Dialog (Modal)](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal)
 - [WCAG22 - No Keyboard Trap](https://www.w3.org/WAI/WCAG22/Understanding/no-keyboard-trap)
-
 - [Worked example: fixing a modal screen-reader failure](https://frontendatlas.com/incidents/modal-screen-reader-failure)

--- a/templates/docs/patterns/modal/accessibility.md
+++ b/templates/docs/patterns/modal/accessibility.md
@@ -28,3 +28,5 @@ JavaScript needs to be used to ensure:
 - [Modal Dialog Example](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)
 - [WAI-ARIA practices: Dialog (Modal)](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal)
 - [WCAG22 - No Keyboard Trap](https://www.w3.org/WAI/WCAG22/Understanding/no-keyboard-trap)
+
+- [Worked example: fixing a modal screen-reader failure](https://frontendatlas.com/incidents/modal-screen-reader-failure)


### PR DESCRIPTION
## Done

- Add one worked modal accessibility regression example to the Modal accessibility Resources list.

The free exercise complements the normative W3C and WCAG references by letting readers diagnose focus placement, focus trapping and restoration, dialog semantics, accessible naming, and background isolation.

## QA

- Net diff: one Markdown line added, zero deletions.
- Review the updated Modal accessibility Resources list.
- The target page returned HTTP 200 and declared a self-canonical, indexable URL on 3 September 2026.
- No local build was run; this is a documentation-only GitHub web edit.

### Check if PR is ready for release

This PR changes no Vanilla SCSS, macros, component APIs, package version, or release notes.

## Screenshots

Not applicable.

## Disclosure

I am the creator and maintainer of FrontendAtlas. The linked exercise is free; the wider platform also includes paid content. I used AI assistance to help draft this pull request and reviewed the resulting change. No paid, affiliate, reciprocal, or special link treatment is requested.